### PR TITLE
Lymon 448 make an endpoint inside guest reservations that retrieves reservations by a guest

### DIFF
--- a/src/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.query-handler.ts
+++ b/src/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.query-handler.ts
@@ -1,0 +1,55 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetReservationsByGuestIdQuery } from './get-reservations-by-guest-id.query';
+import { GetReservationsByGuestIdResult } from './get-reservations-by-guest-id.result';
+import { toReservationDto } from '../shared/reservation.mapper';
+import {
+  RESERVATION_REPOSITORY,
+  type ReservationRepository,
+} from '@/domain/reservation/repositories/reservation.repository';
+import {
+  GUEST_REPOSITORY,
+  type GuestRepository,
+} from '@/domain/guest/repositories/guest.repository';
+import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
+
+@QueryHandler(GetReservationsByGuestIdQuery)
+export class GetReservationsByGuestIdHandler implements IQueryHandler<
+  GetReservationsByGuestIdQuery,
+  GetReservationsByGuestIdResult
+> {
+  constructor(
+    @Inject(RESERVATION_REPOSITORY)
+    private readonly reservationRepository: ReservationRepository,
+    @Inject(GUEST_REPOSITORY)
+    private readonly guestRepository: GuestRepository,
+  ) {}
+
+  async execute(
+    query: GetReservationsByGuestIdQuery,
+  ): Promise<GetReservationsByGuestIdResult> {
+    const guestAccountId = GuestAccountId.createFromString(query.guestAccountId);
+
+    const guestProfiles = await this.guestRepository.findAllByGuestAccountId(guestAccountId);
+
+    const guestIds = guestProfiles
+      .map((g) => g.getId()?.toString())
+      .filter((id): id is string => !!id);
+
+    if (guestIds.length === 0) {
+      return new GetReservationsByGuestIdResult([], 0, query.page, query.limit);
+    }
+
+    const [reservations, total] = await Promise.all([
+      this.reservationRepository.findByGuestIds(guestIds, query.page, query.limit),
+      this.reservationRepository.countByGuestIds(guestIds),
+    ]);
+
+    return new GetReservationsByGuestIdResult(
+      reservations.map(toReservationDto),
+      total,
+      query.page,
+      query.limit,
+    );
+  }
+}

--- a/src/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.query.ts
+++ b/src/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.query.ts
@@ -1,0 +1,7 @@
+export class GetReservationsByGuestIdQuery {
+  constructor(
+    public readonly guestAccountId: string,
+    public readonly page: number,
+    public readonly limit: number,
+  ) {}
+}

--- a/src/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.result.ts
+++ b/src/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.result.ts
@@ -1,0 +1,10 @@
+import { ReservationDto } from '../shared/reservation.dto';
+
+export class GetReservationsByGuestIdResult {
+  constructor(
+    public readonly items: ReservationDto[],
+    public readonly total: number,
+    public readonly page: number,
+    public readonly limit: number,
+  ) {}
+}

--- a/src/application/reservation/reservation-application.module.ts
+++ b/src/application/reservation/reservation-application.module.ts
@@ -13,6 +13,7 @@ import { GetReservationByIdHandler } from '@/application/reservation/queries/get
 import { GetReservationsByTenantHandler } from '@/application/reservation/queries/get-reservations-by-tenant/get-reservations-by-tenant.query-handler';
 import { GetReservationsByUnitHandler } from '@/application/reservation/queries/get-reservations-by-unit/get-reservations-by-unit.query-handler';
 import { GetGuestReservationHandler } from '@/application/reservation/queries/get-guest-reservation/get-guest-reservation.query-handler';
