### PR TITLE
LYMON-87-Listar-notas-internas-del-huésped-LymonPlus-Prime

### DIFF
--- a/src/application/guest-note/guest-note-application.module.ts
+++ b/src/application/guest-note/guest-note-application.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { CreateGuestNoteHandler } from '@/application/guest-note/commands/create-guest-note.handler';
+import { GetGuestNotesByGuestIdHandler } from '@/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.handler';
 
 const CommandHandlers = [CreateGuestNoteHandler];
+const QueryHandlers = [GetGuestNotesByGuestIdHandler];
 
 @Module({
   imports: [CqrsModule, PersistenceModule],
-  providers: [...CommandHandlers],
-  exports: [...CommandHandlers],
+  providers: [...CommandHandlers, ...QueryHandlers],
+  exports: [...CommandHandlers, ...QueryHandlers],
 })
 export class GuestNoteApplicationModule {}

--- a/src/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.handler.ts
+++ b/src/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.handler.ts
@@ -1,0 +1,57 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetGuestNotesByGuestIdQuery } from './get-guest-notes-by-guest-id.query';
+import {
+  GetGuestNotesByGuestIdResult,
+  GuestNoteDto,
+} from './get-guest-notes-by-guest-id.result';
+import {
+  GUEST_NOTE_REPOSITORY,
+  type GuestNoteRepository,
+} from '@/domain/guest-note/repositories/guest-note.repository';
+import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+
+@QueryHandler(GetGuestNotesByGuestIdQuery)
+export class GetGuestNotesByGuestIdHandler
+  implements
+    IQueryHandler<
+      GetGuestNotesByGuestIdQuery,
+      GetGuestNotesByGuestIdResult
+    >
+{
+  constructor(
+    @Inject(GUEST_NOTE_REPOSITORY)
+    private readonly guestNoteRepository: GuestNoteRepository,
+  ) {}
+
+  async execute(
+    query: GetGuestNotesByGuestIdQuery,
+  ): Promise<GetGuestNotesByGuestIdResult> {
+    let guestId: GuestId;
+
+    try {
+      guestId = GuestId.createFromString(query.guestId);
+    } catch {
+      return { items: [] };
+    }
+
+    const notes = await this.guestNoteRepository.findByGuestId(
+      guestId,
+      TenantId.createFromString(query.tenantId),
+    );
+
+    const items: GuestNoteDto[] = notes.map((note) => ({
+      id: note.getId()?.toString() ?? '',
+      guestId: note.getGuestId().toString(),
+      note: note.getNote(),
+      type: note.getType(),
+      status: note.getStatus(),
+      createdBy: note.getCreatedBy(),
+      createdAt: note.getCreatedAt(),
+      updatedAt: note.getUpdatedAt(),
+    }));
+
+    return { items };
+  }
+}

--- a/src/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.query.ts
+++ b/src/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.query.ts
@@ -1,0 +1,6 @@
+export class GetGuestNotesByGuestIdQuery {
+  constructor(
+    public readonly tenantId: string,
+    public readonly guestId: string,
+  ) {}
+}

--- a/src/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.result.ts
+++ b/src/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.result.ts
@@ -1,0 +1,14 @@
+export interface GuestNoteDto {
+  id: string;
+  guestId: string;
+  note: string;
+  type: string;
+  status: string;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface GetGuestNotesByGuestIdResult {
+  items: GuestNoteDto[];
+}

--- a/src/presentation/controllers/crm.controller.ts
+++ b/src/presentation/controllers/crm.controller.ts
@@ -18,6 +18,8 @@ import { CreateGuestNoteCommand } from '@/application/guest-note/commands/create
 import { CreateGuestNoteDto } from '@/presentation/dtos/create-guest-note.dto';
 import { GetGuestBookingsQuery } from '@/application/guest/queries/get-guest-bookings/get-guest-bookings.query';
 import { GetGuestBookingsResult } from '@/application/guest/queries/get-guest-bookings/get-guest-bookings.result';
+import { GetGuestNotesByGuestIdQuery } from '@/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.query';
+import { GetGuestNotesByGuestIdResult } from '@/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.result';
 
 @ApiTags('crm')
 @ApiBearerAuth('JWT-auth')
@@ -88,6 +90,31 @@ export class CrmController {
     return {
       message: 'Internal note added successfully',
       data: result,
+    };
+  }
+
+  @Get('guests/:guestId/notes')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.CRM_VIEW)
+  @ApiOperation({
+    summary: 'Get all internal notes for a guest',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Guest notes retrieved successfully',
+  })
+  async getGuestNotes(
+    @Param('guestId') guestId: string,
+    @CurrentUser() user: JwtPayload,
+  ) {
+    const result = await this.queryBus.execute<
+      GetGuestNotesByGuestIdQuery,
+      GetGuestNotesByGuestIdResult
+    >(new GetGuestNotesByGuestIdQuery(user.tenantId, guestId));
+
+    return {
+      message: 'Guest notes retrieved successfully',
+      data: result.items,
     };
   }
 

