### PR TITLE
Lymon 444 be create public get endpoint to get all units

### DIFF
--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
@@ -1,0 +1,27 @@
+import { Inject } from '@nestjs/common';
+import { QueryHandler, IQueryHandler } from '@nestjs/cqrs';
+import { GetAllPublicUnitsQuery } from './get-all-public-units.query';
+import { GetAllPublicUnitsResult } from './get-all-public-units.result';
+import { UNIT_REPOSITORY } from '@/domain/unit/repositories/unit.repository';
+import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import { mapUnitToPublicDto } from '@/application/reservation/queries/shared/unit.mapper';
+
+@QueryHandler(GetAllPublicUnitsQuery)
+export class GetAllPublicUnitsQueryHandler
+  implements IQueryHandler<GetAllPublicUnitsQuery, GetAllPublicUnitsResult>
+{
+  constructor(
+    @Inject(UNIT_REPOSITORY)
+    private readonly unitRepository: UnitRepository,
+  ) {}
+
+  async execute(query: GetAllPublicUnitsQuery): Promise<GetAllPublicUnitsResult> {
+    const { units, total } = await this.unitRepository.findAllPaginated(
+      query.page,
+      query.limit,
+    );
+    const dtos = units.map(mapUnitToPublicDto);
+
+    return new GetAllPublicUnitsResult(dtos, total, query.page, query.limit);
+  }
+}

--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query.ts
@@ -1,0 +1,8 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class GetAllPublicUnitsQuery implements IQuery {
+  constructor(
+    public readonly page: number = 1,
+    public readonly limit: number = 10,
+  ) {}
+}

--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.result.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.result.ts
@@ -1,0 +1,16 @@
+import {
+  PublicUnitDto,
+} from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.result';
+
+export class GetAllPublicUnitsResult {
+  constructor(
+    public readonly units: PublicUnitDto[],
+    public readonly total: number,
+    public readonly page: number,
+    public readonly limit: number,
+  ) {}
+
+  get totalPages(): number {
+    return Math.ceil(this.total / this.limit);
+  }
+}

--- a/src/application/unit/unit-application.module.ts
+++ b/src/application/unit/unit-application.module.ts
@@ -6,6 +6,7 @@ import { UpdateUnitHandler } from '@/application/unit/commands/update-unit.handl
 import { GetUnitsByPropertyQueryHandler } from '@/application/unit/queries/GetUnitsByProperty/get-units-by-property.query-handler';
 import { GetPublicUnitsByTenantQueryHandler } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler';
 import { GetPublicUnitByIdQueryHandler } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query-handler';
+import { GetAllPublicUnitsQueryHandler } from '@/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 
 const CommandHandlers = [
@@ -17,6 +18,7 @@ const QueryHandlers = [
   GetUnitsByPropertyQueryHandler,
   GetPublicUnitsByTenantQueryHandler,
   GetPublicUnitByIdQueryHandler,
+  GetAllPublicUnitsQueryHandler,
 ];
 
 @Module({

--- a/src/domain/unit/repositories/unit.repository.ts
+++ b/src/domain/unit/repositories/unit.repository.ts
@@ -21,4 +21,8 @@ export interface UnitRepository {
     page: number,
     limit: number,
   ): Promise<{ units: Unit[]; total: number }>;
+  findAllPaginated(
+    page: number,
+    limit: number,
+  ): Promise<{ units: Unit[]; total: number }>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
@@ -114,6 +114,23 @@ export class MongoUnitRepository implements UnitRepository {
     };
   }
 
+  async findAllPaginated(
+    page: number,
+    limit: number,
+  ): Promise<{ units: Unit[]; total: number }> {
+    const filter = { deletedAt: null };
+    const total = await this.unitModel.countDocuments(filter);
+    const documents = await this.unitModel
+      .find(filter)
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit);
+    return {
+      units: documents.map((doc) => this.toDomain(doc)),
+      total,
+    };
+  }
+
   async countByTenantId(tenantId: TenantId): Promise<number> {
     return this.unitModel.countDocuments({
       tenantId: new Types.ObjectId(tenantId.toString()),

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -7,6 +7,8 @@ import { GetUnitsByPropertyQuery } from '@/application/unit/queries/GetUnitsByPr
 import { GetUnitsByPropertyResult } from '@/application/unit/queries/GetUnitsByProperty/get-units-by-property.result';
 import { GetPublicUnitsByTenantQuery } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query';
 import { GetPublicUnitsByTenantResult } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.result';
+import { GetAllPublicUnitsQuery } from '@/application/unit/queries/GetAllPublicUnits/get-all-public-units.query';
+import { GetAllPublicUnitsResult } from '@/application/unit/queries/GetAllPublicUnits/get-all-public-units.result';
 import { GetPublicUnitByIdQuery } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query';
 import { GetPublicUnitByIdResult } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.result';
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
@@ -134,6 +136,49 @@ export class UnitController {
       message: 'Unit updated successfully',
       data: {
         unitId: result.unitId,
+      },
+    };
+  }
+
+  @Public()
+  @Get('public/all')
+  @ApiOperation({
+    summary: 'Get all public units (no authentication required)',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number for pagination',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page (default: 10)',
+  })
+  @ApiResponse({ status: 200, description: 'Units retrieved successfully' })
+  async getAllPublic(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    const query = new GetAllPublicUnitsQuery(page, limit);
+
+    const result = await this.queryBus.execute<
+      GetAllPublicUnitsQuery,
+      GetAllPublicUnitsResult
+    >(query);
+
+    return {
+      message: 'Units retrieved successfully',
+      data: {
+        units: result.units,
+        pagination: {
+          total: result.total,
+          page: result.page,
+          limit: result.limit,
+          totalPages: result.totalPages,
+        },
       },
     };
   }

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -141,7 +141,7 @@ export class UnitController {
   }
 
   @Public()
-  @Get('public/all')
+  @Get('public')
   @ApiOperation({
     summary: 'Get all public units (no authentication required)',
   })


### PR DESCRIPTION
## Summary
  - Added a new public endpoint `GET /units/public` that returns all units
  across tenants with pagination support
  - Follows the same response shape as the existing `GET /units/public/:tenantId`
  endpoint
  - No authentication required

  ## Changes by layer
  - **Domain**: added `findAllPaginated(page, limit)` to `UnitRepository` interface
  - **Infrastructure**: implemented `findAllPaginated` in `MongoUnitRepository`
  (filters soft-deleted records)
  - **Application**: created `GetAllPublicUnits` query, result, and handler;
  registered in `UnitApplicationModule`
  - **Presentation**: added `GET public/all` endpoint in `UnitController`, declared
  before `public/:tenantId` to prevent route shadowing