+import { GetReservationsByGuestIdHandler } from '@/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.query-handler';
 
 const CommandHandlers = [
   CreateReservationHandler,
@@ -30,6 +31,7 @@ const QueryHandlers = [
   GetReservationsByTenantHandler,
   GetReservationsByUnitHandler,
   GetGuestReservationHandler,
+  GetReservationsByGuestIdHandler,
 ];
 
 @Module({

--- a/src/domain/guest/repositories/guest.repository.ts
+++ b/src/domain/guest/repositories/guest.repository.ts
@@ -21,6 +21,7 @@ export interface GuestRepository {
     tenantId: TenantId,
     guestAccountId: GuestAccountId,
   ): Promise<Guest | null>;
+  findAllByGuestAccountId(guestAccountId: GuestAccountId): Promise<Guest[]>;
   countByTenantId(tenantId: TenantId): Promise<number>;
   delete(id: GuestId): Promise<void>;
   search(tenantId: TenantId, term: string): Promise<Guest[]>;

--- a/src/domain/reservation/repositories/reservation.repository.ts
+++ b/src/domain/reservation/repositories/reservation.repository.ts
@@ -51,6 +51,11 @@ export interface ReservationRepository {
   ): Promise<boolean>;
   existsActiveByUnitId(tenantId: string, unitId: string): Promise<boolean>;
   countByTenantId(tenantId: string): Promise<number>;
+  countByGuestId(tenantId: string, guestId: string): Promise<number>;
+  findAllByGuestId(guestId: string, page: number, limit: number): Promise<Reservation[]>;
+  countAllByGuestId(guestId: string): Promise<number>;
+  findByGuestIds(guestIds: string[], page: number, limit: number): Promise<Reservation[]>;
+  countByGuestIds(guestIds: string[]): Promise<number>;
   existsActiveByPropertyId(
     tenantId: string,
     propertyId: string,

--- a/src/infrastructure/persistence/repositories/mongo-guest.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-guest.repository.ts
@@ -115,6 +115,13 @@ export class MongoGuestRepository implements GuestRepository {
     return document ? this.toDomain(document) : null;
   }
 
+  async findAllByGuestAccountId(guestAccountId: GuestAccountId): Promise<Guest[]> {
+    const documents = await this.guestModel.find({
+      guestAccountId: new Types.ObjectId(guestAccountId.toString()),
+    });
+    return documents.map((d) => this.toDomain(d));
+  }
+
   async countByTenantId(tenantId: TenantId): Promise<number> {
     return this.guestModel.countDocuments({
       tenantId: new Types.ObjectId(tenantId.toString()),

--- a/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
@@ -224,6 +224,53 @@ export class MongoReservationRepository implements ReservationRepository {
     });
   }
 
+  async countByGuestId(tenantId: string, guestId: string): Promise<number> {
+    return this.reservationModel.countDocuments({
+      tenantId: new Types.ObjectId(tenantId),
+      guestId: new Types.ObjectId(guestId),
+    });
+  }
+
+  async findAllByGuestId(
+    guestId: string,
+    page: number,
+    limit: number,
+  ): Promise<Reservation[]> {
+    const skip = (page - 1) * limit;
+    const docs = await this.reservationModel
+      .find({ guestId: new Types.ObjectId(guestId) })
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit);
+    return docs.map((d) => this.toDomain(d));
+  }
+
+  async countAllByGuestId(guestId: string): Promise<number> {
+    return this.reservationModel.countDocuments({
+      guestId: new Types.ObjectId(guestId),
+    });
+  }
+
+  async findByGuestIds(
+    guestIds: string[],
+    page: number,
+    limit: number,
+  ): Promise<Reservation[]> {
+    const skip = (page - 1) * limit;
+    const docs = await this.reservationModel
+      .find({ guestId: { $in: guestIds.map((id) => new Types.ObjectId(id)) } })
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit);
+    return docs.map((d) => this.toDomain(d));
+  }
+
+  async countByGuestIds(guestIds: string[]): Promise<number> {
+    return this.reservationModel.countDocuments({
+      guestId: { $in: guestIds.map((id) => new Types.ObjectId(id)) },
+    });
+  }
+
   async findConfirmedDueForCheckIn(date: Date): Promise<Reservation[]> {
     const endOfDay = new Date(date);
     endOfDay.setHours(23, 59, 59, 999);

--- a/src/presentation/controllers/guest-reservation.controller.ts
+++ b/src/presentation/controllers/guest-reservation.controller.ts
@@ -1,8 +1,10 @@
 import {
   Body,
   Controller,
+  DefaultValuePipe,
   Get,
   Param,
+  ParseIntPipe,
   Post,
   Query,
   UseGuards,
@@ -11,6 +13,7 @@ import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -22,6 +25,8 @@ import { CreateGuestReservationDto } from '@/presentation/dtos/create-guest-rese
 import { CreateGuestReservationCommand } from '@/application/reservation/commands/create-guest-reservation/create-guest-reservation.command';
 import { CreateReservationResult } from '@/application/reservation/commands/create-reservation/create-reservation.result';
 import { GetGuestReservationQuery } from '@/application/reservation/queries/get-guest-reservation/get-guest-reservation.query';
+import { GetReservationsByGuestIdQuery } from '@/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.query';
+import { GetReservationsByGuestIdResult } from '@/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.result';
 import { ReservationDto } from '@/application/reservation/queries/shared/reservation.dto';
 
 @ApiTags('guest-reservations')
@@ -62,6 +67,35 @@ export class GuestReservationController {
     return {
       message: 'Reservation created successfully',
       reservationId: result.reservationId,
+    };
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get all reservations for the authenticated guest' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Reservations retrieved successfully' })
+  async findByGuest(
+    @CurrentGuest() guest: GuestJwtPayload,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    const result = await this.queryBus.execute<
+      GetReservationsByGuestIdQuery,
+      GetReservationsByGuestIdResult
+    >(new GetReservationsByGuestIdQuery(guest.guestAccountId, page, limit));
+
+    return {
+      message: 'Reservations retrieved successfully',
+      data: {
+        items: result.items,
+        pagination: {
+          total: result.total,
+          page: result.page,
+          limit: result.limit,
+          totalPages: Math.ceil(result.total / result.limit),
+        },
+      },
     };
   }
 

--- a/test/guest-reservation/get-reservations-by-guest-id.query-handler.spec.ts
+++ b/test/guest-reservation/get-reservations-by-guest-id.query-handler.spec.ts
@@ -1,0 +1,201 @@
+import { GetReservationsByGuestIdHandler } from '@/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.query-handler';
+import { GetReservationsByGuestIdQuery } from '@/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.query';
+import { GetReservationsByGuestIdResult } from '@/application/reservation/queries/get-reservations-by-guest-id/get-reservations-by-guest-id.result';
+import { ReservationRepository } from '@/domain/reservation/repositories/reservation.repository';
+import { GuestRepository } from '@/domain/guest/repositories/guest.repository';
+import { Reservation } from '@/domain/reservation/entities/reservation.entity';
+import { Guest } from '@/domain/guest/entities/guest.entity';
+import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
+import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { ReservationId } from '@/domain/reservation/value-objects/reservation-id.vo';
+import { DateRange } from '@/domain/reservation/value-objects/date-range.vo';
+import {
+  ReservationSource,
+  ReservationSourceEnum,
+} from '@/domain/reservation/value-objects/reservation-source.vo';
+import {
+  GuestStatusEnum,
+  GuestIdentity,
+  GuestSummary,
+} from '@/domain/guest/entities/guest.types';
+
+const GUEST_ACCOUNT_ID = '65f1a1a2b3c4d5e6f7a8b900';
+const GUEST_ID_1 = '65f1a1a2b3c4d5e6f7a8b9d1';
+const GUEST_ID_2 = '65f1a1a2b3c4d5e6f7a8b9d2';
+
+function createReservationRepositoryMock(): jest.Mocked<ReservationRepository> {
+  return {
+    save: jest.fn(),
+    findById: jest.fn(),
+    findByTenantId: jest.fn(),
+    findByPropertyId: jest.fn(),
+    findByUnitId: jest.fn(),
+    findByGuestId: jest.fn(),
+    findByUnitAndDateRange: jest.fn(),
+    findActiveByUnitFromDate: jest.fn(),
+    findByExternalId: jest.fn(),
+    existsActiveByPropertyId: jest.fn(),
+    existsActiveByUnitId: jest.fn(),
+    countByTenantId: jest.fn(),
+    countByGuestId: jest.fn(),
+    findAllByGuestId: jest.fn(),
+    countAllByGuestId: jest.fn(),
+    findByGuestIds: jest.fn(),
+    countByGuestIds: jest.fn(),
+    findConfirmedDueForCheckIn: jest.fn(),
+  };
+}
+
+function createGuestRepositoryMock(): jest.Mocked<GuestRepository> {
+  return {
+    save: jest.fn(),
+    findById: jest.fn(),
+    findByTenantId: jest.fn(),
+    findByPrimaryEmail: jest.fn(),
+    findByGuestAccountId: jest.fn(),
+    findAllByGuestAccountId: jest.fn(),
+    countByTenantId: jest.fn(),
+    delete: jest.fn(),
+    search: jest.fn(),
+  };
+}
+
+function makeGuest(guestId: string, tenantId: string): Guest {
+  const identity: GuestIdentity = {};
+  const summary: GuestSummary = {
+    totalBookings: 0,
+    totalNights: 0,
+    totalSpend: 0,
+    lastStayAt: null,
+    lastPropertyId: null,
+    lastUnitId: null,
+  };
+
+  return Guest.reconstitute(
+    GuestId.createFromString(guestId),
+    TenantId.createFromString(tenantId),
+    GuestAccountId.createFromString(GUEST_ACCOUNT_ID),
+    identity,
+    'John',
+    'Doe',
+    'John Doe',
+    'john@example.com',
+    ['john@example.com'],
+    [],
+    GuestStatusEnum.ACTIVE,
+    [],
+    '',
+    summary,
+    new Date(),
+    new Date(),
+  );
+}
+
+function makeReservation(id: string, guestId: string, tenantId: string): Reservation {
+  const reservation = Reservation.createConfirmed({
+    tenantId: TenantId.createFromString(tenantId),
+    propertyId: PropertyId.create('65f1a1a2b3c4d5e6f7a8b9c1'),
+    unitId: UnitId.create('65f1a1a2b3c4d5e6f7a8b9c2'),
+    guestId: GuestId.createFromString(guestId),
+    dateRange: DateRange.create(
+      new Date(Date.now() + 24 * 60 * 60 * 1000),
+      new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+    ),
+    source: ReservationSource.create(ReservationSourceEnum.DIRECT),
+    guestsCount: 2,
+    pricePerNight: 120,
+  });
+  reservation.setId(ReservationId.create(id));
+  return reservation;
+}
+
+describe('GetReservationsByGuestIdHandler', () => {
+  let handler: GetReservationsByGuestIdHandler;
+  let reservationRepository: jest.Mocked<ReservationRepository>;
+  let guestRepository: jest.Mocked<GuestRepository>;
+
+  beforeEach(() => {
+    reservationRepository = createReservationRepositoryMock();
+    guestRepository = createGuestRepositoryMock();
+    handler = new GetReservationsByGuestIdHandler(
+      reservationRepository,
+      guestRepository,
+    );
+  });
+
+  it('returns empty result when no guest profiles exist for the guestAccountId', async () => {
+    guestRepository.findAllByGuestAccountId.mockResolvedValue([]);
+
+    const result = await handler.execute(
+      new GetReservationsByGuestIdQuery(GUEST_ACCOUNT_ID, 1, 10),
+    );
+
+    expect(result).toBeInstanceOf(GetReservationsByGuestIdResult);
+    expect(result.items).toHaveLength(0);
+    expect(result.total).toBe(0);
+    expect(reservationRepository.findByGuestIds).not.toHaveBeenCalled();
+    expect(reservationRepository.countByGuestIds).not.toHaveBeenCalled();
+  });
+
+  it('returns paginated reservations across all tenants for the guestAccountId', async () => {
+    const guest1 = makeGuest(GUEST_ID_1, 'tenant-1');
+    const guest2 = makeGuest(GUEST_ID_2, 'tenant-2');
+    const res1 = makeReservation('65f1a1a2b3c4d5e6f7a8b9e1', GUEST_ID_1, 'tenant-1');
+    const res2 = makeReservation('65f1a1a2b3c4d5e6f7a8b9e2', GUEST_ID_2, 'tenant-2');
+
+    guestRepository.findAllByGuestAccountId.mockResolvedValue([guest1, guest2]);
+    reservationRepository.findByGuestIds.mockResolvedValue([res1, res2]);
+    reservationRepository.countByGuestIds.mockResolvedValue(2);
+
+    const result = await handler.execute(
+      new GetReservationsByGuestIdQuery(GUEST_ACCOUNT_ID, 1, 10),
+    );
+
+    expect(result).toBeInstanceOf(GetReservationsByGuestIdResult);
+    expect(result.items).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(10);
+    expect(reservationRepository.findByGuestIds).toHaveBeenCalledWith(
+      [GUEST_ID_1, GUEST_ID_2],
+      1,
+      10,
+    );
+  });
+
+  it('passes correct page and limit to the repository', async () => {
+    const guest = makeGuest(GUEST_ID_1, 'tenant-1');
+
+    guestRepository.findAllByGuestAccountId.mockResolvedValue([guest]);
+    reservationRepository.findByGuestIds.mockResolvedValue([]);
+    reservationRepository.countByGuestIds.mockResolvedValue(0);
+
+    await handler.execute(new GetReservationsByGuestIdQuery(GUEST_ACCOUNT_ID, 3, 5));
+
+    expect(reservationRepository.findByGuestIds).toHaveBeenCalledWith(
+      [GUEST_ID_1],
+      3,
+      5,
+    );
+    expect(reservationRepository.countByGuestIds).toHaveBeenCalledWith([GUEST_ID_1]);
+  });
+
+  it('returns correct total when it exceeds the page limit', async () => {
+    const guest = makeGuest(GUEST_ID_1, 'tenant-1');
+    const res = makeReservation('65f1a1a2b3c4d5e6f7a8b9e1', GUEST_ID_1, 'tenant-1');
+
+    guestRepository.findAllByGuestAccountId.mockResolvedValue([guest]);
+    reservationRepository.findByGuestIds.mockResolvedValue([res]);
+    reservationRepository.countByGuestIds.mockResolvedValue(15);
+
+    const result = await handler.execute(
+      new GetReservationsByGuestIdQuery(GUEST_ACCOUNT_ID, 1, 10),
+    );
+
+    expect(result.total).toBe(15);
+    expect(result.items).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Summary

  - Adds a new GET /guest/reservations endpoint on the GuestReservationController that
  retrieves all reservations for the authenticated guest, regardless of tenant
  - The guestAccountId is extracted directly from the JWT token — no extra query params
  needed
  - Resolves all guest profiles linked to the guestAccountId across all tenants, then
  fetches their reservations in a single $in query with pagination support

  Changes

  Domain

  - Added findAllByGuestAccountId to GuestRepository interface
  - Added findByGuestIds, countByGuestIds, findAllByGuestId, and countAllByGuestId to
  ReservationRepository interface

  Infrastructure

  - Implemented findAllByGuestAccountId in MongoGuestRepository (queries guests by
  guestAccountId without tenant filter)
  - Implemented findByGuestIds and countByGuestIds in MongoReservationRepository using $in
  operator

  Application

  - Added GetReservationsByGuestIdQuery, GetReservationsByGuestIdResult, and
  GetReservationsByGuestIdHandler
  - Handler resolves guest profiles → collects guestIds → runs paginated query in parallel
  with count
  - Registered handler in ReservationApplicationModule

  Presentation

  - Added GET /guest/reservations?page=&limit= to GuestReservationController

  Test plan

  - Unit tests pass: GetReservationsByGuestIdHandler covers empty result, cross-tenant
  aggregation, pagination params, and total count
  - GET /guest/reservations returns 200 with paginated reservations for an authenticated
  guest
  - Returns empty list when guest has no profiles or reservations
  - Pagination (page, limit) works correctly across multiple tenants