### PR TITLE
LYMON-36-Eliminar-propiedad

### DIFF
--- a/src/application/property/commands/delete-property.command.ts
+++ b/src/application/property/commands/delete-property.command.ts
@@ -1,0 +1,8 @@
+export class DeletePropertyCommand {
+  constructor(
+    public readonly propertyId: string,
+    public readonly tenantId: string,
+    public readonly actorId: string,
+    public readonly actorEmail: string,
+  ) {}
+}

--- a/src/application/property/commands/delete-property.handler.ts
+++ b/src/application/property/commands/delete-property.handler.ts
@@ -1,0 +1,72 @@
+import { DeletePropertyCommand } from '@/application/property/commands/delete-property.command';
+import {
+  PROPERTY_REPOSITORY,
+  type PropertyRepository,
+} from '@/domain/property/repositories/property.repository';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import {
+  RESERVATION_REPOSITORY,
+  type ReservationRepository,
+} from '@/domain/reservation/repositories/reservation.repository';
+import {
+  AuditAction,
+  AuditEntityType,
+} from '@/domain/audit/value-objects/audit-action.vo';
+import {
+  AuditLoggedEvent,
+  AUDIT_LOG_EVENT,
+} from '@/infrastructure/audit/events/audit-logged.event';
+import { ForbiddenException, Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+@CommandHandler(DeletePropertyCommand)
+export class DeletePropertyHandler implements ICommandHandler<
+  DeletePropertyCommand,
+  void
+> {
+  constructor(
+    @Inject(PROPERTY_REPOSITORY)
+    private readonly propertyRepository: PropertyRepository,
+    @Inject(RESERVATION_REPOSITORY)
+    private readonly reservationRepository: ReservationRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(command: DeletePropertyCommand): Promise<void> {
+    const propertyId = PropertyId.create(command.propertyId);
+    const property = await this.propertyRepository.findById(propertyId);
+
+    if (!property || property.getTenantId().toString() !== command.tenantId) {
+      throw new NotFoundException(
+        `Property with id "${command.propertyId}" not found`,
+      );
+    }
+
+    const hasActiveReservations =
+      await this.reservationRepository.existsActiveByPropertyId(
+        command.tenantId,
+        command.propertyId,
+      );
+
+    if (hasActiveReservations) {
+      throw new ForbiddenException(
+        'Property cannot be deleted because it has active reservations',
+      );
+    }
+
+    await this.propertyRepository.delete(propertyId);
+
+    this.eventEmitter.emit(
+      AUDIT_LOG_EVENT,
+      new AuditLoggedEvent(
+        command.tenantId,
+        command.actorId,
+        command.actorEmail,
+        AuditAction.PROPERTY_DELETED,
+        AuditEntityType.PROPERTY,
+        command.propertyId,
+      ),
+    );
+  }
+}

--- a/src/application/property/property-application.module.ts
+++ b/src/application/property/property-application.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { CreatePropertyHandler } from '@/application/property/commands/create-property.handler';
+import { DeletePropertyHandler } from '@/application/property/commands/delete-property.handler';
 import { GetPropertiesByTenantQueryHandler } from '@/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.query-handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 
-const CommandHandlers = [CreatePropertyHandler];
+const CommandHandlers = [CreatePropertyHandler, DeletePropertyHandler];
 const QueryHandlers = [GetPropertiesByTenantQueryHandler];
 
 @Module({

--- a/src/domain/property/entities/property.entity.ts
+++ b/src/domain/property/entities/property.entity.ts
@@ -24,6 +24,7 @@ export class Property {
     private hostEmail: string,
     private readonly createdAt: Date,
     private updatedAt: Date,
+    private deletedAt: Date | null,
   ) {}
 
   static create(
@@ -70,6 +71,7 @@ export class Property {
       hostEmail,
       new Date(),
       new Date(),
+      null,
     );
   }
 
@@ -92,6 +94,7 @@ export class Property {
     hostEmail: string,
     createdAt: Date,
     updatedAt: Date,
+    deletedAt: Date | null,
   ): Property {
     return new Property(
       id,
@@ -112,6 +115,7 @@ export class Property {
       hostEmail,
       createdAt,
       updatedAt,
+      deletedAt,
     );
   }
 
@@ -187,6 +191,10 @@ export class Property {
     return this.updatedAt;
   }
 
+  getDeletedAt(): Date | null {
+    return this.deletedAt;
+  }
+
   updateDetails(
     name: string,
     description: string,
@@ -239,5 +247,11 @@ export class Property {
     this.hostPhone = phone;
     this.hostEmail = email;
     this.updatedAt = new Date();
+  }
+
+  softDelete(): void {
+    const now = new Date();
+    this.deletedAt = now;
+    this.updatedAt = now;
   }
 }

--- a/src/domain/reservation/repositories/reservation.repository.ts
+++ b/src/domain/reservation/repositories/reservation.repository.ts
@@ -42,5 +42,9 @@ export interface ReservationRepository {
     externalId: string,
   ): Promise<Reservation | null>;
   countByTenantId(tenantId: string): Promise<number>;
+  existsActiveByPropertyId(
+    tenantId: string,
+    propertyId: string,
+  ): Promise<boolean>;
   findConfirmedDueForCheckIn(date: Date): Promise<Reservation[]>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-property.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-property.repository.ts
@@ -65,7 +65,10 @@ export class MongoPropertyRepository implements PropertyRepository {
   }
 
   async findById(id: PropertyId): Promise<Property | null> {
-    const document = await this.propertyModel.findById(id.toString());
+    const document = await this.propertyModel.findOne({
+      _id: new Types.ObjectId(id.toString()),
+      deletedAt: null,
+    });
     if (!document) return null;
 
     return this.toDomain(document);
@@ -73,7 +76,10 @@ export class MongoPropertyRepository implements PropertyRepository {
 
   async findByTenantId(tenantId: TenantId): Promise<Property[]> {
     const documents = await this.propertyModel
-      .find({ tenantId: new Types.ObjectId(tenantId.toString()) })
+      .find({
+        tenantId: new Types.ObjectId(tenantId.toString()),
+        deletedAt: null,
+      })
       .sort({ createdAt: -1 });
 
     return documents.map((doc) => this.toDomain(doc));
@@ -82,11 +88,15 @@ export class MongoPropertyRepository implements PropertyRepository {
   async countByTenantId(tenantId: TenantId): Promise<number> {
     return this.propertyModel.countDocuments({
       tenantId: new Types.ObjectId(tenantId.toString()),
+      deletedAt: null,
     });
   }
 
   async delete(id: PropertyId): Promise<void> {
-    await this.propertyModel.findByIdAndDelete(id.toString());
+    await this.propertyModel.findByIdAndUpdate(id.toString(), {
+      deletedAt: new Date(),
+      updatedAt: new Date(),
+    });
   }
 
   private toDomain(document: PropertyDocument): Property {
@@ -109,6 +119,7 @@ export class MongoPropertyRepository implements PropertyRepository {
       document.hostEmail,
       document.createdAt,
       document.updatedAt,
+      document.deletedAt ?? null,
     );
   }
 }

--- a/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
@@ -177,6 +177,25 @@ export class MongoReservationRepository implements ReservationRepository {
     });
   }
 
+  async existsActiveByPropertyId(
+    tenantId: string,
+    propertyId: string,
+  ): Promise<boolean> {
+    const activeReservation = await this.reservationModel.exists({
+      tenantId: new Types.ObjectId(tenantId),
+      propertyId: new Types.ObjectId(propertyId),
+      status: {
+        $in: [
+          ReservationStatusEnum.PENDING,
+          ReservationStatusEnum.CONFIRMED,
+          ReservationStatusEnum.CHECKED_IN,
+        ],
+      },
+    });
+
+    return Boolean(activeReservation);
+  }
+
   async findConfirmedDueForCheckIn(date: Date): Promise<Reservation[]> {
     const endOfDay = new Date(date);
     endOfDay.setHours(23, 59, 59, 999);

--- a/src/infrastructure/persistence/schemas/property.schema.ts
+++ b/src/infrastructure/persistence/schemas/property.schema.ts
@@ -69,6 +69,9 @@ export class PropertyDocument extends Document {
 
   @Prop()
   updatedAt: Date;
+
+  @Prop({ type: Date, default: null })
+  deletedAt: Date | null;
 }
 
 export const PropertySchema = SchemaFactory.createForClass(PropertyDocument);

--- a/src/presentation/controllers/property.controller.ts
+++ b/src/presentation/controllers/property.controller.ts
@@ -2,15 +2,23 @@ import { CreatePropertyCommand } from '@/application/property/commands/create-pr
 import { CreatePropertyResult } from '@/application/property/commands/create-property.result';
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
+import { RequirePermission } from '@/infrastructure/auth/decorators/require-permission.decorator';
+import { JwtAuthGuard } from '@/infrastructure/auth/guards/jwt-auth.guard';
+import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
 import {
   Body,
   Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
   Post,
   Query,
   ParseBoolPipe,
   DefaultValuePipe,
   ParseIntPipe,
   Get,
+  Param,
+  UseGuards,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
@@ -20,7 +28,9 @@ import {
   ApiTags,
   ApiQuery,
 } from '@nestjs/swagger';
+import { Permission } from '@/domain/role/value-objects/permission.vo';
 import { CreatePropertyDto } from '@/presentation/dtos/create-property.dto';
+import { DeletePropertyCommand } from '@/application/property/commands/delete-property.command';
 import { GetPropertiesByTenantQuery } from '@/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.query';
 import { GetPropertiesByTenantResult } from '@/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.result';
 
@@ -126,5 +136,22 @@ export class PropertyController {
         totalPages: Math.ceil(result.total / result.limit),
       },
     };
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_DELETE)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Soft delete a property' })
+  @ApiResponse({ status: 204, description: 'Property deleted successfully' })
+  @ApiResponse({
+    status: 403,
+    description: 'Property has active reservations and cannot be deleted',
+  })
+  @ApiResponse({ status: 404, description: 'Property not found' })
+  async remove(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
+    await this.commandBus.execute<DeletePropertyCommand, void>(
+      new DeletePropertyCommand(id, user.tenantId, user.userId, user.email),
+    );
   }
 }

--- a/test/application/property/delete-property.handler.spec.ts
+++ b/test/application/property/delete-property.handler.spec.ts
@@ -1,0 +1,125 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { DeletePropertyHandler } from '@/application/property/commands/delete-property.handler';
+import { DeletePropertyCommand } from '@/application/property/commands/delete-property.command';
+import { PropertyRepository } from '@/domain/property/repositories/property.repository';
+import { ReservationRepository } from '@/domain/reservation/repositories/reservation.repository';
+import { createPropertyRepositoryMock } from '@test/shared/mocks/repositories/property-repository.mock';
+import { createReservationRepositoryMock } from '@test/shared/mocks/repositories/reservation-repository.mock';
+import { createEventEmitterMock } from '@test/shared/mocks/services/event-emitter.mock';
+import { makeProperty } from '@test/shared/fixtures/property.fixture';
+
+describe('DeletePropertyHandler', () => {
+  let handler: DeletePropertyHandler;
+  let propertyRepository: jest.Mocked<PropertyRepository>;
+  let reservationRepository: jest.Mocked<ReservationRepository>;
+  let eventEmitter: ReturnType<typeof createEventEmitterMock>;
+
+  beforeEach(() => {
+    propertyRepository = createPropertyRepositoryMock();
+    reservationRepository = createReservationRepositoryMock();
+    eventEmitter = createEventEmitterMock();
+
+    handler = new DeletePropertyHandler(
+      propertyRepository,
+      reservationRepository,
+      eventEmitter as any,
+    );
+  });
+
+  describe('when property does not exist', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        handler.execute(
+          new DeletePropertyCommand(
+            'property-123',
+            'tenant-123',
+            'user-123',
+            'user@example.com',
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(
+        reservationRepository.existsActiveByPropertyId,
+      ).not.toHaveBeenCalled();
+      expect(propertyRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when property belongs to another tenant', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(
+        makeProperty({ tenantId: 'other-tenant' }),
+      );
+
+      await expect(
+        handler.execute(
+          new DeletePropertyCommand(
+            'property-123',
+            'tenant-123',
+            'user-123',
+            'user@example.com',
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(
+        reservationRepository.existsActiveByPropertyId,
+      ).not.toHaveBeenCalled();
+      expect(propertyRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when property has active reservations', () => {
+    it('throws ForbiddenException', async () => {
+      propertyRepository.findById.mockResolvedValue(makeProperty());
+      reservationRepository.existsActiveByPropertyId.mockResolvedValue(true);
+
+      await expect(
+        handler.execute(
+          new DeletePropertyCommand(
+            'property-123',
+            'tenant-123',
+            'user-123',
+            'user@example.com',
+          ),
+        ),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(propertyRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when all validations pass', () => {
+    it('soft deletes property and emits audit event', async () => {
+      propertyRepository.findById.mockResolvedValue(makeProperty());
+      reservationRepository.existsActiveByPropertyId.mockResolvedValue(false);
+
+      await expect(
+        handler.execute(
+          new DeletePropertyCommand(
+            'property-123',
+            'tenant-123',
+            'user-123',
+            'user@example.com',
+          ),
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(propertyRepository.delete).toHaveBeenCalledTimes(1);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          tenantId: 'tenant-123',
+          userId: 'user-123',
+          userEmail: 'user@example.com',
+          action: 'PROPERTY_DELETED',
+          entityType: 'PROPERTY',
+          entityId: 'property-123',
+        }),
+      );
+    });
+  });
+});

--- a/test/shared/fixtures/property.fixture.ts
+++ b/test/shared/fixtures/property.fixture.ts
@@ -59,5 +59,6 @@ export function makeProperty(
     merged.hostEmail,
     new Date(),
     new Date(),
+    null,
   );
 }

--- a/test/shared/mocks/repositories/reservation-repository.mock.ts
+++ b/test/shared/mocks/repositories/reservation-repository.mock.ts
@@ -11,6 +11,7 @@ export function createReservationRepositoryMock(): jest.Mocked<ReservationReposi
     findByUnitAndDateRange: jest.fn(),
     findByExternalId: jest.fn(),
     countByTenantId: jest.fn(),
+    existsActiveByPropertyId: jest.fn(),
     findConfirmedDueForCheckIn: jest.fn(),
   };
 }


### PR DESCRIPTION
Introduces soft delete functionality for properties, allowing them to be logically removed while retaining historical data and preventing deletion of properties with active reservations.

Key changes include:
- Adds a `deletedAt` field to the property entity and its persistence schema.
- Modifies property queries to automatically filter out soft-deleted properties.
- Implements a new command and handler to manage the soft deletion process.
- Prevents deletion if a property has active reservations, throwing a `ForbiddenException`.
- Exposes a dedicated `DELETE` endpoint in the property controller, secured by permissions.
- Emits an audit log event when a property is successfully soft-deleted.
- Includes comprehensive unit tests for the new deletion flow.

Relates to LYMON-36