### PR TITLE
LYMON-138 Implement update inventory item endpoint

### DIFF
--- a/src/application/inventory/commands/update-inventory-item/update-inventory-item.command.ts
+++ b/src/application/inventory/commands/update-inventory-item/update-inventory-item.command.ts
@@ -1,0 +1,15 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class UpdateInventoryItemCommand implements ICommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly propertyId: string,
+    public readonly itemId: string,
+    public readonly name: string | undefined,
+    public readonly category: string | undefined,
+    public readonly unit: string | undefined,
+    public readonly minStock: number | undefined,
+    public readonly actorId: string,
+    public readonly actorEmail: string,
+  ) {}
+}

--- a/src/application/inventory/commands/update-inventory-item/update-inventory-item.handler.ts
+++ b/src/application/inventory/commands/update-inventory-item/update-inventory-item.handler.ts
@@ -1,0 +1,74 @@
+import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { UpdateInventoryItemCommand } from './update-inventory-item.command';
+import { UpdateInventoryItemResult } from './update-inventory-item.result';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item-id.vo';
+import {
+  INVENTORY_ITEM_REPOSITORY,
+  type InventoryItemRepository,
+} from '@/domain/inventory/repositories/inventory-item.repository';
+import {
+  PROPERTY_REPOSITORY,
+  type PropertyRepository,
+} from '@/domain/property/repositories/property.repository';
+
+@CommandHandler(UpdateInventoryItemCommand)
+export class UpdateInventoryItemHandler implements ICommandHandler<
+  UpdateInventoryItemCommand,
+  UpdateInventoryItemResult
+> {
+  constructor(
+    @Inject(INVENTORY_ITEM_REPOSITORY)
+    private readonly inventoryItemRepository: InventoryItemRepository,
+    @Inject(PROPERTY_REPOSITORY)
+    private readonly propertyRepository: PropertyRepository,
+  ) {}
+
+  async execute(
+    command: UpdateInventoryItemCommand,
+  ): Promise<UpdateInventoryItemResult> {
+    if (
+      command.name === undefined &&
+      command.category === undefined &&
+      command.unit === undefined &&
+      command.minStock === undefined
+    ) {
+      throw new BadRequestException(
+        'At least one field is required: name, category, unit or minStock',
+      );
+    }
+
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const propertyId = PropertyId.create(command.propertyId);
+    const itemId = InventoryItemId.create(command.itemId);
+
+    const property = await this.propertyRepository.findById(propertyId);
+    if (
+      !property ||
+      property.getTenantId().toString() !== tenantId.toString()
+    ) {
+      throw new NotFoundException('Property not found');
+    }
+
+    const item = await this.inventoryItemRepository.findById(itemId);
+    if (
+      !item ||
+      item.getTenantId().toString() !== tenantId.toString() ||
+      item.getPropertyId().toString() !== propertyId.toString()
+    ) {
+      throw new NotFoundException('Inventory item not found');
+    }
+
+    item.update({
+      name: command.name,
+      category: command.category,
+      unit: command.unit,
+      minStock: command.minStock,
+    });
+
+    const savedItemId = await this.inventoryItemRepository.save(item);
+    return new UpdateInventoryItemResult(savedItemId);
+  }
+}

--- a/src/application/inventory/commands/update-inventory-item/update-inventory-item.result.ts
+++ b/src/application/inventory/commands/update-inventory-item/update-inventory-item.result.ts
@@ -1,0 +1,3 @@
+export class UpdateInventoryItemResult {
+  constructor(public readonly itemId: string) {}
+}

--- a/src/application/inventory/inventory-application.module.ts
+++ b/src/application/inventory/inventory-application.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { CreateInventoryItemHandler } from '@/application/inventory/commands/create-inventory-item/create-inventory-item.handler';
+import { UpdateInventoryItemHandler } from '@/application/inventory/commands/update-inventory-item/update-inventory-item.handler';
 import { RecordInventoryMovementHandler } from '@/application/inventory/commands/record-inventory-movement/record-inventory-movement.handler';
 import { GetInventoryItemsByPropertyQueryHandler } from '@/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query-handler';
 import { GetLowStockItemsByPropertyQueryHandler } from '@/application/inventory/queries/get-low-stock-items-by-property/get-low-stock-items-by-property.query-handler';
 
 const CommandHandlers = [
   CreateInventoryItemHandler,
+  UpdateInventoryItemHandler,
   RecordInventoryMovementHandler,
 ];
 

