### PR TITLE
LYMON-164-associate-item-with-a-supplier

### DIFF
--- a/docs/adr/013-inventory-item-supplier-association.md
+++ b/docs/adr/013-inventory-item-supplier-association.md
@@ -1,0 +1,119 @@
+# ADR-013: Asociación de Supplier en InventoryItem
+
+**Fecha:** 2026-04-10  
+**Estado:** Aceptado
+
+---
+
+## Contexto
+
+El módulo de inventario necesitaba soportar la asociación opcional entre un `InventoryItem` y un `Supplier` para poder rastrear qué proveedor abastece cada producto.
+
+Además de persistir la relación, el flujo debía permitir:
+
+1. Asociar un supplier existente al item.
+2. Remover la asociación sin eliminar ni el item ni el supplier.
+3. Consultar los items asociados a un supplier desde la vista de detalle del supplier.
+4. Registrar validación de tenant/property/item/supplier antes de mutar el estado.
+
+Había dos posibles modelos:
+
+- Guardar la relación en `InventoryItem` como un campo nullable `supplierId`.
+- Modelar una relación separada o una colección intermedia para representar el vínculo.
+
+---
+
+## Decisión
+
+Se decidió modelar la asociación como una relación opcional en `InventoryItem` mediante el campo nullable `supplierId`.
+
+La relación se persiste en la colección de inventario y se maneja desde la capa de aplicación con comandos explícitos:
+
+- `AssociateSupplierToItemCommand`
+- `RemoveSupplierFromItemCommand`
+
+El endpoint para mutar la relación es propiedad-scoped:
+
+```http
+PATCH /properties/:propertyId/inventory/items/:itemId/supplier
+```
+
+La vista de detalle del supplier obtiene sus items asociados mediante una query dedicada:
+
+- `GetItemsBySupplierQuery`
+
+### Regla de sincronización adicional
+
+Cuando la relación cambia, también se sincroniza el supplier de forma no destructiva:
+
+1. Se vuelve a persistir el supplier con el mismo contenido funcional.
+2. Se actualiza `updatedAt`.
+3. Se emite un evento de auditoría para registrar el cambio.
+
+No se mantiene una lista denormalizada de items dentro de `Supplier`.
+
+---
+
+## Razones
+
+### 1. La relación pertenece naturalmente al item
+
+Un item puede existir sin supplier asignado, pero si existe una relación activa, el item es el lugar más estable para representarla.
+
+### 2. Se evita duplicación de verdad
+
+Mantener `supplierId` en `InventoryItem` evita duplicar el vínculo en dos agregados y reduce el riesgo de inconsistencias.
+
+### 3. El dominio sigue siendo fácil de consultar
+
+La consulta por supplier se resuelve con un filtro indexado sobre la colección de inventario, sin necesidad de joins o estructuras intermedias.
+
+### 4. El unlink no elimina datos
+
+La eliminación de la relación solo nulifica `supplierId`. Eso conserva el historial del item y permite reasignar el supplier después.
+
+### 5. La sincronización del supplier es mínima y explícita
+
+Actualizar solo `updatedAt` y emitir auditoría conserva trazabilidad sin introducir contadores, listas de ids o estado derivado que luego haya que reconciliar.
+
+---
+
+## Consecuencias
+
+**Positivas:**
+
+- La asociación es simple de entender y persistir.
+- El item puede tener o no supplier sin romper el modelo.
+- El supplier detail view puede listar items asociados de forma directa.
+- El unlink es seguro y no destructivo.
+
+**Negativas:**
+
+- La vista de item no expone automáticamente datos completos del supplier; si se necesita nombre/contacto en el detalle del item, habrá que extender el read model.
+- La integridad referencial depende de validación en la capa de aplicación, no de la base de datos.
+- La sincronización de supplier es intencionalmente liviana; si en el futuro se necesita estado agregado como conteos, habrá que diseñarlo aparte.
+
+---
+
+## Alternativas descartadas
+
+### 1. Colección intermedia o relación many-to-many
+
+Se descartó porque el caso de uso actual no necesita múltiples suppliers por item ni historial de asignaciones.
+
+### 2. Denormalizar items dentro de Supplier
+
+Se descartó porque agrega complejidad de consistencia y requiere mantener listas sincronizadas en cada alta/baja de relación.
+
+### 3. Eliminar la asociación mediante borrado físico
+
+Se descartó porque el requerimiento explícitamente pide desasociar sin eliminar el item.
+
+---
+
+## Notas de implementación
+
+- La relación se agregó al schema de inventario como `supplierId` nullable.
+- La capa de dominio de `InventoryItem` expone métodos para asociar y remover supplier.
+- La capa de aplicación valida tenant, property, item y supplier antes de mutar el estado.
+- La mutación de supplier se registra con auditoría para mantener trazabilidad operativa.

--- a/src/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.command.ts
+++ b/src/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.command.ts
@@ -1,0 +1,12 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class AssociateSupplierToItemCommand implements ICommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly propertyId: string,
+    public readonly itemId: string,
+    public readonly supplierId: string,
+    public readonly actorId: string,
+    public readonly actorEmail: string,
+  ) {}
+}

