### PR TITLE
LYMON-39-Editar-unidad

### DIFF
--- a/docs/adr/012-unit-inventory-count-validation.md
+++ b/docs/adr/012-unit-inventory-count-validation.md
@@ -1,0 +1,96 @@
+# ADR-012: Validación de `inventoryCount` por pico de reservas activas concurrentes
+
+**Fecha:** 2026-03-22  
+**Estado:** Aceptado
+
+---
+
+## Contexto
+
+Al implementar la edición de unidades (`UpdateUnit`), surge una regla crítica de negocio:
+
+> No se debe permitir reducir `inventoryCount` por debajo de la demanda ya comprometida por reservas activas para esa unidad.
+
+La pregunta fue cuál es la forma más simple y correcta de validar esta regla sin introducir complejidad innecesaria.
+
+---
+
+## Decisión
+
+Se valida la reducción de `inventoryCount` calculando el **pico de reservas activas concurrentes** mediante un algoritmo de barrido temporal (_sweep line_) en el servicio de dominio:
+
+- `InventoryCountValidator.getMinimumRequiredInventory(reservations)`
+
+El resultado del método representa el **inventario mínimo requerido** para no generar sobreventa.
+
+Regla aplicada en `UpdateUnitHandler`:
+
+$$
+newInventoryCount \ge peakConcurrentActiveReservations
+$$
+
+Si no se cumple, se rechaza el cambio con error de conflicto de negocio.
+
+---
+
+## Implementación
+
+1. Se filtran reservas inactivas (`CANCELLED`, `NO_SHOW`).
+2. Cada reserva activa genera dos eventos:
+   - `checkIn` con `+1`
+   - `checkOut` con `-1`
+3. Se ordenan eventos por fecha (en empate, primero `-1` y luego `+1`).
+4. Se recorre acumulando ocupación actual y registrando el máximo (`peak`).
+5. `peak` es el mínimo `inventoryCount` permitido.
+
+---
+
+## Razones
+
+### 1. Correctitud de negocio
+
+Contar solo reservas activas totales no es suficiente, porque no todas se solapan en las mismas fechas. El pico concurrente sí modela la ocupación máxima real.
+
+### 2. Simplicidad razonable
+
+El algoritmo evita comparaciones cuadráticas complejas entre todas las reservas y mantiene una lógica clara de entrada/salida temporal.
+
+### 3. Complejidad adecuada
+
+- Tiempo: $O(n \log n)$ (por ordenamiento de eventos)
+- Espacio: $O(n)$
+
+Para el volumen esperado por unidad en el MVP, esta complejidad es adecuada.
+
+### 4. Encapsulación limpia
+
+La regla vive en dominio (`InventoryCountValidator`) y no en controlador/DTO, manteniendo Clean Architecture y testabilidad.
+
+---
+
+## Alternativas descartadas
+
+### A) `newInventoryCount >= activeReservations.length`
+
+**Descartada**: sobre-restringe o sub-restringe según solapamientos; no modela concurrencia real.
+
+### B) Validación directa en base de datos con agregaciones complejas
+
+**Descartada para MVP**: mayor complejidad técnica y menor legibilidad para una regla que hoy se resuelve correctamente en dominio.
+
+---
+
+## Consecuencias
+
+- Se evita sobreventa al reducir `inventoryCount`.
+- La validación es consistente y reutilizable desde casos de uso de aplicación.
+- El comportamiento queda explícitamente documentado para futuras iteraciones y refactors.
+
+---
+
+## Archivos relacionados
+
+- `src/domain/reservation/services/inventory-count-validator.domain-service.ts`
+- `src/application/unit/commands/update-unit.handler.ts`
+- `src/domain/reservation/repositories/reservation.repository.ts`
+- `src/infrastructure/persistence/repositories/mongo-reservation.repository.ts`