--- a/src/domain/inventory/entities/inventory-item.entity.ts
+++ b/src/domain/inventory/entities/inventory-item.entity.ts
@@ -11,8 +11,8 @@ export class InventoryItem {
     private readonly propertyId: PropertyId,
     private readonly sku: string,
     private name: string,
-    private readonly category: string,
-    private readonly unit: string,
+    private category: string,
+    private unit: string,
     private minStock: number,
     private currentStock: number,
     private readonly createdAt: Date,
@@ -171,16 +171,36 @@ export class InventoryItem {
     return this.updatedAt;
   }
 
-  updateName(name: string): void {
-    const trimmed = name.trim();
-    if (!trimmed) throw new DomainException('Name is required');
-    this.name = trimmed;
-    this.touch();
-  }
+  update(params: {
+    name?: string;
+    category?: string;
+    unit?: string;
+    minStock?: number;
+  }): void {
+    if (params.name !== undefined) {
+      const name = params.name.trim();
+      if (!name) throw new DomainException('Name is required');
+      this.name = name;
+    }
 
-  updateMinStock(minStock: number): void {
-    if (minStock < 0) throw new DomainException('Min stock cannot be negative');
-    this.minStock = minStock;
+    if (params.category !== undefined) {
+      const category = params.category.trim();
+      if (!category) throw new DomainException('Category is required');
+      this.category = category;
+    }
+
+    if (params.unit !== undefined) {
+      const unit = params.unit.trim();
+      if (!unit) throw new DomainException('Unit is required');
+      this.unit = unit;
+    }
+
+    if (params.minStock !== undefined) {
+      if (params.minStock < 0)
+        throw new DomainException('Min stock cannot be negative');
+      this.minStock = params.minStock;
+    }
+
     this.touch();
   }
 

--- a/src/presentation/controllers/inventory.controller.ts
+++ b/src/presentation/controllers/inventory.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBearerAuth,
@@ -13,9 +21,12 @@ import { Permission } from '@/domain/role/value-objects/permission.vo';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { CreateInventoryItemDto } from '@/presentation/dtos/create-inventory-item.dto';
+import { UpdateInventoryItemDto } from '@/presentation/dtos/update-inventory-item.dto';
 import { RecordInventoryMovementDto } from '@/presentation/dtos/record-inventory-movement.dto';
 import { CreateInventoryItemCommand } from '@/application/inventory/commands/create-inventory-item/create-inventory-item.command';
 import { CreateInventoryItemResult } from '@/application/inventory/commands/create-inventory-item/create-inventory-item.result';
+import { UpdateInventoryItemCommand } from '@/application/inventory/commands/update-inventory-item/update-inventory-item.command';
+import { UpdateInventoryItemResult } from '@/application/inventory/commands/update-inventory-item/update-inventory-item.result';
 import { RecordInventoryMovementCommand } from '@/application/inventory/commands/record-inventory-movement/record-inventory-movement.command';
 import { RecordInventoryMovementResult } from '@/application/inventory/commands/record-inventory-movement/record-inventory-movement.result';
 import { GetInventoryItemsByPropertyQuery } from '@/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query';
@@ -65,6 +76,43 @@ export class InventoryController {
 
     return {
       message: 'Inventory item created successfully',
+      data: result,
+    };
+  }
+
+  @Patch('items/:itemId')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_EDIT)
+  @ApiOperation({ summary: 'Update a stock inventory item for a property' })
+  @ApiResponse({
+    status: 200,
+    description: 'Inventory item updated successfully',
+  })
+  async updateItem(
+    @CurrentUser() user: JwtPayload,
+    @Param('propertyId') propertyId: string,
+    @Param('itemId') itemId: string,
+    @Body() dto: UpdateInventoryItemDto,
+  ) {
+    const result = await this.commandBus.execute<
+      UpdateInventoryItemCommand,
+      UpdateInventoryItemResult
+    >(
+      new UpdateInventoryItemCommand(
+        user.tenantId,
+        propertyId,
+        itemId,
+        dto.name,
+        dto.category,
+        dto.unit,
+        dto.minStock,
+        user.userId,
+        user.email,
+      ),
+    );
+
+    return {
+      message: 'Inventory item updated successfully',
       data: result,
     };
   }

--- a/src/presentation/dtos/update-inventory-item.dto.ts
+++ b/src/presentation/dtos/update-inventory-item.dto.ts
@@ -1,0 +1,25 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class UpdateInventoryItemDto {
+  @ApiPropertyOptional({ example: 'Soap Bar Premium' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'TOILETRIES' })
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @ApiPropertyOptional({ example: 'piece' })
+  @IsOptional()
+  @IsString()
+  unit?: string;
+
+  @ApiPropertyOptional({ example: 30, minimum: 0 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  minStock?: number;
+}


### PR DESCRIPTION
**Summary**

Adds support for updating inventory items.

This PR introduces the endpoint PATCH /properties/:propertyId/inventory/items/:itemId, allowing partial updates to inventory items. The following fields can now be updated:

- name
- category
- unit
- minStock

**Changes**

- Added UpdateInventoryItemDto.
- Implemented UpdateInventoryItemCommand, UpdateInventoryItemHandler, and the corresponding result.
- Updated the InventoryItem domain entity with a consolidated update() method to handle partial updates.
- Registered the update handler in the inventory application module.
- Documented the new endpoint in Swagger.