### PR TITLE
LYMON-35-Editar-propiedad

### DIFF
--- a/src/application/property/commands/update-property.command.ts
+++ b/src/application/property/commands/update-property.command.ts
@@ -1,0 +1,21 @@
+export class UpdatePropertyCommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly propertyId: string,
+    public readonly name: string | undefined,
+    public readonly description: string | undefined,
+    public readonly address: string | undefined,
+    public readonly city: string | undefined,
+    public readonly state: string | undefined,
+    public readonly country: string | undefined,
+    public readonly zipCode: string | undefined,
+    public readonly location: { lat: number; lng: number } | undefined,
+    public readonly checkInTime: string | undefined,
+    public readonly checkOutTime: string | undefined,
+    public readonly cancellationPolicy: string | undefined,
+    public readonly hostPhone: string | undefined,
+    public readonly hostEmail: string | undefined,
+    public readonly actorId: string,
+    public readonly actorEmail: string,
+  ) {}
+}

--- a/src/application/property/commands/update-property.handler.ts
+++ b/src/application/property/commands/update-property.handler.ts
@@ -1,0 +1,132 @@
+import { UpdatePropertyCommand } from '@/application/property/commands/update-property.command';
+import { UpdatePropertyResult } from '@/application/property/commands/update-property.result';
+import {
+  PROPERTY_REPOSITORY,
+  type PropertyRepository,
+} from '@/domain/property/repositories/property.repository';
+import { CancellationPolicy } from '@/domain/property/value-objects/cancellation-policy.vo';
+import { Location } from '@/domain/property/value-objects/location.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import {
+  AuditAction,
+  AuditEntityType,
+} from '@/domain/audit/value-objects/audit-action.vo';
+import {
+  AuditLoggedEvent,
+  AUDIT_LOG_EVENT,
+} from '@/infrastructure/audit/events/audit-logged.event';
+import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+
+@CommandHandler(UpdatePropertyCommand)
+export class UpdatePropertyHandler implements ICommandHandler<
+  UpdatePropertyCommand,
+  UpdatePropertyResult
+> {
+  constructor(
+    @Inject(PROPERTY_REPOSITORY)
+    private readonly propertyRepository: PropertyRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(command: UpdatePropertyCommand): Promise<UpdatePropertyResult> {
+    if (!this.hasAnyUpdatableField(command)) {
+      throw new BadRequestException('At least one field is required to update');
+    }
+
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const propertyId = PropertyId.create(command.propertyId);
+
+    const property = await this.propertyRepository.findById(propertyId);
+    if (!property || !property.getTenantId().equals(tenantId)) {
+      throw new NotFoundException('Property not found');
+    }
+
+    if (this.hasAnyDetailsField(command)) {
+      property.updateDetails(
+        command.name ?? property.getName(),
+        command.description ?? property.getDescription(),
+        command.address ?? property.getAddress(),
+        command.city ?? property.getCity(),
+        command.state ?? property.getState(),
+        command.country ?? property.getCountry(),
+        command.zipCode ?? property.getZipCode(),
+        command.location
+          ? Location.create(command.location.lat, command.location.lng)
+          : property.getLocation(),
+      );
+    }
+
+    if (
+      command.checkInTime !== undefined ||
+      command.checkOutTime !== undefined
+    ) {
+      property.updateCheckInOut(
+        command.checkInTime ?? property.getCheckInTime(),
+        command.checkOutTime ?? property.getCheckOutTime(),
+      );
+    }
+
+    if (command.cancellationPolicy !== undefined) {
+      property.updateCancellationPolicy(
+        CancellationPolicy.create(command.cancellationPolicy),
+      );
+    }
+
+    if (command.hostPhone !== undefined || command.hostEmail !== undefined) {
+      property.updateHostContact(
+        command.hostPhone ?? property.getHostPhone(),
+        command.hostEmail ?? property.getHostEmail(),
+      );
+    }
+
+    const updatedPropertyId = await this.propertyRepository.save(property);
+
+    this.eventEmitter.emit(
+      AUDIT_LOG_EVENT,
+      new AuditLoggedEvent(
+        command.tenantId,
+        command.actorId,
+        command.actorEmail,
+        AuditAction.PROPERTY_UPDATED,
+        AuditEntityType.PROPERTY,
+        command.propertyId,
+      ),
+    );
+
+    return new UpdatePropertyResult(updatedPropertyId);
+  }
+
+  private hasAnyUpdatableField(command: UpdatePropertyCommand): boolean {
+    return [
+      command.name,
+      command.description,
+      command.address,
+      command.city,
+      command.state,
+      command.country,
+      command.zipCode,
+      command.location,
+      command.checkInTime,
+      command.checkOutTime,
+      command.cancellationPolicy,
+      command.hostPhone,
+      command.hostEmail,
+    ].some((field) => field !== undefined);
+  }
+
+  private hasAnyDetailsField(command: UpdatePropertyCommand): boolean {
+    return [
+      command.name,
+      command.description,
+      command.address,
+      command.city,
+      command.state,
+      command.country,
+      command.zipCode,
+      command.location,
+    ].some((field) => field !== undefined);
+  }
+}

--- a/src/application/property/commands/update-property.result.ts
+++ b/src/application/property/commands/update-property.result.ts
@@ -1,0 +1,3 @@
+export class UpdatePropertyResult {
+  constructor(public readonly propertyId: string) {}
+}

--- a/src/application/property/property-application.module.ts
+++ b/src/application/property/property-application.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { CreatePropertyHandler } from '@/application/property/commands/create-property.handler';
+import { UpdatePropertyHandler } from '@/application/property/commands/update-property.handler';
 import { GetPropertiesByTenantQueryHandler } from '@/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.query-handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 
-const CommandHandlers = [CreatePropertyHandler];
+const CommandHandlers = [CreatePropertyHandler, UpdatePropertyHandler];
 const QueryHandlers = [GetPropertiesByTenantQueryHandler];
 
 @Module({

--- a/src/presentation/controllers/property.controller.ts
+++ b/src/presentation/controllers/property.controller.ts
@@ -1,7 +1,12 @@
 import { CreatePropertyCommand } from '@/application/property/commands/create-property.command';
 import { CreatePropertyResult } from '@/application/property/commands/create-property.result';
+import { UpdatePropertyCommand } from '@/application/property/commands/update-property.command';
+import { UpdatePropertyResult } from '@/application/property/commands/update-property.result';
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
+import { RequirePermission } from '@/infrastructure/auth/decorators/require-permission.decorator';
+import { Permission } from '@/domain/role/value-objects/permission.vo';
+import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
 import {
   Body,
   Controller,
@@ -11,6 +16,9 @@ import {
   DefaultValuePipe,
   ParseIntPipe,
   Get,
+  Patch,
+  Param,
+  UseGuards,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
@@ -21,6 +29,7 @@ import {
   ApiQuery,
 } from '@nestjs/swagger';
 import { CreatePropertyDto } from '@/presentation/dtos/create-property.dto';
+import { UpdatePropertyDto } from '@/presentation/dtos/update-property.dto';
 import { GetPropertiesByTenantQuery } from '@/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.query';
 import { GetPropertiesByTenantResult } from '@/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.result';
 
@@ -124,6 +133,51 @@ export class PropertyController {
         page: result.page,
         limit: result.limit,
         totalPages: Math.ceil(result.total / result.limit),
+      },
+    };
+  }
+
+  @Patch(':propertyId')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_EDIT)
+  @ApiOperation({ summary: 'Update an existing property' })
+  @ApiResponse({ status: 200, description: 'Property updated successfully' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Property not found' })
+  async updateProperty(
+    @CurrentUser() user: JwtPayload,
+    @Param('propertyId') propertyId: string,
+    @Body() dto: UpdatePropertyDto,
+  ) {
+    const command = new UpdatePropertyCommand(
+      user.tenantId,
+      propertyId,
+      dto.name,
+      dto.description,
+      dto.address,
+      dto.city,
+      dto.state,
+      dto.country,
+      dto.zipCode,
+      dto.location,
+      dto.checkInTime,
+      dto.checkOutTime,
+      dto.cancellationPolicy,
+      dto.hostPhone,
+      dto.hostEmail,
+      user.userId,
+      user.email,
+    );
+
+    const result = await this.commandBus.execute<
+      UpdatePropertyCommand,
+      UpdatePropertyResult
+    >(command);
+
+    return {
+      message: 'Property updated successfully',
+      data: {
+        propertyId: result.propertyId,
       },
     };
   }

--- a/src/presentation/dtos/update-property.dto.ts
+++ b/src/presentation/dtos/update-property.dto.ts
@@ -1,0 +1,119 @@
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { CancellationPolicyEnum } from '@/domain/property/value-objects/cancellation-policy.vo';
+
+class UpdatePropertyLocationDto {
+  @ApiPropertyOptional({
+    example: 40.7128,
+    description: 'Latitude',
+    minimum: -90,
+    maximum: 90,
+  })
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat: number;
+
+  @ApiPropertyOptional({
+    example: -74.006,
+    description: 'Longitude',
+    minimum: -180,
+    maximum: 180,
+  })
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng: number;
+}
+
+export class UpdatePropertyDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  description?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  address?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  city?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  state?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  country?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  zipCode?: string;
+
+  @ApiPropertyOptional({
+    type: UpdatePropertyLocationDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdatePropertyLocationDto)
+  location?: UpdatePropertyLocationDto;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  checkInTime?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  checkOutTime?: string;
+
+  @ApiPropertyOptional({ enum: CancellationPolicyEnum })
+  @IsOptional()
+  @IsEnum(CancellationPolicyEnum)
+  cancellationPolicy?: CancellationPolicyEnum;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  hostPhone?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEmail()
+  @IsNotEmpty()
+  hostEmail?: string;
+}

--- a/test/application/property/update-property.handler.spec.ts
+++ b/test/application/property/update-property.handler.spec.ts
@@ -1,0 +1,106 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { UpdatePropertyHandler } from '@/application/property/commands/update-property.handler';
+import { UpdatePropertyCommand } from '@/application/property/commands/update-property.command';
+import { UpdatePropertyResult } from '@/application/property/commands/update-property.result';
+import { PropertyRepository } from '@/domain/property/repositories/property.repository';
+import { createPropertyRepositoryMock } from '@test/shared/mocks/repositories/property-repository.mock';
+import { createEventEmitterMock } from '@test/shared/mocks/services/event-emitter.mock';
+import {
+  makeProperty,
+  PROPERTY_FIXTURE_DEFAULTS,
+} from '@test/shared/fixtures/property.fixture';
+
+describe('UpdatePropertyHandler', () => {
+  let handler: UpdatePropertyHandler;
+  let propertyRepository: jest.Mocked<PropertyRepository>;
+  let eventEmitter: ReturnType<typeof createEventEmitterMock>;
+
+  function makeCommand(
+    overrides?: Partial<UpdatePropertyCommand>,
+  ): UpdatePropertyCommand {
+    return new UpdatePropertyCommand(
+      overrides?.tenantId ?? PROPERTY_FIXTURE_DEFAULTS.tenantId,
+      overrides?.propertyId ?? PROPERTY_FIXTURE_DEFAULTS.id,
+      overrides?.name,
+      overrides?.description,
+      overrides?.address,
+      overrides?.city,
+      overrides?.state,
+      overrides?.country,
+      overrides?.zipCode,
+      overrides?.location,
+      overrides?.checkInTime,
+      overrides?.checkOutTime,
+      overrides?.cancellationPolicy,
+      overrides?.hostPhone,
+      overrides?.hostEmail,
+      overrides?.actorId ?? 'user-456',
+      overrides?.actorEmail ?? 'owner@example.com',
+    );
+  }
+
+  beforeEach(() => {
+    propertyRepository = createPropertyRepositoryMock();
+    eventEmitter = createEventEmitterMock();
+
+    handler = new UpdatePropertyHandler(
+      propertyRepository,
+      eventEmitter as any,
+    );
+  });
+
+  describe('when no fields are provided', () => {
+    it('throws BadRequestException', async () => {
+      await expect(handler.execute(makeCommand())).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('when property does not exist', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        handler.execute(makeCommand({ name: 'Casa renovada' })),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('when property belongs to a different tenant', () => {
+    it('throws NotFoundException', async () => {
+      propertyRepository.findById.mockResolvedValue(
+        makeProperty({ tenantId: 'other-tenant' }),
+      );
+
+      await expect(
+        handler.execute(makeCommand({ name: 'Casa renovada' })),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('when update is successful', () => {
+    it('updates and saves property, then emits audit event', async () => {
+      propertyRepository.findById.mockResolvedValue(makeProperty());
+      propertyRepository.save.mockResolvedValue(PROPERTY_FIXTURE_DEFAULTS.id);
+
+      const result = await handler.execute(
+        makeCommand({
+          name: 'Casa del lago premium',
+          city: 'Medellín',
+          checkOutTime: '12:00',
+          cancellationPolicy: 'STANDARD',
+          hostPhone: '+573009876543',
+        }),
+      );
+
+      expect(result).toBeInstanceOf(UpdatePropertyResult);
+      expect(result.propertyId).toBe(PROPERTY_FIXTURE_DEFAULTS.id);
+      expect(propertyRepository.save).toHaveBeenCalledTimes(1);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ entityType: 'PROPERTY' }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds full support for updating an existing property, including a new update command, handler, DTO, and controller endpoint. It also introduces validation, authorization, and auditing for property updates, and includes comprehensive tests for the update logic.

**Property Update Feature Implementation:**

- Added `UpdatePropertyCommand`, `UpdatePropertyResult`, and `UpdatePropertyHandler` to handle property updates, including validation for at least one updatable field, tenant ownership checks, and audit event emission. [[1]](diffhunk://#diff-7c35018340aa23a348b6e4a635d7e4fcd93f1e5cd814a439f5988b5291c7ff8cR1-R21) [[2]](diffhunk://#diff-fabf5852ae05210f05697387706bfd28a384d05839f48b710a18abb98a9d7a28R1-R3) [[3]](diffhunk://#diff-1ac26bb4d34910cb518a93f99b2ad78e2f4611985b837aeb96609766ba3ec08eR1-R132)
- Registered `UpdatePropertyHandler` in the `property-application.module.ts` so it is available for command handling.

**API Layer Enhancements:**

- Added `UpdatePropertyDto` with field-level validation and OpenAPI documentation, including a nested DTO for location.
- Implemented a new `PATCH /property/:propertyId` endpoint in `PropertyController` to handle property updates, with permission checks and proper API responses. [[1]](diffhunk://#diff-d7d88b0f44a9a5bc0a1c4cba84ac22bdbd500a16208b1ebae21939f05d17660bR3-R9) [[2]](diffhunk://#diff-d7d88b0f44a9a5bc0a1c4cba84ac22bdbd500a16208b1ebae21939f05d17660bR19-R21) [[3]](diffhunk://#diff-d7d88b0f44a9a5bc0a1c4cba84ac22bdbd500a16208b1ebae21939f05d17660bR32) [[4]](diffhunk://#diff-d7d88b0f44a9a5bc0a1c4cba84ac22bdbd500a16208b1ebae21939f05d17660bR139-R183)

**Testing:**

- Added unit tests for `UpdatePropertyHandler` covering validation, not found, tenant mismatch, and successful update scenarios.