--- a/src/application/unit/commands/update-unit.command.ts
+++ b/src/application/unit/commands/update-unit.command.ts
@@ -1,0 +1,30 @@
+export class UpdateUnitCommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly unitId: string,
+    public readonly name: string | undefined,
+    public readonly description: string | undefined,
+    public readonly inventoryCount: number | undefined,
+    public readonly maxGuests: number | undefined,
+    public readonly standardGuests: number | undefined,
+    public readonly bedrooms:
+      | Array<{
+          roomName: string;
+          beds: Array<{ type: string; count: number }>;
+        }>
+      | undefined,
+    public readonly bathroomsCount: number | undefined,
+    public readonly isShared: boolean | undefined,
+    public readonly amenities: string[] | undefined,
+    public readonly pricePerNight: number | undefined,
+    public readonly externalIds:
+      | {
+          airbnbId?: string;
+          bookingId?: string;
+          vrboId?: string;
+        }
+      | undefined,
+    public readonly actorId?: string,
+    public readonly actorEmail?: string,
+  ) {}
+}

--- a/src/application/unit/commands/update-unit.handler.ts
+++ b/src/application/unit/commands/update-unit.handler.ts
@@ -1,0 +1,203 @@
+import { UpdateUnitCommand } from '@/application/unit/commands/update-unit.command';
+import { UpdateUnitResult } from '@/application/unit/commands/update-unit.result';
+import {
+  RESERVATION_REPOSITORY,
+  type ReservationRepository,
+} from '@/domain/reservation/repositories/reservation.repository';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import {
+  UNIT_REPOSITORY,
+  type UnitRepository,
+} from '@/domain/unit/repositories/unit.repository';
+import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
+import { BedTypeEnum } from '@/domain/unit/value-objects/bed-type.vo';
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  NotFoundException,
+} from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  AuditAction,
+  AuditEntityType,
+} from '@/domain/audit/value-objects/audit-action.vo';
+import {
+  AuditLoggedEvent,
+  AUDIT_LOG_EVENT,
+} from '@/infrastructure/audit/events/audit-logged.event';
+import { InventoryCountValidator } from '@/domain/reservation/services/inventory-count-validator.domain-service';
+
+@CommandHandler(UpdateUnitCommand)
+export class UpdateUnitHandler implements ICommandHandler<UpdateUnitCommand> {
+  constructor(
+    @Inject(UNIT_REPOSITORY)
+    private readonly unitRepository: UnitRepository,
+    @Inject(RESERVATION_REPOSITORY)
+    private readonly reservationRepository: ReservationRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(command: UpdateUnitCommand): Promise<UpdateUnitResult> {
+    this.validateAtLeastOneField(command);
+
+    const unit = await this.unitRepository.findById(
+      UnitId.create(command.unitId),
+    );
+
+    if (!unit || unit.getTenantId().toString() !== command.tenantId) {
+      throw new NotFoundException('Unit not found');
+    }
+
+    const previousInventoryCount = unit.getInventoryCount();
+
+    if (
+      command.inventoryCount !== undefined &&
+      command.inventoryCount < unit.getInventoryCount()
+    ) {
+      const activeReservations =
+        await this.reservationRepository.findActiveByUnitFromDate(
+          UnitId.create(command.unitId),
+          new Date(),
+        );
+
+      const minimumAllowedInventory =
+        InventoryCountValidator.getMinimumRequiredInventory(activeReservations);
+
+      if (command.inventoryCount < minimumAllowedInventory) {
+        throw new ConflictException(
+          `Cannot reduce inventory count below ${minimumAllowedInventory} because there are active reservations in overlapping dates`,
+        );
+      }
+
+      unit.updateInventoryCount(command.inventoryCount);
+    }
+
+    if (command.name !== undefined || command.description !== undefined) {
+      unit.updateDetails(
+        command.name ?? unit.getName(),
+        command.description ?? unit.getDescription(),
+      );
+    }
+
+    if (
+      command.maxGuests !== undefined ||
+      command.standardGuests !== undefined
+    ) {
+      unit.updateCapacity(
+        command.maxGuests ?? unit.getMaxGuests(),
+        command.standardGuests ?? unit.getStandardGuests(),
+      );
+    }
+
+    if (command.bedrooms !== undefined) {
+      const bedrooms = command.bedrooms.map((bedroom) => ({
+        roomName: bedroom.roomName,
+        beds: bedroom.beds.map((bed) => ({
+          type: bed.type as BedTypeEnum,
+          count: bed.count,
+        })),
+      }));
+      unit.updateBedrooms(bedrooms);
+    }
+
+    if (command.bathroomsCount !== undefined) {
+      unit.updateBathroomsCount(command.bathroomsCount);
+    }
+
+    if (command.isShared !== undefined) {
+      unit.updateShared(command.isShared);
+    }
+
+    if (command.amenities !== undefined) {
+      unit.updateAmenities(command.amenities);
+    }
+
+    if (command.pricePerNight !== undefined) {
+      unit.updatePrice(command.pricePerNight);
+    }
+
+    if (command.externalIds !== undefined) {
+      unit.updateExternalIds(
+        ExternalIds.create(
+          command.externalIds.airbnbId,
+          command.externalIds.bookingId,
+          command.externalIds.vrboId,
+        ),
+      );
+    }
+
+    await this.unitRepository.save(unit);
+
+    if (command.actorId && command.actorEmail) {
+      this.eventEmitter.emit(
+        AUDIT_LOG_EVENT,
+        new AuditLoggedEvent(
+          command.tenantId,
+          command.actorId,
+          command.actorEmail,
+          AuditAction.UNIT_UPDATED,
+          AuditEntityType.UNIT,
+          command.unitId,
+          {
+            changedFields: this.getChangedFields(command),
+            ...(command.inventoryCount !== undefined
+              ? {
+                  inventoryCount: {
+                    before: previousInventoryCount,
+                    after: command.inventoryCount,
+                  },
+                }
+              : {}),
+          },
+        ),
+      );
+    }
+
+    return new UpdateUnitResult(command.unitId);
+  }
+
+  private validateAtLeastOneField(command: UpdateUnitCommand): void {
+    const hasAnyFieldToUpdate =
+      command.name !== undefined ||
+      command.description !== undefined ||
+      command.inventoryCount !== undefined ||
+      command.maxGuests !== undefined ||
+      command.standardGuests !== undefined ||
+      command.bedrooms !== undefined ||
+      command.bathroomsCount !== undefined ||
+      command.isShared !== undefined ||
+      command.amenities !== undefined ||
+      command.pricePerNight !== undefined ||
+      command.externalIds !== undefined;
+
+    if (!hasAnyFieldToUpdate) {
+      throw new BadRequestException(
+        'At least one field must be provided for update',
+      );
+    }
+  }
+
+  private getChangedFields(command: UpdateUnitCommand): string[] {
+    const changedFields: string[] = [];
+
+    if (command.name !== undefined) changedFields.push('name');
+    if (command.description !== undefined) changedFields.push('description');
+    if (command.inventoryCount !== undefined)
+      changedFields.push('inventoryCount');
+    if (command.maxGuests !== undefined) changedFields.push('maxGuests');
+    if (command.standardGuests !== undefined)
+      changedFields.push('standardGuests');
+    if (command.bedrooms !== undefined) changedFields.push('bedrooms');
+    if (command.bathroomsCount !== undefined)
+      changedFields.push('bathroomsCount');
+    if (command.isShared !== undefined) changedFields.push('isShared');
+    if (command.amenities !== undefined) changedFields.push('amenities');
+    if (command.pricePerNight !== undefined)
+      changedFields.push('pricePerNight');
+    if (command.externalIds !== undefined) changedFields.push('externalIds');
+
+    return changedFields;
+  }
+}

--- a/src/application/unit/commands/update-unit.result.ts
+++ b/src/application/unit/commands/update-unit.result.ts
@@ -1,0 +1,3 @@
+export class UpdateUnitResult {
+  constructor(public readonly unitId: string) {}
+}

--- a/src/application/unit/unit-application.module.ts
+++ b/src/application/unit/unit-application.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { CreateUnitHandler } from '@/application/unit/commands/create-unit.handler';
+import { UpdateUnitHandler } from '@/application/unit/commands/update-unit.handler';
 import { GetUnitsByPropertyQueryHandler } from '@/application/unit/queries/GetUnitsByProperty/get-units-by-property.query-handler';
 import { GetPublicUnitsByTenantQueryHandler } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler';
 import { GetPublicUnitByIdQueryHandler } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query-handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 
-const CommandHandlers = [CreateUnitHandler];
+const CommandHandlers = [CreateUnitHandler, UpdateUnitHandler];
 const QueryHandlers = [
   GetUnitsByPropertyQueryHandler,
   GetPublicUnitsByTenantQueryHandler,

--- a/src/domain/reservation/repositories/reservation.repository.ts
+++ b/src/domain/reservation/repositories/reservation.repository.ts
@@ -37,6 +37,10 @@ export interface ReservationRepository {
     unitId: UnitId,
     dateRange: DateRange,
   ): Promise<Reservation[]>;
+  findActiveByUnitFromDate(
+    unitId: UnitId,
+    fromDate: Date,
+  ): Promise<Reservation[]>;
   findByExternalId(
     source: ReservationSourceEnum,
     externalId: string,

--- a/src/domain/reservation/services/inventory-count-validator.domain-service.ts
+++ b/src/domain/reservation/services/inventory-count-validator.domain-service.ts
@@ -1,0 +1,48 @@
+import { Reservation } from '@/domain/reservation/entities/reservation.entity';
+import { ReservationStatusEnum } from '@/domain/reservation/value-objects/reservation-status.vo';
+
+const INACTIVE_STATUSES: ReservationStatusEnum[] = [
+  ReservationStatusEnum.CANCELLED,
+  ReservationStatusEnum.NO_SHOW,
+];
+
+export class InventoryCountValidator {
+  static getMinimumRequiredInventory(reservations: Reservation[]): number {
+    const activeReservations = reservations.filter(
+      (reservation) =>
+        !INACTIVE_STATUSES.includes(reservation.getStatus().getValue()),
+    );
+
+    if (activeReservations.length === 0) {
+      return 0;
+    }
+
+    const events: Array<{ at: Date; delta: number }> = [];
+
+    for (const reservation of activeReservations) {
+      const range = reservation.getDateRange();
+      events.push({ at: range.getCheckIn(), delta: 1 });
+      events.push({ at: range.getCheckOut(), delta: -1 });
+    }
+
+    events.sort((a, b) => {
+      if (a.at.getTime() !== b.at.getTime()) {
+        return a.at.getTime() - b.at.getTime();
+      }
+
+      return a.delta - b.delta;
+    });
+
+    let current = 0;
+    let peak = 0;
+
+    for (const event of events) {
+      current += event.delta;
+      if (current > peak) {
+        peak = current;
+      }
+    }
+
+    return peak;
+  }
+}

--- a/src/domain/unit/entities/unit.entity.ts
+++ b/src/domain/unit/entities/unit.entity.ts
@@ -203,6 +203,34 @@ export class Unit {
     this.updatedAt = new Date();
   }
 
+  updateInventoryCount(inventoryCount: number): void {
+    if (inventoryCount < 1) {
+      throw new Error('Inventory count must be at least 1');
+    }
+
+    this.inventoryCount = inventoryCount;
+    this.updatedAt = new Date();
+  }
+
+  updateBedrooms(bedrooms: Bedroom[]): void {
+    this.bedrooms = bedrooms;
+    this.updatedAt = new Date();
+  }
+
+  updateBathroomsCount(bathroomsCount: number): void {
+    if (bathroomsCount < 0) {
+      throw new Error('Bathrooms count cannot be negative');
+    }
+
+    this.bathroomsCount = bathroomsCount;
+    this.updatedAt = new Date();
+  }
+
+  updateShared(isShared: boolean): void {
+    this.isShared = isShared;
+    this.updatedAt = new Date();
+  }
+
   updatePrice(pricePerNight: number): void {
     if (pricePerNight < 0) {
       throw new Error('Price per night cannot be negative');

--- a/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
@@ -159,6 +159,21 @@ export class MongoReservationRepository implements ReservationRepository {
     return docs.map((d) => this.toDomain(d));
   }
 
+  async findActiveByUnitFromDate(
+    unitId: UnitId,
+    fromDate: Date,
+  ): Promise<Reservation[]> {
+    const docs = await this.reservationModel.find({
+      unitId: new Types.ObjectId(unitId.toString()),
+      status: {
+        $nin: [ReservationStatusEnum.CANCELLED, ReservationStatusEnum.NO_SHOW],
+      },
+      checkOut: { $gt: fromDate },
+    });
+
+    return docs.map((d) => this.toDomain(d));
+  }
+
   async findByExternalId(
     source: ReservationSourceEnum,
     externalId: string,

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -1,5 +1,7 @@
 import { CreateUnitCommand } from '@/application/unit/commands/create-unit.command';
 import { CreateUnitResult } from '@/application/unit/commands/create-unit.result';
+import { UpdateUnitCommand } from '@/application/unit/commands/update-unit.command';
+import { UpdateUnitResult } from '@/application/unit/commands/update-unit.result';
 import { GetUnitsByPropertyQuery } from '@/application/unit/queries/GetUnitsByProperty/get-units-by-property.query';
 import { GetUnitsByPropertyResult } from '@/application/unit/queries/GetUnitsByProperty/get-units-by-property.result';
 import { GetPublicUnitsByTenantQuery } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query';
@@ -9,15 +11,22 @@ import { GetPublicUnitByIdResult } from '@/application/unit/queries/GetPublicUni
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
 import { Public } from '@/infrastructure/auth/decorators/public.decorator';
+import { RequirePermission } from '@/infrastructure/auth/decorators/require-permission.decorator';
+import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
+import { Permission } from '@/domain/role/value-objects/permission.vo';
 import {
   Body,
   Controller,
   DefaultValuePipe,
   Get,
+  HttpCode,
+  HttpStatus,
+  Patch,
   Param,
   ParseIntPipe,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
@@ -28,6 +37,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { CreateUnitDto } from '@/presentation/dtos/create-unit.dto';
+import { UpdateUnitDto } from '@/presentation/dtos/update-unit.dto';
 
 @ApiTags('units')
 @ApiBearerAuth('JWT-auth')
@@ -72,6 +82,53 @@ export class UnitController {
 
     return {
       message: 'Unit created successfully',
+      data: {
+        unitId: result.unitId,
+      },
+    };
+  }
+
+  @Patch(':unitId')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_EDIT)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update an existing unit' })
+  @ApiResponse({ status: 200, description: 'Unit updated successfully' })
+  @ApiResponse({ status: 404, description: 'Unit not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Inventory change conflicts with active reservations',
+  })
+  async update(
+    @CurrentUser() user: JwtPayload,
+    @Param('unitId') unitId: string,
+    @Body() dto: UpdateUnitDto,
+  ) {
+    const command = new UpdateUnitCommand(
+      user.tenantId,
+      unitId,
+      dto.name,
+      dto.description,
+      dto.inventoryCount,
+      dto.maxGuests,
+      dto.standardGuests,
+      dto.bedrooms,
+      dto.bathroomsCount,
+      dto.isShared,
+      dto.amenities,
+      dto.pricePerNight,
+      dto.externalIds,
+      user.userId,
+      user.email,
+    );
+
+    const result = await this.commandBus.execute<
+      UpdateUnitCommand,
+      UpdateUnitResult
+    >(command);
+
+    return {
+      message: 'Unit updated successfully',
       data: {
         unitId: result.unitId,
       },

--- a/src/presentation/dtos/update-unit.dto.ts
+++ b/src/presentation/dtos/update-unit.dto.ts
@@ -1,0 +1,177 @@
+import {
+  IsString,
+  IsNumber,
+  Min,
+  IsBoolean,
+  IsArray,
+  ValidateNested,
+  IsEnum,
+  IsOptional,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { BedTypeEnum } from '@/domain/unit/value-objects/bed-type.vo';
+
+class UpdateBedDto {
+  @ApiPropertyOptional({
+    enum: BedTypeEnum,
+    example: BedTypeEnum.QUEEN,
+    description: 'Type of bed',
+  })
+  @IsEnum(BedTypeEnum)
+  type: BedTypeEnum;
+
+  @ApiPropertyOptional({
+    example: 2,
+    description: 'Number of beds of this type',
+    minimum: 1,
+  })
+  @IsNumber()
+  @Min(1)
+  count: number;
+}
+
+class UpdateBedroomDto {
+  @ApiPropertyOptional({
+    example: 'Master Bedroom',
+    description: 'Name of the bedroom',
+  })
+  @IsString()
+  roomName: string;
+
+  @ApiPropertyOptional({
+    type: [UpdateBedDto],
+    description: 'List of beds in this bedroom',
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpdateBedDto)
+  beds: UpdateBedDto[];
+}
+
+class UpdateExternalIdsDto {
+  @ApiPropertyOptional({
+    example: 'airbnb123456',
+    description: 'Airbnb listing ID',
+  })
+  @IsString()
+  @IsOptional()
+  airbnbId?: string;
+
+  @ApiPropertyOptional({
+    example: 'booking789012',
+    description: 'Booking.com listing ID',
+  })
+  @IsString()
+  @IsOptional()
+  bookingId?: string;
+
+  @ApiPropertyOptional({
+    example: 'vrbo345678',
+    description: 'VRBO listing ID',
+  })
+  @IsString()
+  @IsOptional()
+  vrboId?: string;
+}
+
+export class UpdateUnitDto {
+  @ApiPropertyOptional({ example: 'Deluxe Ocean View Suite' })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiPropertyOptional({
+    example: 'Spacious suite with private balcony and ocean views',
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: 'Number of identical units available',
+    minimum: 1,
+  })
+  @IsNumber()
+  @Min(1)
+  @IsOptional()
+  inventoryCount?: number;
+
+  @ApiPropertyOptional({
+    example: 4,
+    description: 'Maximum number of guests allowed',
+    minimum: 1,
+  })
+  @IsNumber()
+  @Min(1)
+  @IsOptional()
+  maxGuests?: number;
+
+  @ApiPropertyOptional({
+    example: 2,
+    description: 'Standard number of guests (base rate)',
+    minimum: 1,
+  })
+  @IsNumber()
+  @Min(1)
+  @IsOptional()
+  standardGuests?: number;
+
+  @ApiPropertyOptional({
+    type: [UpdateBedroomDto],
+    description: 'List of bedrooms with bed configuration',
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpdateBedroomDto)
+  @IsOptional()
+  bedrooms?: UpdateBedroomDto[];
+
+  @ApiPropertyOptional({
+    example: 2,
+    description: 'Number of bathrooms',
+    minimum: 0,
+  })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  bathroomsCount?: number;
+
+  @ApiPropertyOptional({
+    example: false,
+    description: 'Whether the unit is a shared space',
+  })
+  @IsBoolean()
+  @IsOptional()
+  isShared?: boolean;
+
+  @ApiPropertyOptional({
+    example: ['WiFi', 'Air Conditioning', 'TV', 'Mini Bar'],
+    description: 'List of amenities',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  amenities?: string[];
+
+  @ApiPropertyOptional({
+    example: 150.0,
+    description: 'Price per night in USD',
+    minimum: 0,
+  })
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  pricePerNight?: number;
+
+  @ApiPropertyOptional({
+    type: UpdateExternalIdsDto,
+    description: 'External OTA listing IDs',
+  })
+  @ValidateNested()
+  @Type(() => UpdateExternalIdsDto)
+  @IsOptional()
+  externalIds?: UpdateExternalIdsDto;
+}

--- a/test/application/unit/update-unit.handler.spec.ts
+++ b/test/application/unit/update-unit.handler.spec.ts
@@ -1,0 +1,194 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { UpdateUnitHandler } from '@/application/unit/commands/update-unit.handler';
+import { UpdateUnitCommand } from '@/application/unit/commands/update-unit.command';
+import { UpdateUnitResult } from '@/application/unit/commands/update-unit.result';
+import { Unit } from '@/domain/unit/entities/unit.entity';
+import { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import { ReservationRepository } from '@/domain/reservation/repositories/reservation.repository';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
+import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
+import { createReservationRepositoryMock } from '@test/shared/mocks/repositories/reservation-repository.mock';
+import { createEventEmitterMock } from '@test/shared/mocks/services/event-emitter.mock';
+import { makeReservation } from '@test/shared/fixtures/reservation.fixture';
+
+const UNIT_ID = '65f1a1a2b3c4d5e6f7a8b9c4';
+const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c2';
+const PROPERTY_ID = '65f1a1a2b3c4d5e6f7a8b9c3';
+
+function makeUnit(
+  overrides?: Partial<{ tenantId: string; inventoryCount: number }>,
+): Unit {
+  return Unit.reconstitute(
+    UnitId.create(UNIT_ID),
+    TenantId.createFromString(overrides?.tenantId ?? TENANT_ID),
+    PropertyId.create(PROPERTY_ID),
+    'Deluxe Suite',
+    'Ocean view suite',
+    overrides?.inventoryCount ?? 3,
+    4,
+    2,
+    [{ roomName: 'Master', beds: [{ type: 'QUEEN', count: 1 }] }],
+    1,
+    false,
+    ['wifi'],
+    200,
+    ExternalIds.create('airbnb-1', undefined, undefined),
+    new Date('2030-01-01T00:00:00.000Z'),
+    new Date('2030-01-01T00:00:00.000Z'),
+  );
+}
+
+function makeCommand(
+  overrides?: Partial<{
+    tenantId: string;
+    unitId: string;
+    name: string | undefined;
+    inventoryCount: number | undefined;
+    maxGuests: number | undefined;
+    standardGuests: number | undefined;
+  }>,
+): UpdateUnitCommand {
+  return new UpdateUnitCommand(
+    overrides?.tenantId ?? TENANT_ID,
+    overrides?.unitId ?? UNIT_ID,
+    overrides?.name,
+    undefined,
+    overrides?.inventoryCount,
+    overrides?.maxGuests,
+    overrides?.standardGuests,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'user-1',
+    'owner@example.com',
+  );
+}
+
+describe('UpdateUnitHandler', () => {
+  let handler: UpdateUnitHandler;
+  let unitRepository: jest.Mocked<UnitRepository>;
+  let reservationRepository: jest.Mocked<ReservationRepository>;
+  let eventEmitter: ReturnType<typeof createEventEmitterMock>;
+
+  beforeEach(() => {
+    unitRepository = createUnitRepositoryMock();
+    reservationRepository = createReservationRepositoryMock();
+    eventEmitter = createEventEmitterMock();
+
+    handler = new UpdateUnitHandler(
+      unitRepository,
+      reservationRepository,
+      eventEmitter as any,
+    );
+  });
+
+  it('throws BadRequestException when no field is provided', async () => {
+    unitRepository.findById.mockResolvedValue(makeUnit());
+
+    await expect(
+      handler.execute(
+        new UpdateUnitCommand(
+          TENANT_ID,
+          UNIT_ID,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'user-1',
+          'owner@example.com',
+        ),
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws NotFoundException when unit does not exist', async () => {
+    unitRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(makeCommand({ name: 'Updated Name' })),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws NotFoundException when unit belongs to a different tenant', async () => {
+    unitRepository.findById.mockResolvedValue(
+      makeUnit({ tenantId: 'other-tenant-id' }),
+    );
+
+    await expect(
+      handler.execute(makeCommand({ name: 'Updated Name' })),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws ConflictException when reducing inventory below active overlap peak', async () => {
+    unitRepository.findById.mockResolvedValue(makeUnit({ inventoryCount: 3 }));
+    reservationRepository.findActiveByUnitFromDate.mockResolvedValue([
+      makeReservation({
+        unitId: UNIT_ID,
+        tenantId: TENANT_ID,
+        propertyId: PROPERTY_ID,
+        checkIn: new Date('2030-01-01T14:00:00Z'),
+        checkOut: new Date('2030-01-05T10:00:00Z'),
+      }),
+      makeReservation({
+        id: '65f1a1a2b3c4d5e6f7a8b9d9',
+        unitId: UNIT_ID,
+        tenantId: TENANT_ID,
+        propertyId: PROPERTY_ID,
+        checkIn: new Date('2030-01-03T14:00:00Z'),
+        checkOut: new Date('2030-01-07T10:00:00Z'),
+      }),
+    ]);
+
+    await expect(
+      handler.execute(makeCommand({ inventoryCount: 1 })),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('updates unit, persists changes, and emits audit event', async () => {
+    unitRepository.findById.mockResolvedValue(makeUnit({ inventoryCount: 3 }));
+    reservationRepository.findActiveByUnitFromDate.mockResolvedValue([
+      makeReservation({
+        unitId: UNIT_ID,
+        tenantId: TENANT_ID,
+        propertyId: PROPERTY_ID,
+        checkIn: new Date('2030-01-01T14:00:00Z'),
+        checkOut: new Date('2030-01-02T10:00:00Z'),
+      }),
+    ]);
+    unitRepository.save.mockResolvedValue(UNIT_ID);
+
+    const result = await handler.execute(
+      makeCommand({
+        name: 'Renamed Suite',
+        inventoryCount: 2,
+        maxGuests: 5,
+        standardGuests: 3,
+      }),
+    );
+
+    expect(result).toBeInstanceOf(UpdateUnitResult);
+    expect(result.unitId).toBe(UNIT_ID);
+    expect(unitRepository.save).toHaveBeenCalledTimes(1);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ entityType: 'UNIT' }),
+    );
+  });
+});

--- a/test/shared/mocks/repositories/reservation-repository.mock.ts
+++ b/test/shared/mocks/repositories/reservation-repository.mock.ts
@@ -9,6 +9,7 @@ export function createReservationRepositoryMock(): jest.Mocked<ReservationReposi
     findByUnitId: jest.fn(),
     findByGuestId: jest.fn(),
     findByUnitAndDateRange: jest.fn(),
+    findActiveByUnitFromDate: jest.fn(),
     findByExternalId: jest.fn(),
     countByTenantId: jest.fn(),
     findConfirmedDueForCheckIn: jest.fn(),


### PR DESCRIPTION
Introduces the ability to update units, including robust validation for reducing the `inventoryCount` to prevent overbooking when active reservations exist. It adds a new `UpdateUnit` command and handler, enforces business rules through a domain service, and exposes the update functionality via a new API endpoint. The most notable change is the implementation of a sweep-line algorithm to ensure that `inventoryCount` cannot be set below the peak of concurrent active reservations, maintaining business correctness and preventing overbooking.

**Unit update capability and business rule enforcement:**

* Added `UpdateUnitCommand`, `UpdateUnitHandler`, and `UpdateUnitResult` to support updating unit details, including inventory count, capacity, amenities, and external IDs. The handler ensures at least one field is provided for update and emits audit events on changes. (`src/application/unit/commands/update-unit.command.ts`, `src/application/unit/commands/update-unit.handler.ts`, `src/application/unit/commands/update-unit.result.ts`, `src/application/unit/unit-application.module.ts`) [[1]](diffhunk://#diff-5dce5224e70c38ba02e9e6b9d632fef532e326c88d8a127c597acd1bfe1b9ebcR1-R30) [[2]](diffhunk://#diff-1e7f003477de22dd2a2a0e57e556deebf6ed4b4b35fc408e9cdd97f0b34e7a3aR1-R203) [[3]](diffhunk://#diff-fdcd232043f9b9be621ea3b8775433e3c545d2c4b75712933dfd262e040cfde7R1-R3) [[4]](diffhunk://#diff-0b0ca1088d017b4184e365328f69ddccdfcfb783d47d0c2d6ac68ba2cc9f985aR4-R10)

* Implemented business validation to prevent reducing `inventoryCount` below the peak of concurrent active reservations using a sweep-line algorithm in `InventoryCountValidator.getMinimumRequiredInventory`. This ensures no overbooking occurs when updating inventory. (`src/domain/reservation/services/inventory-count-validator.domain-service.ts`, `docs/adr/012-unit-inventory-count-validation.md`) [[1]](diffhunk://#diff-c6cf5cdc66dba93d774ade06b49d23a295fd1d9a26231a1160a32ce7721268dfR1-R48) [[2]](diffhunk://#diff-733b23cfc627d5b37b2489cb0dd4272795b46c826f71ca5f3ad2eac663a7818cR1-R96)

**Repository and domain enhancements:**

* Extended `ReservationRepository` with `findActiveByUnitFromDate` and implemented it in `MongoReservationRepository` to efficiently retrieve active reservations for validation. (`src/domain/reservation/repositories/reservation.repository.ts`, `src/infrastructure/persistence/repositories/mongo-reservation.repository.ts`) [[1]](diffhunk://#diff-568619e91d06e4a203cd7c76ba2016777a22a65302ae76353580ad137b31ca6cR40-R43) [[2]](diffhunk://#diff-a45f34da4014261f5f6de3b8104e226d83dfe93170f37693eccf54de3f4fdd40R162-R176)

* Added update methods to the `Unit` entity for inventory count, bedrooms, bathrooms, and shared status, enforcing domain invariants (e.g., non-negative values). (`src/domain/unit/entities/unit.entity.ts`)

**API and presentation layer:**

* Exposed the update unit functionality via a new `PATCH /units/:unitId` endpoint, protected by permissions and documented with Swagger. The endpoint uses the new command and DTO, returning appropriate responses for success and business rule violations. (`src/presentation/controllers/unit.controller.ts`) [[1]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR3-R4) [[2]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR14-R29) [[3]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR40) [[4]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR91-R137)

**Documentation:**

* Added ADR-012 to document the business rule and algorithm for inventory count validation, providing context, rationale, and implementation details. (`docs/adr/012-unit-inventory-count-validation.md`)