### PR TITLE
LYMON-40-Eliminar-unidad

### DIFF
--- a/src/application/unit/commands/delete-unit.command.ts
+++ b/src/application/unit/commands/delete-unit.command.ts
@@ -1,0 +1,8 @@
+export class DeleteUnitCommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly unitId: string,
+    public readonly actorId?: string,
+    public readonly actorEmail?: string,
+  ) {}
+}

--- a/src/application/unit/commands/delete-unit.handler.ts
+++ b/src/application/unit/commands/delete-unit.handler.ts
@@ -1,0 +1,75 @@
+import { ForbiddenException, Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DeleteUnitCommand } from './delete-unit.command';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import {
+  UNIT_REPOSITORY,
+  type UnitRepository,
+} from '@/domain/unit/repositories/unit.repository';
+import {
+  RESERVATION_REPOSITORY,
+  type ReservationRepository,
+} from '@/domain/reservation/repositories/reservation.repository';
+import {
+  AUDIT_LOG_EVENT,
+  AuditLoggedEvent,
+} from '@/infrastructure/audit/events/audit-logged.event';
+import {
+  AuditAction,
+  AuditEntityType,
+} from '@/domain/audit/value-objects/audit-action.vo';
+
+@CommandHandler(DeleteUnitCommand)
+export class DeleteUnitHandler implements ICommandHandler<
+  DeleteUnitCommand,
+  void
+> {
+  constructor(
+    @Inject(UNIT_REPOSITORY)
+    private readonly unitRepository: UnitRepository,
+    @Inject(RESERVATION_REPOSITORY)
+    private readonly reservationRepository: ReservationRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(command: DeleteUnitCommand): Promise<void> {
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const unitId = UnitId.create(command.unitId);
+
+    const unit = await this.unitRepository.findById(unitId);
+
+    if (!unit || !unit.getTenantId().equals(tenantId)) {
+      throw new NotFoundException('Unit not found');
+    }
+
+    const hasActiveReservations =
+      await this.reservationRepository.existsActiveByUnitId(
+        command.tenantId,
+        command.unitId,
+      );
+
+    if (hasActiveReservations) {
+      throw new ForbiddenException(
+        'Unit cannot be deleted because it has active reservations',
+      );
+    }
+
+    await this.unitRepository.delete(unitId);
+
+    if (command.actorId && command.actorEmail) {
+      this.eventEmitter.emit(
+        AUDIT_LOG_EVENT,
+        new AuditLoggedEvent(
+          command.tenantId,
+          command.actorId,
+          command.actorEmail,
+          AuditAction.UNIT_DELETED,
+          AuditEntityType.UNIT,
+          command.unitId,
+        ),
+      );
+    }
+  }
+}

--- a/src/application/unit/unit-application.module.ts
+++ b/src/application/unit/unit-application.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { CreateUnitHandler } from '@/application/unit/commands/create-unit.handler';
+import { DeleteUnitHandler } from '@/application/unit/commands/delete-unit.handler';
 import { GetUnitsByPropertyQueryHandler } from '@/application/unit/queries/GetUnitsByProperty/get-units-by-property.query-handler';
 import { GetPublicUnitsByTenantQueryHandler } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler';
 import { GetPublicUnitByIdQueryHandler } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query-handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 
-const CommandHandlers = [CreateUnitHandler];
+const CommandHandlers = [CreateUnitHandler, DeleteUnitHandler];
 const QueryHandlers = [
   GetUnitsByPropertyQueryHandler,
   GetPublicUnitsByTenantQueryHandler,

--- a/src/domain/reservation/repositories/reservation.repository.ts
+++ b/src/domain/reservation/repositories/reservation.repository.ts
@@ -41,6 +41,11 @@ export interface ReservationRepository {
     source: ReservationSourceEnum,
     externalId: string,
   ): Promise<Reservation | null>;
+  existsActiveByPropertyId(
+    tenantId: string,
+    propertyId: string,
+  ): Promise<boolean>;
+  existsActiveByUnitId(tenantId: string, unitId: string): Promise<boolean>;
   countByTenantId(tenantId: string): Promise<number>;
   findConfirmedDueForCheckIn(date: Date): Promise<Reservation[]>;
 }

--- a/src/domain/unit/entities/unit.entity.ts
+++ b/src/domain/unit/entities/unit.entity.ts
@@ -22,6 +22,7 @@ export class Unit {
     private externalIds: ExternalIds,
     private readonly createdAt: Date,
     private updatedAt: Date,
+    private deletedAt: Date | null,
   ) {}
 
   static create(
@@ -76,6 +77,7 @@ export class Unit {
       externalIds,
       new Date(),
       new Date(),
+      null,
     );
   }
 
@@ -96,6 +98,7 @@ export class Unit {
     externalIds: ExternalIds,
     createdAt: Date,
     updatedAt: Date,
+    deletedAt: Date | null,
   ): Unit {
     return new Unit(
       id,
@@ -114,6 +117,7 @@ export class Unit {
       externalIds,
       createdAt,
       updatedAt,
+      deletedAt,
     );
   }
 
@@ -179,6 +183,10 @@ export class Unit {
 
   getUpdatedAt(): Date {
     return this.updatedAt;
+  }
+
+  getDeletedAt(): Date | null {
+    return this.deletedAt;
   }
 
   updateDetails(name: string, description: string): void {

--- a/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
@@ -18,6 +18,12 @@ import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
 import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
 import { TransactionContextData } from '@/domain/shared/transaction-manager.interface';
 
+const ACTIVE_RESERVATION_STATUSES = [
+  ReservationStatusEnum.PENDING,
+  ReservationStatusEnum.CONFIRMED,
+  ReservationStatusEnum.CHECKED_IN,
+];
+
 @Injectable()
 export class MongoReservationRepository implements ReservationRepository {
   constructor(
@@ -169,6 +175,32 @@ export class MongoReservationRepository implements ReservationRepository {
     });
     if (!doc) return null;
     return this.toDomain(doc);
+  }
+
+  async existsActiveByPropertyId(
+    tenantId: string,
+    propertyId: string,
+  ): Promise<boolean> {
+    const count = await this.reservationModel.countDocuments({
+      tenantId: new Types.ObjectId(tenantId),
+      propertyId: new Types.ObjectId(propertyId),
+      status: { $in: ACTIVE_RESERVATION_STATUSES },
+    });
+
+    return count > 0;
+  }
+
+  async existsActiveByUnitId(
+    tenantId: string,
+    unitId: string,
+  ): Promise<boolean> {
+    const count = await this.reservationModel.countDocuments({
+      tenantId: new Types.ObjectId(tenantId),
+      unitId: new Types.ObjectId(unitId),
+      status: { $in: ACTIVE_RESERVATION_STATUSES },
+    });
+
+    return count > 0;
   }
 
   async countByTenantId(tenantId: string): Promise<number> {

--- a/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
@@ -150,6 +150,7 @@ export class MongoUnitRepository implements UnitRepository {
       ),
       document.createdAt,
       document.updatedAt,
+      document.deletedAt,
     );
   }
 }

--- a/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
@@ -62,7 +62,10 @@ export class MongoUnitRepository implements UnitRepository {
   }
 
   async findById(id: UnitId): Promise<Unit | null> {
-    const document = await this.unitModel.findById(id.toString());
+    const document = await this.unitModel.findOne({
+      _id: id.toString(),
+      deletedAt: null,
+    });
     if (!document) return null;
 
     return this.toDomain(document);
@@ -70,7 +73,10 @@ export class MongoUnitRepository implements UnitRepository {
 
   async findByPropertyId(propertyId: PropertyId): Promise<Unit[]> {
     const documents = await this.unitModel
-      .find({ propertyId: new Types.ObjectId(propertyId.toString()) })
+      .find({
+        propertyId: new Types.ObjectId(propertyId.toString()),
+        deletedAt: null,
+      })
       .sort({ createdAt: -1 });
 
     return documents.map((doc) => this.toDomain(doc));
@@ -78,7 +84,10 @@ export class MongoUnitRepository implements UnitRepository {
 
   async findByTenantId(tenantId: TenantId): Promise<Unit[]> {
     const documents = await this.unitModel
-      .find({ tenantId: new Types.ObjectId(tenantId.toString()) })
+      .find({
+        tenantId: new Types.ObjectId(tenantId.toString()),
+        deletedAt: null,
+      })
       .sort({ createdAt: -1 });
 
     return documents.map((doc) => this.toDomain(doc));
@@ -89,7 +98,10 @@ export class MongoUnitRepository implements UnitRepository {
     page: number,
     limit: number,
   ): Promise<{ units: Unit[]; total: number }> {
-    const filter = { tenantId: new Types.ObjectId(tenantId.toString()) };
+    const filter = {
+      tenantId: new Types.ObjectId(tenantId.toString()),
+      deletedAt: null,
+    };
     const total = await this.unitModel.countDocuments(filter);
     const documents = await this.unitModel
       .find(filter)
@@ -105,11 +117,15 @@ export class MongoUnitRepository implements UnitRepository {
   async countByTenantId(tenantId: TenantId): Promise<number> {
     return this.unitModel.countDocuments({
       tenantId: new Types.ObjectId(tenantId.toString()),
+      deletedAt: null,
     });
   }
 
   async delete(id: UnitId): Promise<void> {
-    await this.unitModel.findByIdAndDelete(id.toString());
+    await this.unitModel.findByIdAndUpdate(id.toString(), {
+      deletedAt: new Date(),
+      updatedAt: new Date(),
+    });
   }
 
   private toDomain(document: UnitDocument): Unit {

--- a/src/infrastructure/persistence/schemas/unit.schema.ts
+++ b/src/infrastructure/persistence/schemas/unit.schema.ts
@@ -87,6 +87,9 @@ export class UnitDocument extends Document {
 
   @Prop()
   updatedAt: Date;
+
+  @Prop({ type: Date, default: null })
+  deletedAt: Date | null;
 }
 
 export const UnitSchema = SchemaFactory.createForClass(UnitDocument);

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -13,6 +13,7 @@ import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
 import { Public } from '@/infrastructure/auth/decorators/public.decorator';
 import { RequirePermission } from '@/infrastructure/auth/decorators/require-permission.decorator';
+import { JwtAuthGuard } from '@/infrastructure/auth/guards/jwt-auth.guard';
 import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
 import { Permission } from '@/domain/role/value-objects/permission.vo';
 import {
@@ -257,8 +258,11 @@ export class UnitController {
   }
 
   @Delete(':unitId')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.UNIT_DELETE)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a unit' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @ApiResponse({ status: 204, description: 'Unit deleted successfully' })
   @ApiResponse({ status: 404, description: 'Unit not found' })
   async deleteUnit(

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -1,5 +1,6 @@
 import { CreateUnitCommand } from '@/application/unit/commands/create-unit.command';
 import { CreateUnitResult } from '@/application/unit/commands/create-unit.result';
+import { DeleteUnitCommand } from '@/application/unit/commands/delete-unit.command';
 import { GetUnitsByPropertyQuery } from '@/application/unit/queries/GetUnitsByProperty/get-units-by-property.query';
 import { GetUnitsByPropertyResult } from '@/application/unit/queries/GetUnitsByProperty/get-units-by-property.result';
 import { GetPublicUnitsByTenantQuery } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query';
@@ -13,7 +14,10 @@ import {
   Body,
   Controller,
   DefaultValuePipe,
+  Delete,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   ParseIntPipe,
   Post,
@@ -195,5 +199,24 @@ export class UnitController {
         },
       },
     };
+  }
+
+  @Delete(':unitId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a unit' })
+  @ApiResponse({ status: 204, description: 'Unit deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Unit not found' })
+  async deleteUnit(
+    @CurrentUser() user: JwtPayload,
+    @Param('unitId') unitId: string,
+  ): Promise<void> {
+    const command = new DeleteUnitCommand(
+      user.tenantId,
+      unitId,
+      user.userId,
+      user.email,
+    );
+
+    await this.commandBus.execute<DeleteUnitCommand, void>(command);
   }
 }

--- a/test/application/guest/get-guest-bookings.handler.spec.ts
+++ b/test/application/guest/get-guest-bookings.handler.spec.ts
@@ -60,6 +60,7 @@ describe('GetGuestBookingsHandler', () => {
       ExternalIds.create(),
       new Date('2030-01-01T10:00:00Z'),
       new Date('2030-01-01T10:00:00Z'),
+      null,
     );
   }
 

--- a/test/application/reservation/create-reservation.handler.spec.ts
+++ b/test/application/reservation/create-reservation.handler.spec.ts
@@ -60,6 +60,7 @@ describe('CreateReservationHandler', () => {
       ExternalIds.create(),
       new Date(),
       new Date(),
+      null,
     );
   }
 

--- a/test/application/unit/delete-unit.handler.spec.ts
+++ b/test/application/unit/delete-unit.handler.spec.ts
@@ -34,6 +34,7 @@ function makeUnit(overrides?: Partial<{ tenantId: string; id: string }>): Unit {
     ExternalIds.create(),
     new Date(),
     new Date(),
+    null,
   );
 }
 

--- a/test/application/unit/delete-unit.handler.spec.ts
+++ b/test/application/unit/delete-unit.handler.spec.ts
@@ -1,0 +1,139 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DeleteUnitHandler } from '@/application/unit/commands/delete-unit.handler';
+import { DeleteUnitCommand } from '@/application/unit/commands/delete-unit.command';
+import { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
+import { ReservationRepository } from '@/domain/reservation/repositories/reservation.repository';
+import { createReservationRepositoryMock } from '@test/shared/mocks/repositories/reservation-repository.mock';
+import { Unit } from '@/domain/unit/entities/unit.entity';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
+
+const UNIT_ID = 'unit-123';
+const TENANT_ID = 'tenant-123';
+const PROPERTY_ID = 'property-123';
+
+function makeUnit(overrides?: Partial<{ tenantId: string; id: string }>): Unit {
+  return Unit.reconstitute(
+    UnitId.create(overrides?.id ?? UNIT_ID),
+    TenantId.createFromString(overrides?.tenantId ?? TENANT_ID),
+    PropertyId.create(PROPERTY_ID),
+    'Unit Name',
+    'Unit Description',
+    1,
+    4,
+    2,
+    [],
+    1,
+    false,
+    ['wifi'],
+    100,
+    ExternalIds.create(),
+    new Date(),
+    new Date(),
+  );
+}
+
+describe('DeleteUnitHandler', () => {
+  let handler: DeleteUnitHandler;
+  let unitRepository: jest.Mocked<UnitRepository>;
+  let reservationRepository: jest.Mocked<ReservationRepository>;
+  let eventEmitter: jest.Mocked<EventEmitter2>;
+
+  beforeEach(() => {
+    unitRepository = createUnitRepositoryMock();
+    reservationRepository = createReservationRepositoryMock();
+    reservationRepository.existsActiveByUnitId.mockResolvedValue(false);
+    eventEmitter = {
+      emit: jest.fn(),
+    } as unknown as jest.Mocked<EventEmitter2>;
+
+    handler = new DeleteUnitHandler(
+      unitRepository,
+      reservationRepository,
+      eventEmitter,
+    );
+  });
+
+  describe('when unit does not exist', () => {
+    it('throws NotFoundException', async () => {
+      unitRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        handler.execute(new DeleteUnitCommand(TENANT_ID, UNIT_ID)),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(reservationRepository.existsActiveByUnitId).not.toHaveBeenCalled();
+      expect(unitRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when unit belongs to another tenant', () => {
+    it('throws NotFoundException', async () => {
+      unitRepository.findById.mockResolvedValue(
+        makeUnit({ tenantId: 'other-tenant' }),
+      );
+
+      await expect(
+        handler.execute(new DeleteUnitCommand(TENANT_ID, UNIT_ID)),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(reservationRepository.existsActiveByUnitId).not.toHaveBeenCalled();
+      expect(unitRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when unit has active reservations', () => {
+    it('throws ForbiddenException', async () => {
+      unitRepository.findById.mockResolvedValue(makeUnit());
+      reservationRepository.existsActiveByUnitId.mockResolvedValue(true);
+
+      await expect(
+        handler.execute(new DeleteUnitCommand(TENANT_ID, UNIT_ID)),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(unitRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when unit exists and belongs to tenant', () => {
+    it('deletes unit successfully', async () => {
+      unitRepository.findById.mockResolvedValue(makeUnit());
+
+      await expect(
+        handler.execute(new DeleteUnitCommand(TENANT_ID, UNIT_ID)),
+      ).resolves.toBeUndefined();
+
+      expect(unitRepository.delete).toHaveBeenCalledTimes(1);
+      expect(unitRepository.delete).toHaveBeenCalledWith(
+        expect.objectContaining({}),
+      );
+    });
+
+    it('emits audit event when actor info is present', async () => {
+      unitRepository.findById.mockResolvedValue(makeUnit());
+
+      await handler.execute(
+        new DeleteUnitCommand(
+          TENANT_ID,
+          UNIT_ID,
+          'actor-1',
+          'actor@example.com',
+        ),
+      );
+
+      expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not emit audit event without actor info', async () => {
+      unitRepository.findById.mockResolvedValue(makeUnit());
+
+      await handler.execute(new DeleteUnitCommand(TENANT_ID, UNIT_ID));
+
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/application/unit/get-public-unit-by-id.spec.ts
+++ b/test/application/unit/get-public-unit-by-id.spec.ts
@@ -36,6 +36,7 @@ function makeUnit(overrides?: Partial<{ id: string }>): Unit {
     ExternalIds.create('ext-airbnb', 'ext-booking', 'ext-vrbo'),
     new Date(),
     new Date(),
+    null,
   );
 }
 

--- a/test/application/unit/update-unit.handler.spec.ts
+++ b/test/application/unit/update-unit.handler.spec.ts
@@ -13,6 +13,7 @@ import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
+import { BedTypeEnum } from '@/domain/unit/value-objects/bed-type.vo';
 import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
 import { createReservationRepositoryMock } from '@test/shared/mocks/repositories/reservation-repository.mock';
 import { createEventEmitterMock } from '@test/shared/mocks/services/event-emitter.mock';
@@ -34,7 +35,7 @@ function makeUnit(
     overrides?.inventoryCount ?? 3,
     4,
     2,
-    [{ roomName: 'Master', beds: [{ type: 'QUEEN', count: 1 }] }],
+    [{ roomName: 'Master', beds: [{ type: BedTypeEnum.QUEEN, count: 1 }] }],
     1,
     false,
     ['wifi'],
@@ -42,6 +43,7 @@ function makeUnit(
     ExternalIds.create('airbnb-1', undefined, undefined),
     new Date('2030-01-01T00:00:00.000Z'),
     new Date('2030-01-01T00:00:00.000Z'),
+    null,
   );
 }
 

--- a/test/infrastructure/persistence/repositories/mongo-unit.repository.spec.ts
+++ b/test/infrastructure/persistence/repositories/mongo-unit.repository.spec.ts
@@ -1,0 +1,107 @@
+import { Types } from 'mongoose';
+import { MongoUnitRepository } from '@/infrastructure/persistence/repositories/mongo-unit.repository';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+
+describe('MongoUnitRepository soft delete', () => {
+  const UNIT_ID = '65f0c8bf0d4f3a6f9b6a1201';
+  const PROPERTY_ID = '65f0c8bf0d4f3a6f9b6a1202';
+  const TENANT_ID = '65f0c8bf0d4f3a6f9b6a1203';
+
+  let repository: MongoUnitRepository;
+  let unitModel: {
+    findOne: jest.Mock;
+    find: jest.Mock;
+    countDocuments: jest.Mock;
+    findByIdAndUpdate: jest.Mock;
+    create: jest.Mock;
+  };
+
+  beforeEach(() => {
+    unitModel = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      countDocuments: jest.fn(),
+      findByIdAndUpdate: jest.fn(),
+      create: jest.fn(),
+    };
+
+    repository = new MongoUnitRepository(unitModel as any);
+  });
+
+  it('findById filters out soft-deleted units', async () => {
+    unitModel.findOne.mockResolvedValue(null);
+
+    await repository.findById(UnitId.create(UNIT_ID));
+
+    expect(unitModel.findOne).toHaveBeenCalledWith({
+      _id: UNIT_ID,
+      deletedAt: null,
+    });
+  });
+
+  it('findByPropertyId applies deletedAt filter', async () => {
+    const sort = jest.fn().mockResolvedValue([]);
+    unitModel.find.mockReturnValue({ sort });
+
+    await repository.findByPropertyId(PropertyId.create(PROPERTY_ID));
+
+    expect(unitModel.find).toHaveBeenCalledTimes(1);
+    const filter = unitModel.find.mock.calls[0][0];
+    expect(filter).toMatchObject({ deletedAt: null });
+    expect(filter.propertyId).toBeInstanceOf(Types.ObjectId);
+    expect(filter.propertyId.toString()).toBe(PROPERTY_ID);
+  });
+
+  it('findByTenantIdPaginated only counts and returns non-deleted units', async () => {
+    const limit = jest.fn().mockResolvedValue([]);
+    const skip = jest.fn().mockReturnValue({ limit });
+    const sort = jest.fn().mockReturnValue({ skip });
+
+    unitModel.countDocuments.mockResolvedValue(0);
+    unitModel.find.mockReturnValue({ sort });
+
+    await repository.findByTenantIdPaginated(
+      TenantId.createFromString(TENANT_ID),
+      2,
+      10,
+    );
+
+    const countFilter = unitModel.countDocuments.mock.calls[0][0];
+    const findFilter = unitModel.find.mock.calls[0][0];
+
+    expect(countFilter).toMatchObject({ deletedAt: null });
+    expect(findFilter).toMatchObject({ deletedAt: null });
+    expect(countFilter.tenantId).toBeInstanceOf(Types.ObjectId);
+    expect(countFilter.tenantId.toString()).toBe(TENANT_ID);
+    expect(skip).toHaveBeenCalledWith(10);
+    expect(limit).toHaveBeenCalledWith(10);
+  });
+
+  it('countByTenantId excludes soft-deleted units', async () => {
+    unitModel.countDocuments.mockResolvedValue(3);
+
+    await repository.countByTenantId(TenantId.createFromString(TENANT_ID));
+
+    const filter = unitModel.countDocuments.mock.calls[0][0];
+    expect(filter).toMatchObject({ deletedAt: null });
+    expect(filter.tenantId).toBeInstanceOf(Types.ObjectId);
+    expect(filter.tenantId.toString()).toBe(TENANT_ID);
+  });
+
+  it('delete performs soft delete by setting deletedAt and updatedAt', async () => {
+    unitModel.findByIdAndUpdate.mockResolvedValue(null);
+
+    await repository.delete(UnitId.create(UNIT_ID));
+
+    expect(unitModel.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    expect(unitModel.findByIdAndUpdate).toHaveBeenCalledWith(
+      UNIT_ID,
+      expect.objectContaining({
+        deletedAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      }),
+    );
+  });
+});

--- a/test/shared/mocks/repositories/reservation-repository.mock.ts
+++ b/test/shared/mocks/repositories/reservation-repository.mock.ts
@@ -10,6 +10,8 @@ export function createReservationRepositoryMock(): jest.Mocked<ReservationReposi
     findByGuestId: jest.fn(),
     findByUnitAndDateRange: jest.fn(),
     findByExternalId: jest.fn(),
+    existsActiveByPropertyId: jest.fn(),
+    existsActiveByUnitId: jest.fn(),
     countByTenantId: jest.fn(),
     findConfirmedDueForCheckIn: jest.fn(),
   };


### PR DESCRIPTION
This pull request introduces the ability to soft-delete units, ensuring units with active reservations cannot be deleted, and adds comprehensive backend support for this feature, including persistence, domain logic, API endpoint, and testing. The main changes are grouped below:

**Soft-delete logic and domain model updates:**

* Added a `deletedAt` property to the `Unit` entity and schema, updated constructors and factory methods, and exposed a getter for `deletedAt`. This enables soft deletion rather than hard deletion. [[1]](diffhunk://#diff-7349e222aface12aa0d4b84d5de4b7aad40fe90f0678bef9930ec10a7c38f326R25) [[2]](diffhunk://#diff-7349e222aface12aa0d4b84d5de4b7aad40fe90f0678bef9930ec10a7c38f326R80) [[3]](diffhunk://#diff-7349e222aface12aa0d4b84d5de4b7aad40fe90f0678bef9930ec10a7c38f326R101) [[4]](diffhunk://#diff-7349e222aface12aa0d4b84d5de4b7aad40fe90f0678bef9930ec10a7c38f326R120) [[5]](diffhunk://#diff-7349e222aface12aa0d4b84d5de4b7aad40fe90f0678bef9930ec10a7c38f326R188-R191) [[6]](diffhunk://#diff-6acfa8f3dbd5c45c8733f8b7864984391deb2ab73a8fa6c461f10b0dd8661d77R90-R92)
* Updated the `MongoUnitRepository` to filter out soft-deleted units in all relevant queries and to set `deletedAt`/`updatedAt` timestamps on delete instead of removing the document. [[1]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06L65-R90) [[2]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06L92-R104) [[3]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R120-R128) [[4]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R153)

**Delete unit command and handler:**

* Introduced `DeleteUnitCommand` and `DeleteUnitHandler` implementing soft-delete logic, enforcing that only units without active reservations and belonging to the tenant can be deleted. Emits an audit event if actor info is present. [[1]](diffhunk://#diff-5d46808bec75818634cabeb0cabf8428ed108ce2e37ebc60c43167a1c91acb84R1-R8) [[2]](diffhunk://#diff-bf25c3f0db72f487a9734465ee491f0b388ed41f27c9aff5ae8cfa67c9c9c3aaR1-R75)
* Registered the new handler in the application module.

**Reservation repository enhancements:**

* Added `existsActiveByUnitId` and `existsActiveByPropertyId` to the `ReservationRepository` interface and implemented these methods in the Mongo repository to check for active reservations. [[1]](diffhunk://#diff-568619e91d06e4a203cd7c76ba2016777a22a65302ae76353580ad137b31ca6cR48-R52) [[2]](diffhunk://#diff-a45f34da4014261f5f6de3b8104e226d83dfe93170f37693eccf54de3f4fdd40R21-R26) [[3]](diffhunk://#diff-a45f34da4014261f5f6de3b8104e226d83dfe93170f37693eccf54de3f4fdd40R195-R220)

**API and controller changes:**

* Exposed a new `DELETE /units/:unitId` endpoint in `UnitController`, secured with authentication and permission guards, invoking the new command. [[1]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR3) [[2]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR16-R23) [[3]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR259-R280)

**Testing:**

* Added comprehensive tests for the delete unit handler, covering all edge cases (unit not found, wrong tenant, active reservations, audit logging).
* Updated test utilities and specs to accommodate the new `deletedAt` field in `Unit`. [[1]](diffhunk://#diff-0a0226a6916f3151b2ba7fbdb418e31277db1b740c8c48c84ace83203559ad75R63) [[2]](diffhunk://#diff-1639a9d1e00457628a3dcbc05b3d79f3b468501c744ab99d37c3d228965f0c89R63) [[3]](diffhunk://#diff-f2c8cca6dee1adae95f2cb6737bc008be616ad0e2f3d02fd590be90bdb3fb76bR39) [[4]](diffhunk://#diff-60fa3b807f3e9be0d52b30d2dc4888e9696b7ddcd659a2061c89a19524bf3c11R16)