--- a/test/application/guest-note/get-guest-notes-by-guest-id.handler.spec.ts
+++ b/test/application/guest-note/get-guest-notes-by-guest-id.handler.spec.ts
@@ -1,0 +1,112 @@
+import { GetGuestNotesByGuestIdHandler } from '@/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.handler';
+import { GetGuestNotesByGuestIdQuery } from '@/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.query';
+import { GuestNote } from '@/domain/guest-note/entities/guest-note.entity';
+import { GuestNoteRepository } from '@/domain/guest-note/repositories/guest-note.repository';
+import { GuestNoteStatusEnum } from '@/domain/guest-note/value-objects/guest-node-status.vo';
+import { GuestNoteTypeEnum } from '@/domain/guest-note/value-objects/guest-node-type.vo';
+import { GuestNoteId } from '@/domain/guest-note/value-objects/guest-note-id.vo';
+import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+
+function createGuestNoteRepositoryMock(): jest.Mocked<GuestNoteRepository> {
+  return {
+    save: jest.fn(),
+    findById: jest.fn(),
+    findByGuestId: jest.fn(),
+    delete: jest.fn(),
+  };
+}
+
+describe('GetGuestNotesByGuestIdHandler', () => {
+  let handler: GetGuestNotesByGuestIdHandler;
+  let guestNoteRepository: jest.Mocked<GuestNoteRepository>;
+
+  const tenantId = 'tenant-123';
+  const guestId = '65f1a1a2b3c4d5e6f7a8b9c0';
+
+  beforeEach(() => {
+    guestNoteRepository = createGuestNoteRepositoryMock();
+    handler = new GetGuestNotesByGuestIdHandler(guestNoteRepository);
+  });
+
+  function makeGuestNote(
+    overrides?: Partial<{
+      id: string;
+      tenantId: string;
+      guestId: string;
+      note: string;
+      type: GuestNoteTypeEnum;
+      status: GuestNoteStatusEnum;
+      createdBy: string;
+      createdAt: Date;
+      updatedAt: Date;
+    }>,
+  ): GuestNote {
+    return GuestNote.reconstitute(
+      GuestNoteId.createFromString(overrides?.id ?? 'note-123'),
+      TenantId.createFromString(overrides?.tenantId ?? tenantId),
+      GuestId.createFromString(overrides?.guestId ?? guestId),
+      overrides?.note ?? 'Prefers a quiet room',
+      overrides?.type ?? GuestNoteTypeEnum.PREFERENCE,
+      overrides?.status ?? GuestNoteStatusEnum.NOT_PINNED,
+      overrides?.createdBy ?? 'user-123',
+      overrides?.createdAt ?? new Date('2030-01-01T10:00:00Z'),
+      overrides?.updatedAt ?? new Date('2030-01-01T10:00:00Z'),
+      null,
+    );
+  }
+
+  describe('when guest notes exist', () => {
+    it('returns notes mapped to DTOs', async () => {
+      const note = makeGuestNote({
+        id: 'note-abc',
+        note: 'VIP guest',
+        type: GuestNoteTypeEnum.GENERAL,
+        status: GuestNoteStatusEnum.IS_PINNED,
+        createdBy: 'staff-001',
+      });
+      guestNoteRepository.findByGuestId.mockResolvedValue([note]);
+
+      const query = new GetGuestNotesByGuestIdQuery(tenantId, guestId);
+      const result = await handler.execute(query);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        id: 'note-abc',
+        guestId,
+        note: 'VIP guest',
+        type: GuestNoteTypeEnum.GENERAL,
+        status: GuestNoteStatusEnum.IS_PINNED,
+        createdBy: 'staff-001',
+      });
+      expect(guestNoteRepository.findByGuestId).toHaveBeenCalledWith(
+        expect.objectContaining({ toString: expect.any(Function) }),
+        expect.objectContaining({ toString: expect.any(Function) }),
+      );
+    });
+  });
+
+  describe('when the guest id format is invalid', () => {
+    it('returns an empty list and does not query the repository', async () => {
+      const query = new GetGuestNotesByGuestIdQuery(
+        tenantId,
+        'invalid-guest-id',
+      );
+      const result = await handler.execute(query);
+
+      expect(result.items).toEqual([]);
+      expect(guestNoteRepository.findByGuestId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when there are no guest notes', () => {
+    it('returns an empty list', async () => {
+      guestNoteRepository.findByGuestId.mockResolvedValue([]);
+
+      const query = new GetGuestNotesByGuestIdQuery(tenantId, guestId);
+      const result = await handler.execute(query);
+
+      expect(result.items).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new query for retrieving all internal notes associated with a guest, integrating it into the application layer, controller, and adding corresponding tests. The main changes include the implementation of the query handler, DTOs, controller endpoint, and module registration.

**Guest Note Query Feature:**

* Added `GetGuestNotesByGuestIdHandler`, which handles fetching guest notes for a given guest ID, mapping them to DTOs, and returning them in a standardized result format. Handles invalid guest IDs gracefully by returning an empty list.
* Defined the `GetGuestNotesByGuestIdQuery` class to encapsulate the query parameters (tenantId and guestId) and the result/DTO interfaces for consistent data transfer. 
* Registered the new query handler in `GuestNoteApplicationModule` so it is available for dependency injection and CQRS operations.

**Controller Integration:**

* Added a new endpoint `GET /guests/:guestId/notes` to the `CrmController` that allows authorized users to fetch all internal notes for a specific guest, leveraging the new query and returning a standardized response. 

**Testing:**

* Introduced unit tests for `GetGuestNotesByGuestIdHandler`, covering cases for existing notes, invalid guest IDs, and no notes found, ensuring correct mapping and repository usage.