### PR TITLE
Implementar asignación de etiquetas a huéspedes (LYMON-392)

### DIFF
--- a/src/application/guest/commands/assign-guest-tags.command.ts
+++ b/src/application/guest/commands/assign-guest-tags.command.ts
@@ -1,0 +1,7 @@
+export class AssignGuestTagsCommand {
+  constructor(
+    public readonly guestId: string,
+    public readonly tags: string[],
+    public readonly tenantId: string,
+  ) {}
+}

--- a/src/application/guest/commands/assign-guest-tags.handler.ts
+++ b/src/application/guest/commands/assign-guest-tags.handler.ts
@@ -1,0 +1,30 @@
+import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { AssignGuestTagsCommand } from "./assign-guest-tags.command";
+import { ForbiddenException, Inject, NotFoundException } from "@nestjs/common";
+import { GuestId } from "@/domain/guest/value-objects/guest-id.vo";
+import type { GuestRepository } from "@/domain/guest/repositories/guest.repository";
+import { GUEST_REPOSITORY } from "@/domain/guest/repositories/guest.repository";
+
+@CommandHandler(AssignGuestTagsCommand)
+export class AssignGuestTagsHandler implements ICommandHandler<AssignGuestTagsCommand> {
+    
+    constructor(
+        @Inject(GUEST_REPOSITORY)
+        private readonly repository: GuestRepository
+    ) {}
+    
+    async execute(command: AssignGuestTagsCommand): Promise<void> {
+        const { guestId, tags, tenantId } = command;
+        const guest = await this.repository.findById(GuestId.createFromString(guestId));
+
+        if (!guest) {
+            throw new NotFoundException(`Guest with ID ${guestId} not found`);
+        }
+        if (guest.getTenantId().toString() !== tenantId) {
+            throw new ForbiddenException('You do not have permission to modify this guest');
+        }
+
+        guest.setTags(tags);
+        await this.repository.save(guest);
+    }
+}

--- a/src/application/guest/guest-application.module.ts
+++ b/src/application/guest/guest-application.module.ts
@@ -5,8 +5,14 @@ import { SearchGuestsQuery } from './queries/search-guests.query';
 import { GetGuestByIdHandler } from './queries/get-guest-by-id/get-guest-by-id.handler';
 import { GetGuestBookingsHandler } from './queries/get-guest-bookings/get-guest-bookings.handler';
 import { CreateGuestHandler } from '@/application/guest/commands/create-guest.handler';
+import { AssignGuestTagsCommand } from './commands/assign-guest-tags.command';
+import { AssignGuestTagsHandler } from './commands/assign-guest-tags.handler';
+import { MongoGuestRepository } from '@/infrastructure/persistence/repositories/mongo-guest.repository';
 
-const CommandHandlers = [CreateGuestHandler];
+const CommandHandlers = [
+  CreateGuestHandler,
+  AssignGuestTagsHandler,
+];
 const QueryHandlers = [
   SearchGuestsQuery,
   GetGuestByIdHandler,

--- a/src/domain/guest/entities/guest.entity.ts
+++ b/src/domain/guest/entities/guest.entity.ts
@@ -259,7 +259,7 @@ export class Guest {
 
   private static uniqueStrings(values: string[]): string[] {
     const normalized = values
-      .map((value) => value.trim())
+      .map((value) => value.trim().toLowerCase())
       .filter((value) => value.length > 0);
 
     return [...new Set(normalized)];

--- a/src/presentation/controllers/guest.controller.ts
+++ b/src/presentation/controllers/guest.controller.ts
@@ -12,8 +12,9 @@ import { RequirePermission } from '@/infrastructure/auth/decorators/require-perm
 import { JwtAuthGuard } from '@/infrastructure/auth/guards/jwt-auth.guard';
 import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
 import { CreateGuestDto } from '@/presentation/dtos/create-guest.dto';
-import { Body, Controller, Get, Param, Post, Query, UseGuards, NotFoundException } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, UseGuards, NotFoundException, Patch } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { AssignGuestTagsCommand } from '@/application/guest/commands/assign-guest-tags.command';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -120,6 +121,25 @@ export class GuestController {
     return {
       message: 'Guest profile retrieved successfully',
       data: result.item,
+    };
+  }
+
+  @Patch(':guestId/tags')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.CRM_MANAGE) 
+  @ApiOperation({ summary: 'Assign tags to a guest' })
+  @ApiResponse({ status: 200, description: 'Tags assigned successfully' })
+  async assignTags(
+    @CurrentUser() user: JwtPayload,
+    @Param('guestId') guestId: string,
+    @Body('tags') tags: string[],
+  ) {
+    await this.commandBus.execute(
+      new AssignGuestTagsCommand(guestId, tags, user.tenantId),
+    );
+
+    return {
+      message: 'Tags assigned successfully',
     };
   }
 }


### PR DESCRIPTION
Se ha implementado la funcionalidad para asignar etiquetas (tags) a los huéspedes

Cambios:

En domain se actualizó la entidad para manejar etiquetas de forma case-insensitive y evitar duplicados

Se creó AssignGuestTagsCommand con inyección correcta de GUEST_REPOSITORY.

Registro del Handler en GuestApplicationModule

Nuevo endpoint PATCH /guests/:guestId/tags

Se valido el codigo con npm run build, terminando exitosamente sin errores de compilación ni de dependencias.

Nota: Se detectó un error de conexión ECONNREFUSED con el Cluster de MongoDB Atlas en el entorno local