### PR TITLE
LYMON-119-Cambiar-contraseña-desde-perfil-del-huésped

### DIFF
--- a/src/application/guest-auth/commands/change-guest-password/change-guest-password.command.ts
+++ b/src/application/guest-auth/commands/change-guest-password/change-guest-password.command.ts
@@ -1,0 +1,7 @@
+export class ChangeGuestPasswordCommand {
+  constructor(
+    public readonly guestAccountId: string,
+    public readonly currentPassword: string,
+    public readonly newPassword: string,
+  ) {}
+}

--- a/src/application/guest-auth/commands/change-guest-password/change-guest-password.handler.ts
+++ b/src/application/guest-auth/commands/change-guest-password/change-guest-password.handler.ts
@@ -1,0 +1,68 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import {
+  BadRequestException,
+  Inject,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ChangeGuestPasswordCommand } from '@/application/guest-auth/commands/change-guest-password/change-guest-password.command';
+import {
+  GUEST_ACCOUNT_REPOSITORY,
+  type GuestAccountRepository,
+} from '@/domain/guest-account/repositories/guest-account.repository';
+import {
+  PASSWORD_HASHER,
+  type IPasswordHasher,
+} from '@/application/auth/services/password-hasher.service';
+import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
+
+export class ChangeGuestPasswordResult {
+  constructor(public readonly message: string) {}
+}
+
+@CommandHandler(ChangeGuestPasswordCommand)
+export class ChangeGuestPasswordHandler implements ICommandHandler<ChangeGuestPasswordCommand> {
+  constructor(
+    @Inject(GUEST_ACCOUNT_REPOSITORY)
+    private readonly guestAccountRepository: GuestAccountRepository,
+    @Inject(PASSWORD_HASHER)
+    private readonly passwordHasher: IPasswordHasher,
+  ) {}
+
+  async execute(
+    command: ChangeGuestPasswordCommand,
+  ): Promise<ChangeGuestPasswordResult> {
+    const account = await this.guestAccountRepository.findById(
+      GuestAccountId.createFromString(command.guestAccountId),
+    );
+
+    if (!account) {
+      throw new UnauthorizedException('Account not found');
+    }
+
+    const isCurrentPasswordValid = await this.passwordHasher.compare(
+      command.currentPassword,
+      account.getPasswordHash(),
+    );
+
+    if (!isCurrentPasswordValid) {
+      throw new UnauthorizedException('Current password is incorrect');
+    }
+
+    const isSamePassword = await this.passwordHasher.compare(
+      command.newPassword,
+      account.getPasswordHash(),
+    );
+
+    if (isSamePassword) {
+      throw new BadRequestException(
+        'New password cannot be the same as the current password',
+      );
+    }
+
+    const newPasswordHash = await this.passwordHasher.hash(command.newPassword);
+    account.changePassword(newPasswordHash);
+    await this.guestAccountRepository.save(account);
+
+    return new ChangeGuestPasswordResult('Password changed successfully');
+  }
+}

--- a/src/application/guest-auth/guest-auth-application.module.ts
+++ b/src/application/guest-auth/guest-auth-application.module.ts
@@ -8,6 +8,7 @@ import { VerifyGuestEmailHandler } from '@/application/guest-auth/commands/verif
 import { GuestLoginHandler } from '@/application/guest-auth/commands/login-guest/login-guest.handler';
 import { RecoverGuestPasswordHandler } from '@/application/guest-auth/commands/recover-guest-password/recover-guest-password.handler';
 import { ConfirmRecoverGuestPasswordHandler } from '@/application/guest-auth/commands/confirm-recover-guest-password/confirm-recover-guest-password.handler';
