### PR TITLE
LYMON-374 Add pagination to the property items

### DIFF
--- a/src/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query-handler.ts
+++ b/src/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query-handler.ts
@@ -45,6 +45,15 @@ export class GetInventoryItemsByPropertyQueryHandler implements IQueryHandler<
       propertyId,
     );
 
-    return new GetInventoryItemsByPropertyResult(items.map(toInventoryItemDto));
+    const total = items.length;
+    const start = (query.page - 1) * query.limit;
+    const paginatedItems = items.slice(start, start + query.limit);
+
+    return new GetInventoryItemsByPropertyResult(
+      paginatedItems.map(toInventoryItemDto),
+      total,
+      query.page,
+      query.limit,
+    );
   }
 }

--- a/src/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query.ts
+++ b/src/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query.ts
@@ -4,5 +4,7 @@ export class GetInventoryItemsByPropertyQuery implements IQuery {
   constructor(
     public readonly tenantId: string,
     public readonly propertyId: string,
+    public readonly page: number = 1,
+    public readonly limit: number = 20,
   ) {}
 }

--- a/src/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.result.ts
+++ b/src/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.result.ts
@@ -1,5 +1,14 @@
 import { InventoryItemDto } from '@/application/inventory/queries/shared/inventory-item.dto';
 
 export class GetInventoryItemsByPropertyResult {
-  constructor(public readonly items: InventoryItemDto[]) {}
+  constructor(
+    public readonly items: InventoryItemDto[],
+    public readonly total: number,
+    public readonly page: number,
+    public readonly limit: number,
+  ) {}
+
+  get totalPages(): number {
+    return Math.ceil(this.total / this.limit);
+  }
 }

--- a/src/presentation/controllers/inventory.controller.ts
+++ b/src/presentation/controllers/inventory.controller.ts
@@ -8,11 +8,16 @@ import {
   Param,
   Post,
   UseGuards,
+  DefaultValuePipe,
+  ParseIntPipe,
+  Query,
+  Patch,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -160,6 +165,18 @@ export class InventoryController {
   @UseGuards(JwtAuthGuard, PermissionGuard)
   @RequirePermission(Permission.PROPERTY_VIEW)
   @ApiOperation({ summary: 'Get all inventory items by property' })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number for pagination',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page (default: 10)',
+  })
   @ApiResponse({
     status: 200,
     description: 'Inventory items retrieved successfully',
@@ -167,15 +184,31 @@ export class InventoryController {
   async getItems(
     @CurrentUser() user: JwtPayload,
     @Param('propertyId') propertyId: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
   ) {
-    const result = await this.queryBus.execute<
-      GetInventoryItemsByPropertyQuery,
-      GetInventoryItemsByPropertyResult
-    >(new GetInventoryItemsByPropertyQuery(user.tenantId, propertyId));
+    const result: GetInventoryItemsByPropertyResult =
+      await this.queryBus.execute<
+        GetInventoryItemsByPropertyQuery,
+        GetInventoryItemsByPropertyResult
+      >(
+        new GetInventoryItemsByPropertyQuery(
+          user.tenantId,
+          propertyId,
+          page,
+          limit,
+        ),
+      );
 
     return {
       message: 'Inventory items retrieved successfully',
       data: result.items,
+      pagination: {
+        total: result.total,
+        page: result.page,
+        limit: result.limit,
+        totalPages: result.totalPages,
+      },
     };
   }
 

--- a/src/presentation/controllers/inventory.controller.ts
+++ b/src/presentation/controllers/inventory.controller.ts
@@ -12,7 +12,6 @@ import {
   DefaultValuePipe,
   ParseIntPipe,
   Query,
-  Patch,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {


### PR DESCRIPTION
Pagination support to the "Get Inventory Items by Property" API endpoint. The changes add `page` and `limit` query parameters, update the query and result handling to support pagination, and enhance the API response with pagination metadata.

**Pagination support for inventory items retrieval:**

* Added `page` and `limit` parameters to the `GetInventoryItemsByPropertyQuery` class, with default values for both, enabling pagination in queries.
* Updated the `GetInventoryItemsByPropertyQueryHandler` to paginate the list of items, returning only the relevant slice based on `page` and `limit`, and including pagination metadata in the result.
* Modified the `GetInventoryItemsByPropertyResult` class to include `total`, `page`, and `limit` fields, and added a `totalPages` getter for convenience.

**API and documentation enhancements:**

* Updated the `InventoryController` to accept `page` and `limit` as query parameters, provide them to the query, and include pagination info in the API response.
* Enhanced Swagger API documentation by adding `@ApiQuery` decorators for the new pagination parameters.