--- a/src/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.handler.ts
+++ b/src/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.handler.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
+import { Inject, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { AssociateSupplierToItemCommand } from './associate-supplier-to-item.command';
@@ -52,24 +52,20 @@ export class AssociateSupplierToItemHandler implements ICommandHandler<
   async execute(
     command: AssociateSupplierToItemCommand,
   ): Promise<AssociateSupplierToItemResult> {
-    const tenantId = this.parseTenantId(command.tenantId);
-    const propertyId = this.parsePropertyId(command.propertyId);
-    const itemId = this.parseItemId(command.itemId);
-    const supplierId = this.parseSupplierId(command.supplierId);
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const propertyId = PropertyId.create(command.propertyId);
+    const itemId = InventoryItemId.create(command.itemId);
+    const supplierId = SupplierId.create(command.supplierId);
 
     const property = await this.propertyRepository.findById(propertyId);
-    if (
-      !property ||
-      property.getTenantId().toString() !== tenantId.toString()
-    ) {
+    if (property?.getTenantId().toString() !== tenantId.toString()) {
       throw new NotFoundException('Property not found');
     }
 
     const item = await this.inventoryItemRepository.findById(itemId);
     if (
-      !item ||
-      item.getTenantId().toString() !== tenantId.toString() ||
-      item.getPropertyId().toString() !== propertyId.toString()
+      item?.getTenantId().toString() !== tenantId.toString() ||
+      item?.getPropertyId().toString() !== propertyId.toString()
     ) {
       throw new NotFoundException('Inventory item not found');
     }
@@ -77,10 +73,7 @@ export class AssociateSupplierToItemHandler implements ICommandHandler<
     const inventoryItem = item as InventoryItemWithSupplierAssociation;
 
     const supplier = await this.supplierRepository.findById(supplierId);
-    if (
-      !supplier ||
-      supplier.getTenantId().toString() !== tenantId.toString()
-    ) {
+    if (supplier?.getTenantId().toString() !== tenantId.toString()) {
       throw new NotFoundException('Supplier not found');
     }
 
@@ -119,38 +112,6 @@ export class AssociateSupplierToItemHandler implements ICommandHandler<
       itemId.toString(),
       supplierId.toString(),
     );
-  }
-
-  private parseTenantId(value: string): TenantId {
-    try {
-      return TenantId.createFromString(value);
-    } catch {
-      throw new BadRequestException('tenantId is required');
-    }
-  }
-
-  private parsePropertyId(value: string): PropertyId {
-    try {
-      return PropertyId.create(value);
-    } catch {
-      throw new BadRequestException('propertyId is required');
-    }
-  }
-
-  private parseItemId(value: string): InventoryItemId {
-    try {
-      return InventoryItemId.create(value);
-    } catch {
-      throw new BadRequestException('itemId is required');
-    }
-  }
-
-  private parseSupplierId(value: string): SupplierId {
-    try {
-      return SupplierId.create(value);
-    } catch {
-      throw new BadRequestException('supplierId is required');
-    }
   }
 
   private refreshSupplierMetadata(

--- a/src/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.handler.ts
+++ b/src/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.handler.ts
@@ -1,0 +1,225 @@
+import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { AssociateSupplierToItemCommand } from './associate-supplier-to-item.command';
+import { AssociateSupplierToItemResult } from './associate-supplier-to-item.result';
+import {
+  INVENTORY_ITEM_REPOSITORY,
+  type InventoryItemRepository,
+} from '@/domain/inventory/repositories/inventory-item.repository';
+import {
+  PROPERTY_REPOSITORY,
+  type PropertyRepository,
+} from '@/domain/property/repositories/property.repository';
+import {
+  SUPPLIER_REPOSITORY,
+  type SupplierRepository,
+} from '@/domain/inventory/repositories/supplier.repository';
+import { Supplier } from '@/domain/inventory/entities/supplier.entity';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item-id.vo';
+import { SupplierId } from '@/domain/inventory/value-objects/supplier-id.vo';
+import {
+  AuditAction,
+  AuditEntityType,
+} from '@/domain/audit/value-objects/audit-action.vo';
+import {
+  AUDIT_LOG_EVENT,
+  AuditLoggedEvent,
+} from '@/infrastructure/audit/events/audit-logged.event';
+
+type InventoryItemWithSupplierAssociation = {
+  associateSupplier(supplierId: SupplierId): void;
+  getSupplierId(): SupplierId | null;
+};
+
+@CommandHandler(AssociateSupplierToItemCommand)
+export class AssociateSupplierToItemHandler implements ICommandHandler<
+  AssociateSupplierToItemCommand,
+  AssociateSupplierToItemResult
+> {
+  constructor(
+    @Inject(INVENTORY_ITEM_REPOSITORY)
+    private readonly inventoryItemRepository: InventoryItemRepository,
+    @Inject(PROPERTY_REPOSITORY)
+    private readonly propertyRepository: PropertyRepository,
+    @Inject(SUPPLIER_REPOSITORY)
+    private readonly supplierRepository: SupplierRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(
+    command: AssociateSupplierToItemCommand,
+  ): Promise<AssociateSupplierToItemResult> {
+    const tenantId = this.parseTenantId(command.tenantId);
+    const propertyId = this.parsePropertyId(command.propertyId);
+    const itemId = this.parseItemId(command.itemId);
+    const supplierId = this.parseSupplierId(command.supplierId);
+
+    const property = await this.propertyRepository.findById(propertyId);
+    if (
+      !property ||
+      property.getTenantId().toString() !== tenantId.toString()
+    ) {
+      throw new NotFoundException('Property not found');
+    }
+
+    const item = await this.inventoryItemRepository.findById(itemId);
+    if (
+      !item ||
+      item.getTenantId().toString() !== tenantId.toString() ||
+      item.getPropertyId().toString() !== propertyId.toString()
+    ) {
+      throw new NotFoundException('Inventory item not found');
+    }
+
+    const inventoryItem = item as InventoryItemWithSupplierAssociation;
+
+    const supplier = await this.supplierRepository.findById(supplierId);
+    if (
+      !supplier ||
+      supplier.getTenantId().toString() !== tenantId.toString()
+    ) {
+      throw new NotFoundException('Supplier not found');
+    }
+
+    const previousSnapshot = this.getItemSupplierSnapshot(inventoryItem);
+
+    inventoryItem.associateSupplier(supplierId);
+    const nextSnapshot = this.getItemSupplierSnapshot(inventoryItem);
+    const auditDiff = this.buildAuditDiff(previousSnapshot, nextSnapshot);
+
+    await this.inventoryItemRepository.save(item);
+
+    const refreshedSupplier = this.refreshSupplierMetadata(
+      supplier,
+      supplierId,
+    );
+    await this.supplierRepository.save(refreshedSupplier);
+
+    this.eventEmitter.emit(
+      AUDIT_LOG_EVENT,
+      new AuditLoggedEvent(
+        command.tenantId,
+        command.actorId ?? '',
+        command.actorEmail ?? '',
+        AuditAction.SUPPLIER_UPDATED,
+        AuditEntityType.SUPPLIER,
+        command.supplierId,
+        auditDiff.changedFields.length > 0
+          ? { changedFields: auditDiff.changedFields }
+          : undefined,
+        auditDiff.previousValue,
+        auditDiff.newValue,
+      ),
+    );
+
+    return new AssociateSupplierToItemResult(
+      itemId.toString(),
+      supplierId.toString(),
+    );
+  }
+
+  private parseTenantId(value: string): TenantId {
+    try {
+      return TenantId.createFromString(value);
+    } catch {
+      throw new BadRequestException('tenantId is required');
+    }
+  }
+
+  private parsePropertyId(value: string): PropertyId {
+    try {
+      return PropertyId.create(value);
+    } catch {
+      throw new BadRequestException('propertyId is required');
+    }
+  }
+
+  private parseItemId(value: string): InventoryItemId {
+    try {
+      return InventoryItemId.create(value);
+    } catch {
+      throw new BadRequestException('itemId is required');
+    }
+  }
+
+  private parseSupplierId(value: string): SupplierId {
+    try {
+      return SupplierId.create(value);
+    } catch {
+      throw new BadRequestException('supplierId is required');
+    }
+  }
+
+  private refreshSupplierMetadata(
+    supplier: {
+      getId(): { toString(): string } | null;
+      getTenantId(): TenantId;
+      getName(): string;
+      getContactEmail(): string;
+      getContactPhone(): string;
+      getCountry(): string;
+      getCity(): string;
+      getNit(): string;
+      getCreatedAt(): Date;
+      getDeletedAt(): Date | null;
+    },
+    supplierId: SupplierId,
+  ) {
+    return Supplier.reconstitute({
+      id: supplierId,
+      tenantId: supplier.getTenantId(),
+      name: supplier.getName(),
+      contactEmail: supplier.getContactEmail(),
+      contactPhone: supplier.getContactPhone(),
+      country: supplier.getCountry(),
+      city: supplier.getCity(),
+      nit: supplier.getNit(),
+      createdAt: supplier.getCreatedAt(),
+      updatedAt: new Date(),
+      deletedAt: supplier.getDeletedAt(),
+    });
+  }
+
+  private getItemSupplierSnapshot(item: {
+    getSupplierId(): SupplierId | null;
+  }): Record<string, unknown> {
+    return {
+      supplierId: item.getSupplierId()?.toString() ?? null,
+    };
+  }
+
+  private buildAuditDiff(
+    previousSnapshot: Record<string, unknown>,
+    nextSnapshot: Record<string, unknown>,
+  ): {
+    changedFields: string[];
+    previousValue?: Record<string, unknown>;
+    newValue?: Record<string, unknown>;
+  } {
+    const changedFields: string[] = [];
+    const previousValue: Record<string, unknown> = {};
+    const newValue: Record<string, unknown> = {};
+
+    for (const field of Object.keys(nextSnapshot)) {
+      const previousFieldValue = previousSnapshot[field];
+      const nextFieldValue = nextSnapshot[field];
+
+      if (previousFieldValue === nextFieldValue) {
+        continue;
+      }
+
+      changedFields.push(field);
+      previousValue[field] = previousFieldValue;
+      newValue[field] = nextFieldValue;
+    }
+
+    return {
+      changedFields,
+      previousValue: changedFields.length > 0 ? previousValue : undefined,
+      newValue: changedFields.length > 0 ? newValue : undefined,
+    };
+  }
+}

--- a/src/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.result.ts
+++ b/src/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.result.ts
@@ -1,0 +1,6 @@
+export class AssociateSupplierToItemResult {
+  constructor(
+    public readonly itemId: string,
+    public readonly supplierId: string,
+  ) {}
+}

--- a/src/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.command.ts
+++ b/src/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.command.ts
@@ -1,0 +1,11 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class RemoveSupplierFromItemCommand implements ICommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly propertyId: string,
+    public readonly itemId: string,
+    public readonly actorId: string,
+    public readonly actorEmail: string,
+  ) {}
+}

--- a/src/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.handler.ts
+++ b/src/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.handler.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
+import { Inject, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { RemoveSupplierFromItemCommand } from './remove-supplier-from-item.command';
@@ -52,23 +52,19 @@ export class RemoveSupplierFromItemHandler implements ICommandHandler<
   async execute(
     command: RemoveSupplierFromItemCommand,
   ): Promise<RemoveSupplierFromItemResult> {
-    const tenantId = this.parseTenantId(command.tenantId);
-    const propertyId = this.parsePropertyId(command.propertyId);
-    const itemId = this.parseItemId(command.itemId);
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const propertyId = PropertyId.create(command.propertyId);
+    const itemId = InventoryItemId.create(command.itemId);
 
     const property = await this.propertyRepository.findById(propertyId);
-    if (
-      !property ||
-      property.getTenantId().toString() !== tenantId.toString()
-    ) {
+    if (property?.getTenantId().toString() !== tenantId.toString()) {
       throw new NotFoundException('Property not found');
     }
 
     const item = await this.inventoryItemRepository.findById(itemId);
     if (
-      !item ||
-      item.getTenantId().toString() !== tenantId.toString() ||
-      item.getPropertyId().toString() !== propertyId.toString()
+      item?.getTenantId().toString() !== tenantId.toString() ||
+      item?.getPropertyId().toString() !== propertyId.toString()
     ) {
       throw new NotFoundException('Inventory item not found');
     }
@@ -85,10 +81,7 @@ export class RemoveSupplierFromItemHandler implements ICommandHandler<
 
     if (supplierId) {
       const supplier = await this.supplierRepository.findById(supplierId);
-      if (
-        supplier &&
-        supplier.getTenantId().toString() === tenantId.toString()
-      ) {
+      if (supplier?.getTenantId().toString() === tenantId.toString()) {
         await this.supplierRepository.save(
           Supplier.reconstitute({
             id: supplier.getId()!,
@@ -125,30 +118,6 @@ export class RemoveSupplierFromItemHandler implements ICommandHandler<
     }
 
     return new RemoveSupplierFromItemResult(itemId.toString());
-  }
-
-  private parseTenantId(value: string): TenantId {
-    try {
-      return TenantId.createFromString(value);
-    } catch {
-      throw new BadRequestException('tenantId is required');
-    }
-  }
-
-  private parsePropertyId(value: string): PropertyId {
-    try {
-      return PropertyId.create(value);
-    } catch {
-      throw new BadRequestException('propertyId is required');
-    }
-  }
-
-  private parseItemId(value: string): InventoryItemId {
-    try {
-      return InventoryItemId.create(value);
-    } catch {
-      throw new BadRequestException('itemId is required');
-    }
   }
 
   private getItemSupplierSnapshot(item: {

--- a/src/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.handler.ts
+++ b/src/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.handler.ts
@@ -1,0 +1,193 @@
+import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { RemoveSupplierFromItemCommand } from './remove-supplier-from-item.command';
+import { RemoveSupplierFromItemResult } from './remove-supplier-from-item.result';
+import {
+  INVENTORY_ITEM_REPOSITORY,
+  type InventoryItemRepository,
+} from '@/domain/inventory/repositories/inventory-item.repository';
+import {
+  PROPERTY_REPOSITORY,
+  type PropertyRepository,
+} from '@/domain/property/repositories/property.repository';
+import {
+  SUPPLIER_REPOSITORY,
+  type SupplierRepository,
+} from '@/domain/inventory/repositories/supplier.repository';
+import { Supplier } from '@/domain/inventory/entities/supplier.entity';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item-id.vo';
+import { SupplierId } from '@/domain/inventory/value-objects/supplier-id.vo';
+import {
+  AuditAction,
+  AuditEntityType,
+} from '@/domain/audit/value-objects/audit-action.vo';
+import {
+  AUDIT_LOG_EVENT,
+  AuditLoggedEvent,
+} from '@/infrastructure/audit/events/audit-logged.event';
+
+type InventoryItemWithSupplierAssociation = {
+  getSupplierId(): SupplierId | null;
+  removeSupplier(): void;
+};
+
+@CommandHandler(RemoveSupplierFromItemCommand)
+export class RemoveSupplierFromItemHandler implements ICommandHandler<
+  RemoveSupplierFromItemCommand,
+  RemoveSupplierFromItemResult
+> {
+  constructor(
+    @Inject(INVENTORY_ITEM_REPOSITORY)
+    private readonly inventoryItemRepository: InventoryItemRepository,
+    @Inject(PROPERTY_REPOSITORY)
+    private readonly propertyRepository: PropertyRepository,
+    @Inject(SUPPLIER_REPOSITORY)
+    private readonly supplierRepository: SupplierRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(
+    command: RemoveSupplierFromItemCommand,
+  ): Promise<RemoveSupplierFromItemResult> {
+    const tenantId = this.parseTenantId(command.tenantId);
+    const propertyId = this.parsePropertyId(command.propertyId);
+    const itemId = this.parseItemId(command.itemId);
+
+    const property = await this.propertyRepository.findById(propertyId);
+    if (
+      !property ||
+      property.getTenantId().toString() !== tenantId.toString()
+    ) {
+      throw new NotFoundException('Property not found');
+    }
+
+    const item = await this.inventoryItemRepository.findById(itemId);
+    if (
+      !item ||
+      item.getTenantId().toString() !== tenantId.toString() ||
+      item.getPropertyId().toString() !== propertyId.toString()
+    ) {
+      throw new NotFoundException('Inventory item not found');
+    }
+
+    const inventoryItem = item as InventoryItemWithSupplierAssociation;
+
+    const supplierId: SupplierId | null = inventoryItem.getSupplierId();
+    const previousSnapshot = this.getItemSupplierSnapshot(inventoryItem);
+    inventoryItem.removeSupplier();
+    const nextSnapshot = this.getItemSupplierSnapshot(inventoryItem);
+    const auditDiff = this.buildAuditDiff(previousSnapshot, nextSnapshot);
+
+    await this.inventoryItemRepository.save(item);
+
+    if (supplierId) {
+      const supplier = await this.supplierRepository.findById(supplierId);
+      if (
+        supplier &&
+        supplier.getTenantId().toString() === tenantId.toString()
+      ) {
+        await this.supplierRepository.save(
+          Supplier.reconstitute({
+            id: supplier.getId()!,
+            tenantId: supplier.getTenantId(),
+            name: supplier.getName(),
+            contactEmail: supplier.getContactEmail(),
+            contactPhone: supplier.getContactPhone(),
+            country: supplier.getCountry(),
+            city: supplier.getCity(),
+            nit: supplier.getNit(),
+            createdAt: supplier.getCreatedAt(),
+            updatedAt: new Date(),
+            deletedAt: supplier.getDeletedAt(),
+          }),
+        );
+
+        this.eventEmitter.emit(
+          AUDIT_LOG_EVENT,
+          new AuditLoggedEvent(
+            command.tenantId,
+            command.actorId ?? '',
+            command.actorEmail ?? '',
+            AuditAction.SUPPLIER_UPDATED,
+            AuditEntityType.SUPPLIER,
+            supplierId.toString(),
+            auditDiff.changedFields.length > 0
+              ? { changedFields: auditDiff.changedFields }
+              : undefined,
+            auditDiff.previousValue,
+            auditDiff.newValue,
+          ),
+        );
+      }
+    }
+
+    return new RemoveSupplierFromItemResult(itemId.toString());
+  }
+
+  private parseTenantId(value: string): TenantId {
+    try {
+      return TenantId.createFromString(value);
+    } catch {
+      throw new BadRequestException('tenantId is required');
+    }
+  }
+
+  private parsePropertyId(value: string): PropertyId {
+    try {
+      return PropertyId.create(value);
+    } catch {
+      throw new BadRequestException('propertyId is required');
+    }
+  }
+
+  private parseItemId(value: string): InventoryItemId {
+    try {
+      return InventoryItemId.create(value);
+    } catch {
+      throw new BadRequestException('itemId is required');
+    }
+  }
+
+  private getItemSupplierSnapshot(item: {
+    getSupplierId(): { toString(): string } | null;
+  }): Record<string, unknown> {
+    return {
+      supplierId: item.getSupplierId()?.toString() ?? null,
+    };
+  }
+
+  private buildAuditDiff(
+    previousSnapshot: Record<string, unknown>,
+    nextSnapshot: Record<string, unknown>,
+  ): {
+    changedFields: string[];
+    previousValue?: Record<string, unknown>;
+    newValue?: Record<string, unknown>;
+  } {
+    const changedFields: string[] = [];
+    const previousValue: Record<string, unknown> = {};
+    const newValue: Record<string, unknown> = {};
+
+    for (const field of Object.keys(nextSnapshot)) {
+      const previousFieldValue = previousSnapshot[field];
+      const nextFieldValue = nextSnapshot[field];
+
+      if (previousFieldValue === nextFieldValue) {
+        continue;
+      }
+
+      changedFields.push(field);
+      previousValue[field] = previousFieldValue;
+      newValue[field] = nextFieldValue;
+    }
+
+    return {
+      changedFields,
+      previousValue: changedFields.length > 0 ? previousValue : undefined,
+      newValue: changedFields.length > 0 ? newValue : undefined,
+    };
+  }
+}

--- a/src/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.result.ts
+++ b/src/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.result.ts
@@ -1,0 +1,3 @@
+export class RemoveSupplierFromItemResult {
+  constructor(public readonly itemId: string) {}
+}

--- a/src/application/inventory/inventory-application.module.ts
+++ b/src/application/inventory/inventory-application.module.ts
@@ -7,8 +7,11 @@ import { RecordInventoryMovementHandler } from '@/application/inventory/commands
 import { DeleteInventoryItemHandler } from '@/application/inventory/commands/delete-inventory-item/delete-inventory-item.handler';
 import { CreateSupplierHandler } from '@/application/inventory/commands/create-supplier/create-supplier.handler';
 import { UpdateSupplierHandler } from '@/application/inventory/commands/update-supplier/update-supplier.handler';
+import { AssociateSupplierToItemHandler } from '@/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.handler';
+import { RemoveSupplierFromItemHandler } from '@/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.handler';
 import { GetInventoryItemsByPropertyQueryHandler } from '@/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query-handler';
 import { GetLowStockItemsByPropertyQueryHandler } from '@/application/inventory/queries/get-low-stock-items-by-property/get-low-stock-items-by-property.query-handler';
+import { GetItemsBySupplierQueryHandler } from '@/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.query-handler';
 
 const CommandHandlers = [
   CreateInventoryItemHandler,
@@ -17,11 +20,14 @@ const CommandHandlers = [
   DeleteInventoryItemHandler,
   CreateSupplierHandler,
   UpdateSupplierHandler,
+  AssociateSupplierToItemHandler,
+  RemoveSupplierFromItemHandler,
 ];
 
 const QueryHandlers = [
   GetInventoryItemsByPropertyQueryHandler,
   GetLowStockItemsByPropertyQueryHandler,
+  GetItemsBySupplierQueryHandler,
 ];
 
 @Module({

--- a/src/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.query-handler.ts
+++ b/src/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.query-handler.ts
@@ -1,0 +1,58 @@
+import { Inject, NotFoundException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetItemsBySupplierQuery } from './get-items-by-supplier.query';
+import { GetItemsBySupplierResult } from './get-items-by-supplier.result';
+import {
+  INVENTORY_ITEM_REPOSITORY,
+  type InventoryItemRepository,
+} from '@/domain/inventory/repositories/inventory-item.repository';
+import {
+  SUPPLIER_REPOSITORY,
+  type SupplierRepository,
+} from '@/domain/inventory/repositories/supplier.repository';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { SupplierId } from '@/domain/inventory/value-objects/supplier-id.vo';
+import { toInventoryItemDto } from '@/application/inventory/queries/shared/inventory-item.dto';
+
+@QueryHandler(GetItemsBySupplierQuery)
+export class GetItemsBySupplierQueryHandler
+  implements IQueryHandler<GetItemsBySupplierQuery, GetItemsBySupplierResult>
+{
+  constructor(
+    @Inject(INVENTORY_ITEM_REPOSITORY)
+    private readonly inventoryItemRepository: InventoryItemRepository,
+    @Inject(SUPPLIER_REPOSITORY)
+    private readonly supplierRepository: SupplierRepository,
+  ) {}
+
+  async execute(
+    query: GetItemsBySupplierQuery,
+  ): Promise<GetItemsBySupplierResult> {
+    const tenantId = TenantId.createFromString(query.tenantId);
+    const supplierId = SupplierId.create(query.supplierId);
+
+    const supplier = await this.supplierRepository.findById(supplierId);
+    if (
+      !supplier ||
+      supplier.getTenantId().toString() !== tenantId.toString()
+    ) {
+      throw new NotFoundException('Supplier not found');
+    }
+
+    const items = await this.inventoryItemRepository.findBySupplierId(
+      tenantId,
+      supplierId,
+    );
+
+    const total = items.length;
+    const start = (query.page - 1) * query.limit;
+    const paginatedItems = items.slice(start, start + query.limit);
+
+    return new GetItemsBySupplierResult(
+      paginatedItems.map(toInventoryItemDto),
+      total,
+      query.page,
+      query.limit,
+    );
+  }
+}

--- a/src/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.query.ts
+++ b/src/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.query.ts
@@ -1,0 +1,10 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class GetItemsBySupplierQuery implements IQuery {
+  constructor(
+    public readonly tenantId: string,
+    public readonly supplierId: string,
+    public readonly page: number = 1,
+    public readonly limit: number = 20,
+  ) {}
+}

--- a/src/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.result.ts
+++ b/src/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.result.ts
@@ -1,0 +1,14 @@
+import { InventoryItemDto } from '@/application/inventory/queries/shared/inventory-item.dto';
+
+export class GetItemsBySupplierResult {
+  constructor(
+    public readonly items: InventoryItemDto[],
+    public readonly total: number,
+    public readonly page: number,
+    public readonly limit: number,
+  ) {}
+
+  get totalPages(): number {
+    return Math.ceil(this.total / this.limit);
+  }
+}

--- a/src/domain/inventory/entities/inventory-item.entity.ts
+++ b/src/domain/inventory/entities/inventory-item.entity.ts
@@ -3,6 +3,7 @@ import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { InventoryMovementType } from '@/domain/inventory/value-objects/inventory-movement-type.vo';
 import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item-id.vo';
+import { SupplierId } from '@/domain/inventory/value-objects/supplier-id.vo';
 
 export class InventoryItem {
   private constructor(
@@ -15,6 +16,7 @@ export class InventoryItem {
     private unit: string,
     private minStock: number,
     private currentStock: number,
+    private supplierId: SupplierId | null,
     private readonly createdAt: Date,
     private updatedAt: Date,
   ) {}
@@ -28,6 +30,7 @@ export class InventoryItem {
     unit: string;
     minStock: number;
     initialStock?: number;
+    supplierId?: SupplierId | null;
   }): InventoryItem {
     const sku = params.sku.trim();
     const name = params.name.trim();
@@ -54,36 +57,45 @@ export class InventoryItem {
       unit,
       params.minStock,
       initialStock,
+      params.supplierId ?? null,
       new Date(),
       new Date(),
     );
   }
 
-  static reconstitute(
-    id: InventoryItemId,
-    tenantId: TenantId,
-    propertyId: PropertyId,
-    sku: string,
-    name: string,
-    category: string,
-    unit: string,
-    minStock: number,
-    currentStock: number,
-    createdAt: Date,
-    updatedAt: Date,
-  ): InventoryItem {
+  static reconstitute(data: {
+    identity: {
+      id: InventoryItemId;
+      tenantId: TenantId;
+      propertyId: PropertyId;
+    };
+    profile: {
+      sku: string;
+      name: string;
+      category: string;
+      unit: string;
+      minStock: number;
+      currentStock: number;
+      supplierId: SupplierId | null;
+    };
+    timestamps: {
+      createdAt: Date;
+      updatedAt: Date;
+    };
+  }): InventoryItem {
     return new InventoryItem(
-      id,
-      tenantId,
-      propertyId,
-      sku,
-      name,
-      category,
-      unit,
-      minStock,
-      currentStock,
-      createdAt,
-      updatedAt,
+      data.identity.id,
+      data.identity.tenantId,
+      data.identity.propertyId,
+      data.profile.sku,
+      data.profile.name,
+      data.profile.category,
+      data.profile.unit,
+      data.profile.minStock,
+      data.profile.currentStock,
+      data.profile.supplierId,
+      data.timestamps.createdAt,
+      data.timestamps.updatedAt,
     );
   }
 
@@ -163,6 +175,10 @@ export class InventoryItem {
     return this.currentStock;
   }
 
+  getSupplierId(): SupplierId | null {
+    return this.supplierId;
+  }
+
   getCreatedAt(): Date {
     return this.createdAt;
   }
@@ -201,6 +217,16 @@ export class InventoryItem {
       this.minStock = params.minStock;
     }
 
+    this.touch();
+  }
+
+  associateSupplier(supplierId: SupplierId): void {
+    this.supplierId = supplierId;
+    this.touch();
+  }
+
+  removeSupplier(): void {
+    this.supplierId = null;
     this.touch();
   }
 

--- a/src/domain/inventory/repositories/inventory-item.repository.ts
+++ b/src/domain/inventory/repositories/inventory-item.repository.ts
@@ -3,6 +3,7 @@ import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TransactionContextData } from '@/domain/shared/transaction-manager.interface';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { SupplierId } from '@/domain/inventory/value-objects/supplier-id.vo';
 
 export const INVENTORY_ITEM_REPOSITORY = 'INVENTORY_ITEM_REPOSITORY';
 
@@ -25,5 +26,9 @@ export interface InventoryItemRepository {
     propertyId: PropertyId,
     sku: string,
   ): Promise<InventoryItem | null>;
+  findBySupplierId(
+    tenantId: TenantId,
+    supplierId: SupplierId,
+  ): Promise<InventoryItem[]>;
   delete(id: InventoryItemId): Promise<void>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-inventory-item.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-inventory-item.repository.ts
@@ -7,6 +7,7 @@ import { InventoryItem } from '@/domain/inventory/entities/inventory-item.entity
 import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { SupplierId } from '@/domain/inventory/value-objects/supplier-id.vo';
 import { TransactionContextData } from '@/domain/shared/transaction-manager.interface';
 
 @Injectable()
@@ -32,6 +33,9 @@ export class MongoInventoryItemRepository implements InventoryItemRepository {
       unit: item.getUnit(),
       minStock: item.getMinStock(),
       currentStock: item.getCurrentStock(),
+      supplierId: item.getSupplierId()
+        ? new Types.ObjectId(item.getSupplierId()!.toString())
+        : null,
       updatedAt: item.getUpdatedAt(),
     };
 
@@ -53,7 +57,7 @@ export class MongoInventoryItemRepository implements InventoryItemRepository {
       { session },
     );
 
-    return created._id.toString();
+    return created._id.toHexString();
   }
 
   async findById(id: InventoryItemId): Promise<InventoryItem | null> {
@@ -112,6 +116,24 @@ export class MongoInventoryItemRepository implements InventoryItemRepository {
     return this.toDomain(document);
   }
 
+  async findBySupplierId(
+    tenantId: TenantId,
+    supplierId: SupplierId,
+  ): Promise<InventoryItem[]> {
+    const tenantObjectId = new Types.ObjectId(tenantId.toString());
+    const supplierObjectId = new Types.ObjectId(supplierId.toString());
+
+    const documents = await this.inventoryItemModel
+      .find({
+        tenantId: tenantObjectId,
+        supplierId: supplierObjectId,
+        deletedAt: null,
+      })
+      .sort({ createdAt: -1 });
+
+    return documents.map((document) => this.toDomain(document));
+  }
+
   async delete(id: InventoryItemId): Promise<void> {
     await this.inventoryItemModel.findByIdAndUpdate(id.toString(), {
       deletedAt: new Date(),
@@ -119,18 +141,27 @@ export class MongoInventoryItemRepository implements InventoryItemRepository {
   }
 
   private toDomain(document: InventoryItemDocument): InventoryItem {
-    return InventoryItem.reconstitute(
-      InventoryItemId.create(document._id.toString()),
-      TenantId.createFromString(document.tenantId.toString()),
-      PropertyId.create(document.propertyId.toString()),
-      document.sku,
-      document.name,
-      document.category,
-      document.unit,
-      document.minStock,
-      document.currentStock,
-      document.createdAt,
-      document.updatedAt,
-    );
+    return InventoryItem.reconstitute({
+      identity: {
+        id: InventoryItemId.create(document._id.toHexString()),
+        tenantId: TenantId.createFromString(document.tenantId.toHexString()),
+        propertyId: PropertyId.create(document.propertyId.toHexString()),
+      },
+      profile: {
+        sku: document.sku,
+        name: document.name,
+        category: document.category,
+        unit: document.unit,
+        minStock: document.minStock,
+        currentStock: document.currentStock,
+        supplierId: document.supplierId
+          ? SupplierId.create(document.supplierId.toHexString())
+          : null,
+      },
+      timestamps: {
+        createdAt: document.createdAt,
+        updatedAt: document.updatedAt,
+      },
+    });
   }
 }

--- a/src/infrastructure/persistence/schemas/inventory-item.schema.ts
+++ b/src/infrastructure/persistence/schemas/inventory-item.schema.ts
@@ -38,6 +38,9 @@ export class InventoryItemDocument extends Document {
   @Prop({ required: true, default: 0 })
   currentStock: number;
 
+  @Prop({ type: Types.ObjectId, default: null, index: true })
+  supplierId: Types.ObjectId | null;
+
   @Prop({ type: Date, default: null })
   deletedAt: Date | null;
 }
@@ -50,6 +53,7 @@ InventoryItemSchema.index(
   { tenantId: 1, propertyId: 1, sku: 1 },
   { unique: true },
 );
+InventoryItemSchema.index({ tenantId: 1, supplierId: 1 });
 InventoryItemSchema.index({
   tenantId: 1,
   propertyId: 1,

--- a/src/presentation/controllers/inventory.controller.ts
+++ b/src/presentation/controllers/inventory.controller.ts
@@ -30,6 +30,7 @@ import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { CreateInventoryItemDto } from '@/presentation/dtos/create-inventory-item.dto';
 import { UpdateInventoryItemDto } from '@/presentation/dtos/update-inventory-item.dto';
 import { RecordInventoryMovementDto } from '@/presentation/dtos/record-inventory-movement.dto';
+import { UpdateInventoryItemSupplierDto } from '@/presentation/dtos/update-inventory-item-supplier.dto';
 import { CreateInventoryItemCommand } from '@/application/inventory/commands/create-inventory-item/create-inventory-item.command';
 import { CreateInventoryItemResult } from '@/application/inventory/commands/create-inventory-item/create-inventory-item.result';
 import { UpdateInventoryItemCommand } from '@/application/inventory/commands/update-inventory-item/update-inventory-item.command';
@@ -37,6 +38,10 @@ import { UpdateInventoryItemResult } from '@/application/inventory/commands/upda
 import { RecordInventoryMovementCommand } from '@/application/inventory/commands/record-inventory-movement/record-inventory-movement.command';
 import { RecordInventoryMovementResult } from '@/application/inventory/commands/record-inventory-movement/record-inventory-movement.result';
 import { DeleteInventoryItemCommand } from '@/application/inventory/commands/delete-inventory-item/delete-inventory-item.command';
+import { AssociateSupplierToItemCommand } from '@/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.command';
+import { AssociateSupplierToItemResult } from '@/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.result';
+import { RemoveSupplierFromItemCommand } from '@/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.command';
+import { RemoveSupplierFromItemResult } from '@/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.result';
 import { GetInventoryItemsByPropertyQuery } from '@/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.query';
 import { GetInventoryItemsByPropertyResult } from '@/application/inventory/queries/get-inventory-items-by-property/get-inventory-items-by-property.result';
 import { GetLowStockItemsByPropertyQuery } from '@/application/inventory/queries/get-low-stock-items-by-property/get-low-stock-items-by-property.query';
@@ -252,5 +257,61 @@ export class InventoryController {
     await this.commandBus.execute<DeleteInventoryItemCommand, void>(
       new DeleteInventoryItemCommand(user.tenantId, propertyId, itemId),
     );
+  }
+
+  @Patch('items/:itemId/supplier')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_EDIT)
+  @ApiOperation({
+    summary: 'Associate or remove a supplier from an inventory item',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Inventory item supplier updated successfully',
+  })
+  async updateItemSupplier(
+    @CurrentUser() user: JwtPayload,
+    @Param('propertyId') propertyId: string,
+    @Param('itemId') itemId: string,
+    @Body() dto: UpdateInventoryItemSupplierDto,
+  ) {
+    if (dto.supplierId === null) {
+      const result = await this.commandBus.execute<
+        RemoveSupplierFromItemCommand,
+        RemoveSupplierFromItemResult
+      >(
+        new RemoveSupplierFromItemCommand(
+          user.tenantId,
+          propertyId,
+          itemId,
+          user.userId,
+          user.email,
+        ),
+      );
+
+      return {
+        message: 'Inventory item supplier removed successfully',
+        data: result,
+      };
+    }
+
+    const result = await this.commandBus.execute<
+      AssociateSupplierToItemCommand,
+      AssociateSupplierToItemResult
+    >(
+      new AssociateSupplierToItemCommand(
+        user.tenantId,
+        propertyId,
+        itemId,
+        dto.supplierId,
+        user.userId,
+        user.email,
+      ),
+    );
+
+    return {
+      message: 'Inventory item supplier updated successfully',
+      data: result,
+    };
   }
 }

--- a/src/presentation/controllers/suppliers.controller.ts
+++ b/src/presentation/controllers/suppliers.controller.ts
@@ -4,11 +4,15 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  Get,
   Post,
   Patch,
   UseGuards,
+  DefaultValuePipe,
+  ParseIntPipe,
+  Query,
 } from '@nestjs/common';
-import { CommandBus } from '@nestjs/cqrs';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -27,13 +31,18 @@ import { CreateSupplierResult } from '@/application/inventory/commands/create-su
 import { UpdateSupplierDto } from '@/presentation/dtos/update-supplier.dto';
 import { UpdateSupplierCommand } from '@/application/inventory/commands/update-supplier/update-supplier.command';
 import { UpdateSupplierResult } from '@/application/inventory/commands/update-supplier/update-supplier.result';
+import { GetItemsBySupplierQuery } from '@/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.query';
+import { GetItemsBySupplierResult } from '@/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.result';
 
 @ApiTags('suppliers')
 @ApiBearerAuth('JWT-auth')
 @UseGuards(JwtAuthGuard)
 @Controller('suppliers')
 export class SuppliersController {
-  constructor(private readonly commandBus: CommandBus) {}
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
+  ) {}
 
   @Post()
   @UseGuards(PermissionGuard)
@@ -110,6 +119,38 @@ export class SuppliersController {
       message: 'Supplier updated successfully',
       data: {
         supplierId: result.supplierId,
+      },
+    };
+  }
+
+  @Get(':supplierId/items')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_VIEW)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get inventory items by supplier' })
+  @ApiResponse({
+    status: 200,
+    description: 'Supplier items retrieved successfully',
+  })
+  async getSupplierItems(
+    @CurrentUser() user: JwtPayload,
+    @Param('supplierId') supplierId: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    const result: GetItemsBySupplierResult = await this.queryBus.execute<
+      GetItemsBySupplierQuery,
+      GetItemsBySupplierResult
+    >(new GetItemsBySupplierQuery(user.tenantId, supplierId, page, limit));
+
+    return {
+      message: 'Supplier items retrieved successfully',
+      data: result.items,
+      pagination: {
+        total: result.total,
+        page: result.page,
+        limit: result.limit,
+        totalPages: result.totalPages,
       },
     };
   }

--- a/src/presentation/dtos/update-inventory-item-supplier.dto.ts
+++ b/src/presentation/dtos/update-inventory-item-supplier.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { ValidateIf, IsString, MinLength } from 'class-validator';
+
+export class UpdateInventoryItemSupplierDto {
+  @ApiProperty({ nullable: true, example: 'supplier-id-or-null' })
+  @Transform(({ value }: { value: unknown }): unknown =>
+    value === '' ? null : value,
+  )
+  @ValidateIf((_, value) => value !== null)
+  @IsString()
+  @MinLength(1)
+  supplierId!: string | null;
+}

--- a/test/application/inventory/associate-supplier-to-item.handler.spec.ts
+++ b/test/application/inventory/associate-supplier-to-item.handler.spec.ts
@@ -1,0 +1,106 @@
+import { NotFoundException } from '@nestjs/common';
+import { AssociateSupplierToItemHandler } from '@/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.handler';
+import { AssociateSupplierToItemCommand } from '@/application/inventory/commands/associate-supplier-to-item/associate-supplier-to-item.command';
+import { InventoryItemRepository } from '@/domain/inventory/repositories/inventory-item.repository';
+import { PropertyRepository } from '@/domain/property/repositories/property.repository';
+import { SupplierRepository } from '@/domain/inventory/repositories/supplier.repository';
+import { createInventoryItemRepositoryMock } from '@test/shared/mocks/repositories/inventory-item-repository.mock';
+import { createPropertyRepositoryMock } from '@test/shared/mocks/repositories/property-repository.mock';
+import { createSupplierRepositoryMock } from '@test/shared/mocks/repositories/supplier-repository.mock';
+import { createEventEmitterMock } from '@test/shared/mocks/services/event-emitter.mock';
+import { makeProperty } from '@test/shared/fixtures/property.fixture';
+import { makeInventoryItem } from '@test/shared/fixtures/inventory-item.fixture';
+import { makeSupplier } from '@test/shared/fixtures/supplier.fixture';
+
+describe('AssociateSupplierToItemHandler', () => {
+  let handler: AssociateSupplierToItemHandler;
+  let inventoryItemRepository: jest.Mocked<InventoryItemRepository>;
+  let propertyRepository: jest.Mocked<PropertyRepository>;
+  let supplierRepository: jest.Mocked<SupplierRepository>;
+  let eventEmitter: ReturnType<typeof createEventEmitterMock>;
+
+  beforeEach(() => {
+    inventoryItemRepository = createInventoryItemRepositoryMock();
+    propertyRepository = createPropertyRepositoryMock();
+    supplierRepository = createSupplierRepositoryMock();
+    eventEmitter = createEventEmitterMock();
+
+    handler = new AssociateSupplierToItemHandler(
+      inventoryItemRepository,
+      propertyRepository,
+      supplierRepository,
+      eventEmitter as any,
+    );
+  });
+
+  it('associates a supplier to an inventory item', async () => {
+    propertyRepository.findById.mockResolvedValue(
+      makeProperty({ id: 'property-123', tenantId: 'tenant-123' }),
+    );
+    inventoryItemRepository.findById.mockResolvedValue(
+      makeInventoryItem({
+        id: 'item-123',
+        tenantId: 'tenant-123',
+        propertyId: 'property-123',
+      }),
+    );
+    supplierRepository.findById.mockResolvedValue(
+      makeSupplier({ id: 'supplier-123', tenantId: 'tenant-123' }),
+    );
+    inventoryItemRepository.save.mockResolvedValue('item-123');
+    supplierRepository.save.mockResolvedValue('supplier-123');
+
+    const result = await handler.execute(
+      new AssociateSupplierToItemCommand(
+        'tenant-123',
+        'property-123',
+        'item-123',
+        'supplier-123',
+        'admin-user-id',
+        'admin@example.com',
+      ),
+    );
+
+    expect(result.itemId).toBe('item-123');
+    expect(result.supplierId).toBe('supplier-123');
+
+    const savedItem = inventoryItemRepository.save.mock.calls[0][0];
+    expect(savedItem.getSupplierId()?.toString()).toBe('supplier-123');
+
+    expect(supplierRepository.save).toHaveBeenCalledTimes(1);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ entityType: 'SUPPLIER' }),
+    );
+  });
+
+  it('throws NotFoundException when the supplier does not exist', async () => {
+    propertyRepository.findById.mockResolvedValue(
+      makeProperty({ id: 'property-123', tenantId: 'tenant-123' }),
+    );
+    inventoryItemRepository.findById.mockResolvedValue(
+      makeInventoryItem({
+        id: 'item-123',
+        tenantId: 'tenant-123',
+        propertyId: 'property-123',
+      }),
+    );
+    supplierRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(
+        new AssociateSupplierToItemCommand(
+          'tenant-123',
+          'property-123',
+          'item-123',
+          'supplier-123',
+          'admin-user-id',
+          'admin@example.com',
+        ),
+      ),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(inventoryItemRepository.save).not.toHaveBeenCalled();
+    expect(supplierRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/test/application/inventory/get-items-by-supplier.query-handler.spec.ts
+++ b/test/application/inventory/get-items-by-supplier.query-handler.spec.ts
@@ -1,0 +1,66 @@
+import { NotFoundException } from '@nestjs/common';
+import { GetItemsBySupplierQueryHandler } from '@/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.query-handler';
+import { GetItemsBySupplierQuery } from '@/application/inventory/queries/get-items-by-supplier/get-items-by-supplier.query';
+import { InventoryItemRepository } from '@/domain/inventory/repositories/inventory-item.repository';
+import { SupplierRepository } from '@/domain/inventory/repositories/supplier.repository';
+import { createInventoryItemRepositoryMock } from '@test/shared/mocks/repositories/inventory-item-repository.mock';
+import { createSupplierRepositoryMock } from '@test/shared/mocks/repositories/supplier-repository.mock';
+import { makeInventoryItem } from '@test/shared/fixtures/inventory-item.fixture';
+import { makeSupplier } from '@test/shared/fixtures/supplier.fixture';
+
+describe('GetItemsBySupplierQueryHandler', () => {
+  let handler: GetItemsBySupplierQueryHandler;
+  let inventoryItemRepository: jest.Mocked<InventoryItemRepository>;
+  let supplierRepository: jest.Mocked<SupplierRepository>;
+
+  beforeEach(() => {
+    inventoryItemRepository = createInventoryItemRepositoryMock();
+    supplierRepository = createSupplierRepositoryMock();
+
+    handler = new GetItemsBySupplierQueryHandler(
+      inventoryItemRepository,
+      supplierRepository,
+    );
+  });
+
+  it('returns items for the supplier with pagination metadata', async () => {
+    supplierRepository.findById.mockResolvedValue(
+      makeSupplier({ id: 'supplier-123', tenantId: 'tenant-123' }),
+    );
+    inventoryItemRepository.findBySupplierId.mockResolvedValue([
+      makeInventoryItem({
+        id: 'item-1',
+        tenantId: 'tenant-123',
+        supplierId: 'supplier-123',
+      }),
+      makeInventoryItem({
+        id: 'item-2',
+        tenantId: 'tenant-123',
+        supplierId: 'supplier-123',
+      }),
+    ]);
+
+    const result = await handler.execute(
+      new GetItemsBySupplierQuery('tenant-123', 'supplier-123', 1, 10),
+    );
+
+    expect(result.total).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect(inventoryItemRepository.findBySupplierId).toHaveBeenCalledWith(
+      expect.objectContaining({ toString: expect.any(Function) }),
+      expect.objectContaining({ toString: expect.any(Function) }),
+    );
+  });
+
+  it('throws NotFoundException when the supplier does not exist', async () => {
+    supplierRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(
+        new GetItemsBySupplierQuery('tenant-123', 'supplier-123', 1, 10),
+      ),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(inventoryItemRepository.findBySupplierId).not.toHaveBeenCalled();
+  });
+});

--- a/test/application/inventory/remove-supplier-from-item.handler.spec.ts
+++ b/test/application/inventory/remove-supplier-from-item.handler.spec.ts
@@ -1,0 +1,122 @@
+import { NotFoundException } from '@nestjs/common';
+import { RemoveSupplierFromItemHandler } from '@/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.handler';
+import { RemoveSupplierFromItemCommand } from '@/application/inventory/commands/remove-supplier-from-item/remove-supplier-from-item.command';
+import { InventoryItemRepository } from '@/domain/inventory/repositories/inventory-item.repository';
+import { PropertyRepository } from '@/domain/property/repositories/property.repository';
+import { SupplierRepository } from '@/domain/inventory/repositories/supplier.repository';
+import { createInventoryItemRepositoryMock } from '@test/shared/mocks/repositories/inventory-item-repository.mock';
+import { createPropertyRepositoryMock } from '@test/shared/mocks/repositories/property-repository.mock';
+import { createSupplierRepositoryMock } from '@test/shared/mocks/repositories/supplier-repository.mock';
+import { createEventEmitterMock } from '@test/shared/mocks/services/event-emitter.mock';
+import { makeProperty } from '@test/shared/fixtures/property.fixture';
+import { makeInventoryItem } from '@test/shared/fixtures/inventory-item.fixture';
+import { makeSupplier } from '@test/shared/fixtures/supplier.fixture';
+
+describe('RemoveSupplierFromItemHandler', () => {
+  let handler: RemoveSupplierFromItemHandler;
+  let inventoryItemRepository: jest.Mocked<InventoryItemRepository>;
+  let propertyRepository: jest.Mocked<PropertyRepository>;
+  let supplierRepository: jest.Mocked<SupplierRepository>;
+  let eventEmitter: ReturnType<typeof createEventEmitterMock>;
+
+  beforeEach(() => {
+    inventoryItemRepository = createInventoryItemRepositoryMock();
+    propertyRepository = createPropertyRepositoryMock();
+    supplierRepository = createSupplierRepositoryMock();
+    eventEmitter = createEventEmitterMock();
+
+    handler = new RemoveSupplierFromItemHandler(
+      inventoryItemRepository,
+      propertyRepository,
+      supplierRepository,
+      eventEmitter as any,
+    );
+  });
+
+  it('removes the supplier from an inventory item', async () => {
+    propertyRepository.findById.mockResolvedValue(
+      makeProperty({ id: 'property-123', tenantId: 'tenant-123' }),
+    );
+    inventoryItemRepository.findById.mockResolvedValue(
+      makeInventoryItem({
+        id: 'item-123',
+        tenantId: 'tenant-123',
+        propertyId: 'property-123',
+        supplierId: 'supplier-123',
+      }),
+    );
+    supplierRepository.findById.mockResolvedValue(
+      makeSupplier({ id: 'supplier-123', tenantId: 'tenant-123' }),
+    );
+    inventoryItemRepository.save.mockResolvedValue('item-123');
+    supplierRepository.save.mockResolvedValue('supplier-123');
+
+    const result = await handler.execute(
+      new RemoveSupplierFromItemCommand(
+        'tenant-123',
+        'property-123',
+        'item-123',
+        'admin-user-id',
+        'admin@example.com',
+      ),
+    );
+
+    expect(result.itemId).toBe('item-123');
+
+    const savedItem = inventoryItemRepository.save.mock.calls[0][0];
+    expect(savedItem.getSupplierId()).toBeNull();
+    expect(supplierRepository.save).toHaveBeenCalledTimes(1);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ entityType: 'SUPPLIER' }),
+    );
+  });
+
+  it('removes the supplier without touching supplier persistence when none is linked', async () => {
+    propertyRepository.findById.mockResolvedValue(
+      makeProperty({ id: 'property-123', tenantId: 'tenant-123' }),
+    );
+    inventoryItemRepository.findById.mockResolvedValue(
+      makeInventoryItem({
+        id: 'item-123',
+        tenantId: 'tenant-123',
+        propertyId: 'property-123',
+      }),
+    );
+    inventoryItemRepository.save.mockResolvedValue('item-123');
+
+    await handler.execute(
+      new RemoveSupplierFromItemCommand(
+        'tenant-123',
+        'property-123',
+        'item-123',
+        'admin-user-id',
+        'admin@example.com',
+      ),
+    );
+
+    expect(supplierRepository.findById).not.toHaveBeenCalled();
+    expect(supplierRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundException when the item does not exist', async () => {
+    propertyRepository.findById.mockResolvedValue(
+      makeProperty({ id: 'property-123', tenantId: 'tenant-123' }),
+    );
+    inventoryItemRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(
+        new RemoveSupplierFromItemCommand(
+          'tenant-123',
+          'property-123',
+          'item-123',
+          'admin-user-id',
+          'admin@example.com',
+        ),
+      ),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(inventoryItemRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/test/shared/fixtures/inventory-item.fixture.ts
+++ b/test/shared/fixtures/inventory-item.fixture.ts
@@ -2,12 +2,12 @@ import { InventoryItem } from '@/domain/inventory/entities/inventory-item.entity
 import { InventoryItemId } from '@/domain/inventory/value-objects/inventory-item-id.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { SupplierId } from '@/domain/inventory/value-objects/supplier-id.vo';
 import { PROPERTY_FIXTURE_DEFAULTS } from '@test/shared/fixtures/property.fixture';
 import { TENANT_FIXTURE_DEFAULTS } from '@test/shared/fixtures/tenant.fixture';
-import { randomUUID } from 'crypto';
 
 export const INVENTORY_ITEM_FIXTURE_DEFAULTS = {
-  id: randomUUID(),
+  id: 'inventory-item-default',
   tenantId: TENANT_FIXTURE_DEFAULTS.id,
   propertyId: PROPERTY_FIXTURE_DEFAULTS.id,
   sku: 'SKU-001',
@@ -16,6 +16,7 @@ export const INVENTORY_ITEM_FIXTURE_DEFAULTS = {
   unit: 'unidad',
   minStock: 5,
   currentStock: 20,
+  supplierId: null,
 };
 
 export function makeInventoryItem(
@@ -29,21 +30,31 @@ export function makeInventoryItem(
     unit: string;
     minStock: number;
     currentStock: number;
+    supplierId: string | null;
   }>,
 ): InventoryItem {
   const merged = { ...INVENTORY_ITEM_FIXTURE_DEFAULTS, ...overrides };
 
-  return InventoryItem.reconstitute(
-    InventoryItemId.create(merged.id),
-    TenantId.createFromString(merged.tenantId),
-    PropertyId.create(merged.propertyId),
-    merged.sku,
-    merged.name,
-    merged.category,
-    merged.unit,
-    merged.minStock,
-    merged.currentStock,
-    new Date(),
-    new Date(),
-  );
+  return InventoryItem.reconstitute({
+    identity: {
+      id: InventoryItemId.create(merged.id),
+      tenantId: TenantId.createFromString(merged.tenantId),
+      propertyId: PropertyId.create(merged.propertyId),
+    },
+    profile: {
+      sku: merged.sku,
+      name: merged.name,
+      category: merged.category,
+      unit: merged.unit,
+      minStock: merged.minStock,
+      currentStock: merged.currentStock,
+      supplierId: merged.supplierId
+        ? SupplierId.create(merged.supplierId)
+        : null,
+    },
+    timestamps: {
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
 }

--- a/test/shared/mocks/repositories/inventory-item-repository.mock.ts
+++ b/test/shared/mocks/repositories/inventory-item-repository.mock.ts
@@ -7,6 +7,7 @@ export function createInventoryItemRepositoryMock(): jest.Mocked<InventoryItemRe
     findByPropertyId: jest.fn(),
     findLowStockByPropertyId: jest.fn(),
     findByPropertyIdAndSku: jest.fn(),
+    findBySupplierId: jest.fn(),
     delete: jest.fn(),
   };
 }


### PR DESCRIPTION
This pull request introduces a new feature to support an optional association between `InventoryItem` and `Supplier`, allowing inventory items to be linked to suppliers, unlinked, and queried by supplier. The association is managed via explicit commands and is reflected in the application and domain layers, with proper validation, auditing, and minimal synchronization. Additionally, a new ADR documents the design decision and rationale.

**Inventory Item–Supplier Association**

- Added support for associating and removing a supplier from an inventory item via new commands (`AssociateSupplierToItemCommand`, `RemoveSupplierFromItemCommand`) and their respective handlers, including validation, persistence, and audit logging. [[1]](diffhunk://#diff-8ec7767360f2f0d9309270f3eeb5abb440c9f946b173233a0a05eb5b89bce3b2R1-R12) [[2]](diffhunk://#diff-0d37eb2b285c8a9737cb4e7fd694ed5dfed400c3670922d966ddbc8c73d068f3R1-R225) [[3]](diffhunk://#diff-65375f85be8fbd95f9da0c32bf146fa8a53106000c56deef70ebe925797d3b5fR1-R6) [[4]](diffhunk://#diff-0e3545053f48f4ae14930e9fe8c3dce1561a1c3391a4c4ba9ac2f764f318f77eR1-R11) [[5]](diffhunk://#diff-fd751e58a81a205df6a9a7e7b9da43c9532ec7f069e1b753bae0461797574440R1-R193) [[6]](diffhunk://#diff-0989ef8c5f83fc6346b18dce74685aebc75e5a7127f4c03765625d4e19f9bb13R1-R3)
- The handlers ensure that tenant, property, item, and supplier are validated before mutating state, and that changes are audited and supplier metadata is minimally synchronized (i.e., only `updatedAt` is changed). [[1]](diffhunk://#diff-0d37eb2b285c8a9737cb4e7fd694ed5dfed400c3670922d966ddbc8c73d068f3R1-R225) [[2]](diffhunk://#diff-fd751e58a81a205df6a9a7e7b9da43c9532ec7f069e1b753bae0461797574440R1-R193)

**Querying Items by Supplier**

- Introduced a new query and handler (`GetItemsBySupplierQueryHandler`) to retrieve inventory items associated with a given supplier, supporting pagination and proper validation.

**Module Registration**

- Registered the new command and query handlers in the `inventory-application.module.ts` to ensure they are available in the application layer. [[1]](diffhunk://#diff-1e71514cbfe351207649f79a74e34d286843ef89bbbfa8fd1794c5e571f0b0ebR10-R14) [[2]](diffhunk://#diff-1e71514cbfe351207649f79a74e34d286843ef89bbbfa8fd1794c5e571f0b0ebR23-R30)

**Architecture Decision Record**

- Added ADR-013 documenting the decision to model the supplier association as an optional field (`supplierId`) on `InventoryItem`, with rationale, alternatives considered, and implementation notes.