+import { ChangeGuestPasswordHandler } from '@/application/guest-auth/commands/change-guest-password/change-guest-password.handler';
 
 const CommandHandlers = [
   RegisterGuestAccountHandler,
@@ -15,6 +16,7 @@ const CommandHandlers = [
   GuestLoginHandler,
   RecoverGuestPasswordHandler,
   ConfirmRecoverGuestPasswordHandler,
+  ChangeGuestPasswordHandler,
 ];
 
 @Module({

--- a/src/domain/guest-account/entities/guest-account.entity.ts
+++ b/src/domain/guest-account/entities/guest-account.entity.ts
@@ -125,6 +125,12 @@ export class GuestAccount {
     this.clearResetToken();
   }
 
+  changePassword(newHash: string): void {
+    this.passwordHash = newHash;
+    this.passwordChangedAt = new Date();
+    this.touch();
+  }
+
   updateProfile(
     fullName: string,
     firstName?: string | null,

--- a/src/infrastructure/persistence/schemas/user.schema.ts
+++ b/src/infrastructure/persistence/schemas/user.schema.ts
@@ -18,7 +18,10 @@ export class UserDocument extends Document {
   isOwner: boolean;
 
   @Prop({ type: [Object], required: true, default: [] })
-  roleAssignments: { roleId: string; scope: { type: string; resourceIds?: string[] } }[];
+  roleAssignments: {
+    roleId: string;
+    scope: { type: string; resourceIds?: string[] };
+  }[];
 
   @Prop({ required: true, default: false })
   emailVerified: boolean;

--- a/src/presentation/controllers/guest.controller.ts
+++ b/src/presentation/controllers/guest.controller.ts
@@ -1,4 +1,7 @@
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
+import { ChangeGuestPasswordCommand } from '@/application/guest-auth/commands/change-guest-password/change-guest-password.command';
+import { ChangeGuestPasswordResult } from '@/application/guest-auth/commands/change-guest-password/change-guest-password.handler';
+import { type GuestJwtPayload } from '@/application/guest-auth/services/guest-jwt.service';
 import { CreateGuestCommand } from '@/application/guest/commands/create-guest.command';
 import { CreateGuestResult } from '@/application/guest/commands/create-guest.result';
 import { SearchGuestsQuery } from '@/application/guest/queries/search-guests.query';
@@ -11,8 +14,21 @@ import { Public } from '@/infrastructure/auth/decorators/public.decorator';
 import { RequirePermission } from '@/infrastructure/auth/decorators/require-permission.decorator';
 import { JwtAuthGuard } from '@/infrastructure/auth/guards/jwt-auth.guard';
 import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
+import { CurrentGuest } from '@/infrastructure/guest-auth/decorators/current-guest.decorator';
+import { GuestJwtAuthGuard } from '@/infrastructure/guest-auth/guards/guest-jwt-auth.guard';
+import { ChangePasswordDto } from '@/presentation/dtos/change-password.dto';
 import { CreateGuestDto } from '@/presentation/dtos/create-guest.dto';
-import { Body, Controller, Get, Param, Post, Query, UseGuards, NotFoundException } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+  NotFoundException,
+} from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBearerAuth,
@@ -102,16 +118,53 @@ export class GuestController {
       total: guests.length,
     };
   }
+
+  @Public()
+  @UseGuards(GuestJwtAuthGuard)
+  @Patch('change-password')
+  @ApiBearerAuth('GuestJWT-auth')
+  @ApiOperation({ summary: 'Change password from guest profile' })
+  @ApiResponse({ status: 200, description: 'Password changed successfully' })
+  @ApiResponse({ status: 401, description: 'Current password is incorrect' })
+  @ApiResponse({
+    status: 400,
+    description: 'New password cannot be the same as the current password',
+  })
+  async changePassword(
+    @CurrentGuest() guest: GuestJwtPayload,
+    @Body() dto: ChangePasswordDto,
+  ) {
+    const result = await this.commandBus.execute<
+      ChangeGuestPasswordCommand,
+      ChangeGuestPasswordResult
+    >(
+      new ChangeGuestPasswordCommand(
+        guest.guestAccountId,
+        dto.currentPassword,
+        dto.newPassword,
+      ),
+    );
+
+    return { message: result.message };
+  }
+
   @Get(':guestId')
   @UseGuards(JwtAuthGuard, PermissionGuard)
   @RequirePermission(Permission.CRM_VIEW)
   @ApiOperation({ summary: 'Get complete profile of a guest by ID' })
-  @ApiResponse({ status: 200, description: 'Guest profile retrieved successfully' })
+  @ApiResponse({
+    status: 200,
+    description: 'Guest profile retrieved successfully',
+  })
   @ApiResponse({ status: 404, description: 'Guest not found' })
-  async getById(@CurrentUser() user: JwtPayload, @Param('guestId') guestId: string) {
-    const result = await this.queryBus.execute<GetGuestByIdQuery, GetGuestByIdResult>(
-      new GetGuestByIdQuery(user.tenantId, guestId)
-    );
+  async getById(
+    @CurrentUser() user: JwtPayload,
+    @Param('guestId') guestId: string,
+  ) {
+    const result = await this.queryBus.execute<
+      GetGuestByIdQuery,
+      GetGuestByIdResult
+    >(new GetGuestByIdQuery(user.tenantId, guestId));
 
     if (!result.item) {
       throw new NotFoundException('Guest not found');


### PR DESCRIPTION
New feature that allows guest users to securely change their own passwords via an authenticated endpoint. The implementation includes command, handler, and controller logic, as well as necessary updates to the guest account entity and module registration.

**Guest Password Change Feature:**

* Adds a `ChangeGuestPasswordCommand` and its handler to validate the current password, prevent reusing the same password, hash the new password, and persist the change (`change-guest-password.command.ts`, `change-guest-password.handler.ts`). [[1]](diffhunk://#diff-7e74fd54c1fcd557c317aa1d6756a6f7ee5735f9974b85b092dc596f3a411f29R1-R7) [[2]](diffhunk://#diff-05745934e179831dd10916b9618a822662953c7516cd1137056f51648330b2b0R1-R68)
* Updates the `GuestAccount` entity with a `changePassword` method to update the password hash and record the change time (`guest-account.entity.ts`).
* Registers the new command handler in the guest authentication application module (`guest-auth-application.module.ts`).

**API and Controller Updates:**

* Adds a new PATCH endpoint `/change-password` to `GuestController` for authenticated guests, with appropriate guards, DTO validation, and API documentation (`guest.controller.ts`). [[1]](diffhunk://#diff-68a43fca50d65ec09a565ce3cf3a5a4fa7023ce5d2d05db5c5043f4e86f48044R2-R4) [[2]](diffhunk://#diff-68a43fca50d65ec09a565ce3cf3a5a4fa7023ce5d2d05db5c5043f4e86f48044R17-R31) [[3]](diffhunk://#diff-68a43fca50d65ec09a565ce3cf3a5a4fa7023ce5d2d05db5c5043f4e86f48044R121-R167)