### PR TITLE
LYMON-139 Implement soft delete inventory item functionality

### DIFF
--- a/src/application/inventory/commands/delete-inventory-item/delete-inventory-item.command.ts
+++ b/src/application/inventory/commands/delete-inventory-item/delete-inventory-item.command.ts
@@ -1,0 +1,7 @@
+export class DeleteInventoryItemCommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly propertyId: string,
+    public readonly itemId: string,
+  ) {}
+}

--- a/src/application/inventory/commands/delete-inventory-item/delete-inventory-item.handler.ts
+++ b/src/application/inventory/commands/delete-inventory-item/delete-inventory-item.handler.ts
@@ -1,0 +1,52 @@
+import { Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { DeleteInventoryItemCommand } from './delete-inventory-item.command';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item-id.vo';
+import {
+  INVENTORY_ITEM_REPOSITORY,
+  type InventoryItemRepository,
+} from '@/domain/inventory/repositories/inventory-item.repository';
+import {
+  PROPERTY_REPOSITORY,
+  type PropertyRepository,
+} from '@/domain/property/repositories/property.repository';
+
+@CommandHandler(DeleteInventoryItemCommand)
+export class DeleteInventoryItemHandler implements ICommandHandler<
+  DeleteInventoryItemCommand,
+  void
+> {
+  constructor(
+    @Inject(INVENTORY_ITEM_REPOSITORY)
+    private readonly inventoryItemRepository: InventoryItemRepository,
+    @Inject(PROPERTY_REPOSITORY)
+    private readonly propertyRepository: PropertyRepository,
+  ) {}
+
+  async execute(command: DeleteInventoryItemCommand): Promise<void> {
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const propertyId = PropertyId.create(command.propertyId);
+    const itemId = InventoryItemId.create(command.itemId);
+
+    const property = await this.propertyRepository.findById(propertyId);
+    if (
+      !property ||
+      property.getTenantId().toString() !== tenantId.toString()
+    ) {
+      throw new NotFoundException('Property not found');
+    }
+
+    const item = await this.inventoryItemRepository.findById(itemId);
+    if (
+      !item ||
+      item.getTenantId().toString() !== tenantId.toString() ||
+      item.getPropertyId().toString() !== propertyId.toString()
+    ) {
+      throw new NotFoundException('Inventory item not found');
+    }
+
+    await this.inventoryItemRepository.delete(itemId);
+  }
+}

--- a/src/application/inventory/inventory-application.module.ts
+++ b/src/application/inventory/inventory-application.module.ts
@@ -3,12 +3,14 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { CreateInventoryItemHandler } from '@/application/inventory/commands/create-inventory-item/create-inventory-item.handler';
 import { RecordInventoryMovementHandler } from '@/application/inventory/commands/record-inventory-movement/record-inventory-movement.handler';
+import { DeleteInventoryItemHandler } from '@/application/inventory/commands/delete-inventory-item/delete-inventory-item.handler';
 import { GetInventoryItemsByPropertyQueryHandler } from '@/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query-handler';
 import { GetLowStockItemsByPropertyQueryHandler } from '@/application/inventory/queries/get-low-stock-items-by-property/get-low-stock-items-by-property.query-handler';
 
 const CommandHandlers = [
   CreateInventoryItemHandler,
   RecordInventoryMovementHandler,
+  DeleteInventoryItemHandler,
 ];
 
 const QueryHandlers = [

--- a/src/domain/inventory/repositories/inventory-item.repository.ts
+++ b/src/domain/inventory/repositories/inventory-item.repository.ts
@@ -25,4 +25,5 @@ export interface InventoryItemRepository {
     propertyId: PropertyId,
     sku: string,
   ): Promise<InventoryItem | null>;
+  delete(id: InventoryItemId): Promise<void>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-inventory-item.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-inventory-item.repository.ts
@@ -57,7 +57,10 @@ export class MongoInventoryItemRepository implements InventoryItemRepository {
   }
 
   async findById(id: InventoryItemId): Promise<InventoryItem | null> {
-    const document = await this.inventoryItemModel.findById(id.toString());
+    const document = await this.inventoryItemModel.findOne({
+      _id: id.toString(),
+      deletedAt: null,
+    });
     if (!document) return null;
     return this.toDomain(document);
   }
@@ -70,6 +73,7 @@ export class MongoInventoryItemRepository implements InventoryItemRepository {
       .find({
         tenantId: new Types.ObjectId(tenantId.toString()),
         propertyId: new Types.ObjectId(propertyId.toString()),
+        deletedAt: null,
       })
       .sort({ createdAt: -1 });
 
@@ -84,6 +88,7 @@ export class MongoInventoryItemRepository implements InventoryItemRepository {
       .find({
         tenantId: new Types.ObjectId(tenantId.toString()),
         propertyId: new Types.ObjectId(propertyId.toString()),
+        deletedAt: null,
         $expr: { $lte: ['$currentStock', '$minStock'] },
       })
       .sort({ currentStock: 1, updatedAt: -1 });
@@ -100,10 +105,17 @@ export class MongoInventoryItemRepository implements InventoryItemRepository {
       tenantId: new Types.ObjectId(tenantId.toString()),
       propertyId: new Types.ObjectId(propertyId.toString()),
       sku: sku.trim(),
+      deletedAt: null,
     });
 
     if (!document) return null;
     return this.toDomain(document);
+  }
+
+  async delete(id: InventoryItemId): Promise<void> {
+    await this.inventoryItemModel.findByIdAndUpdate(id.toString(), {
+      deletedAt: new Date(),
+    });
   }
 
   private toDomain(document: InventoryItemDocument): InventoryItem {

--- a/src/infrastructure/persistence/schemas/inventory-item.schema.ts
+++ b/src/infrastructure/persistence/schemas/inventory-item.schema.ts
@@ -37,6 +37,9 @@ export class InventoryItemDocument extends Document {
 
   @Prop({ required: true, default: 0 })
   currentStock: number;
+
+  @Prop({ type: Date, default: null })
+  deletedAt: Date | null;
 }
 
 export const InventoryItemSchema = SchemaFactory.createForClass(

--- a/src/infrastructure/persistence/schemas/user.schema.ts
+++ b/src/infrastructure/persistence/schemas/user.schema.ts
@@ -18,7 +18,10 @@ export class UserDocument extends Document {
   isOwner: boolean;
 
   @Prop({ type: [Object], required: true, default: [] })
-  roleAssignments: { roleId: string; scope: { type: string; resourceIds?: string[] } }[];
+  roleAssignments: {
+    roleId: string;
+    scope: { type: string; resourceIds?: string[] };
+  }[];
 
   @Prop({ required: true, default: false })
   emailVerified: boolean;

--- a/src/presentation/controllers/inventory.controller.ts
+++ b/src/presentation/controllers/inventory.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBearerAuth,
@@ -18,6 +28,7 @@ import { CreateInventoryItemCommand } from '@/application/inventory/commands/cre
 import { CreateInventoryItemResult } from '@/application/inventory/commands/create-inventory-item/create-inventory-item.result';
 import { RecordInventoryMovementCommand } from '@/application/inventory/commands/record-inventory-movement/record-inventory-movement.command';
 import { RecordInventoryMovementResult } from '@/application/inventory/commands/record-inventory-movement/record-inventory-movement.result';
+import { DeleteInventoryItemCommand } from '@/application/inventory/commands/delete-inventory-item/delete-inventory-item.command';
 import { GetInventoryItemsByPropertyQuery } from '@/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query';
 import { GetInventoryItemsByPropertyResult } from '@/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.result';
 import { GetLowStockItemsByPropertyQuery } from '@/application/inventory/queries/get-low-stock-items-by-property/get-low-stock-items-by-property.query';
@@ -149,5 +160,24 @@ export class InventoryController {
       message: 'Low stock items retrieved successfully',
       data: result.items,
     };
+  }
+
+  @Delete('items/:itemId')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_EDIT)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a stock inventory item for a property' })
+  @ApiResponse({
+    status: 204,
+    description: 'Inventory item deleted successfully',
+  })
+  async deleteItem(
+    @CurrentUser() user: JwtPayload,
+    @Param('propertyId') propertyId: string,
+    @Param('itemId') itemId: string,
+  ) {
+    await this.commandBus.execute<DeleteInventoryItemCommand, void>(
+      new DeleteInventoryItemCommand(user.tenantId, propertyId, itemId),
+    );
   }
 }

--- a/test/application/inventory/delete-inventory-item.handler.spec.ts
+++ b/test/application/inventory/delete-inventory-item.handler.spec.ts
@@ -1,0 +1,151 @@
+import { NotFoundException } from '@nestjs/common';
+import { DeleteInventoryItemHandler } from '@/application/inventory/commands/delete-inventory-item/delete-inventory-item.handler';
+import { DeleteInventoryItemCommand } from '@/application/inventory/commands/delete-inventory-item/delete-inventory-item.command';
+import { InventoryItemRepository } from '@/domain/inventory/repositories/inventory-item.repository';
+import { PropertyRepository } from '@/domain/property/repositories/property.repository';
+import { createInventoryItemRepositoryMock } from '@test/shared/mocks/repositories/inventory-item-repository.mock';
+import { createPropertyRepositoryMock } from '@test/shared/mocks/repositories/property-repository.mock';
+import { makeProperty } from '@test/shared/fixtures/property.fixture';
+import {
+  INVENTORY_ITEM_FIXTURE_DEFAULTS,
+  makeInventoryItem,
+} from '@test/shared/fixtures/inventory-item.fixture';
+
+describe('DeleteInventoryItemHandler', () => {
+  let handler: DeleteInventoryItemHandler;
+  let inventoryItemRepository: jest.Mocked<InventoryItemRepository>;
+  let propertyRepository: jest.Mocked<PropertyRepository>;
+
+  beforeEach(() => {
+    inventoryItemRepository = createInventoryItemRepositoryMock();
+    propertyRepository = createPropertyRepositoryMock();
+
+    handler = new DeleteInventoryItemHandler(
+      inventoryItemRepository,
+      propertyRepository,
+    );
+  });
+
+  describe('when property does not exist', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        handler.execute(
+          new DeleteInventoryItemCommand(
+            'tenant-123',
+            'property-123',
+            INVENTORY_ITEM_FIXTURE_DEFAULTS.id,
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(inventoryItemRepository.findById).not.toHaveBeenCalled();
+      expect(inventoryItemRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when property belongs to a different tenant', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(
+        makeProperty({ tenantId: 'other-tenant' }),
+      );
+
+      await expect(
+        handler.execute(
+          new DeleteInventoryItemCommand(
+            'tenant-123',
+            'property-123',
+            INVENTORY_ITEM_FIXTURE_DEFAULTS.id,
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(inventoryItemRepository.findById).not.toHaveBeenCalled();
+      expect(inventoryItemRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when inventory item does not exist', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(makeProperty());
+      inventoryItemRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        handler.execute(
+          new DeleteInventoryItemCommand(
+            'tenant-123',
+            'property-123',
+            INVENTORY_ITEM_FIXTURE_DEFAULTS.id,
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(inventoryItemRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when inventory item belongs to another tenant', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(makeProperty());
+      inventoryItemRepository.findById.mockResolvedValue(
+        makeInventoryItem({ tenantId: 'other-tenant' }),
+      );
+
+      await expect(
+        handler.execute(
+          new DeleteInventoryItemCommand(
+            'tenant-123',
+            'property-123',
+            INVENTORY_ITEM_FIXTURE_DEFAULTS.id,
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(inventoryItemRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when inventory item belongs to another property', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(makeProperty());
+      inventoryItemRepository.findById.mockResolvedValue(
+        makeInventoryItem({ propertyId: 'other-property' }),
+      );
+
+      await expect(
+        handler.execute(
+          new DeleteInventoryItemCommand(
+            'tenant-123',
+            'property-123',
+            INVENTORY_ITEM_FIXTURE_DEFAULTS.id,
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(inventoryItemRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when all validations pass', () => {
+    it('deletes inventory item successfully', async () => {
+      propertyRepository.findById.mockResolvedValue(makeProperty());
+      inventoryItemRepository.findById.mockResolvedValue(makeInventoryItem());
+
+      await expect(
+        handler.execute(
+          new DeleteInventoryItemCommand(
+            'tenant-123',
+            'property-123',
+            INVENTORY_ITEM_FIXTURE_DEFAULTS.id,
+          ),
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(inventoryItemRepository.delete).toHaveBeenCalledTimes(1);
+      expect(inventoryItemRepository.delete).toHaveBeenCalledWith(
+        expect.objectContaining({}),
+      );
+    });
+  });
+});

--- a/test/shared/fixtures/inventory-item.fixture.ts
+++ b/test/shared/fixtures/inventory-item.fixture.ts
@@ -1,0 +1,49 @@
+import { InventoryItem } from '@/domain/inventory/entities/inventory-item.entity';
+import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PROPERTY_FIXTURE_DEFAULTS } from '@test/shared/fixtures/property.fixture';
+import { TENANT_FIXTURE_DEFAULTS } from '@test/shared/fixtures/tenant.fixture';
+import { randomUUID } from 'crypto';
+
+export const INVENTORY_ITEM_FIXTURE_DEFAULTS = {
+  id: randomUUID(),
+  tenantId: TENANT_FIXTURE_DEFAULTS.id,
+  propertyId: PROPERTY_FIXTURE_DEFAULTS.id,
+  sku: 'SKU-001',
+  name: 'Toalla',
+  category: 'Limpieza',
+  unit: 'unidad',
+  minStock: 5,
+  currentStock: 20,
+};
+
+export function makeInventoryItem(
+  overrides?: Partial<{
+    id: string;
+    tenantId: string;
+    propertyId: string;
+    sku: string;
+    name: string;
+    category: string;
+    unit: string;
+    minStock: number;
+    currentStock: number;
+  }>,
+): InventoryItem {
+  const merged = { ...INVENTORY_ITEM_FIXTURE_DEFAULTS, ...overrides };
+
+  return InventoryItem.reconstitute(
+    InventoryItemId.create(merged.id),
+    TenantId.createFromString(merged.tenantId),
+    PropertyId.create(merged.propertyId),
+    merged.sku,
+    merged.name,
+    merged.category,
+    merged.unit,
+    merged.minStock,
+    merged.currentStock,
+    new Date(),
+    new Date(),
+  );
+}

--- a/test/shared/mocks/repositories/inventory-item-repository.mock.ts
+++ b/test/shared/mocks/repositories/inventory-item-repository.mock.ts
@@ -1,0 +1,12 @@
+import { InventoryItemRepository } from '@/domain/inventory/repositories/inventory-item.repository';
+
+export function createInventoryItemRepositoryMock(): jest.Mocked<InventoryItemRepository> {
+  return {
+    save: jest.fn(),
+    findById: jest.fn(),
+    findByPropertyId: jest.fn(),
+    findLowStockByPropertyId: jest.fn(),
+    findByPropertyIdAndSku: jest.fn(),
+    delete: jest.fn(),
+  };
+}


### PR DESCRIPTION
**Summary**
Implements inventory item removal through soft deletion, exposing the DELETE endpoint for the inventory story.

**Main Changes**

- Added endpoint: DELETE /properties/:propertyId/inventory/items/:itemId
- Added CQRS flow for inventory item deletion:
- DeleteInventoryItemCommand
- DeleteInventoryItemHandler
- Handler registration in InventoryApplicationModule
- Implemented logical deletion in persistence:
- added deletedAt field to inventory item schema
- added delete method in inventory item repository (sets deletedAt)
- Updated queries to exclude logically deleted items:
- findById
- findByPropertyId
- findLowStockByPropertyId
- findByPropertyIdAndSku

**Testing**

- Added unit tests for DeleteInventoryItemHandler covering:
- property not found
- property from another tenant
- item not found
- item from another tenant
- item from another property
- successful deletion
- Added inventory item fixtures/mocks for tests.
- Updated inventory item id in tests to use a generated UUID.