### PR TITLE
LYMON-696-parameters-for-get-suppliers

### DIFF
--- a/src/application/inventory/queries/get-suppliers/get-suppliers.query-handler.ts
+++ b/src/application/inventory/queries/get-suppliers/get-suppliers.query-handler.ts
@@ -25,7 +25,7 @@ export class GetSuppliersQueryHandler implements IQueryHandler<
   async execute(query: GetSuppliersQuery): Promise<GetSuppliersResult> {
     const tenantId = TenantId.createFromString(query.tenantId);
     const page = query.page > 0 ? query.page : 1;
-    const limit = query.limit > 0 ? query.limit : 20;
+    const limit = query.limit > 0 ? query.limit : 10;
     const normalizedSearch = query.search?.trim().toLowerCase() ?? '';
 
     const suppliers: Supplier[] = await this.supplierRepository.findByTenantId(

--- a/src/application/inventory/queries/get-suppliers/get-suppliers.query.ts
+++ b/src/application/inventory/queries/get-suppliers/get-suppliers.query.ts
@@ -7,7 +7,7 @@ export class GetSuppliersQuery implements IQuery {
   constructor(
     public readonly tenantId: string,
     public readonly page: number = 1,
-    public readonly limit: number = 20,
+    public readonly limit: number = 10,
     public readonly search?: string,
     public readonly sortBy: SupplierSortBy = 'createdAt',
     public readonly sortOrder: SupplierSortOrder = 'desc',

--- a/src/presentation/controllers/suppliers.controller.ts
+++ b/src/presentation/controllers/suppliers.controller.ts
@@ -16,6 +16,7 @@ import {
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBearerAuth,
+  ApiQuery,
   ApiOperation,
   ApiResponse,
   ApiTags,
@@ -57,11 +58,41 @@ export class SuppliersController {
   @RequirePermission(Permission.PROPERTY_VIEW)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Get suppliers list' })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number for pagination',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page (default: 10)',
+  })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: 'Search suppliers by name',
+  })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    enum: ['name', 'createdAt'],
+    description: 'Sort field (default: createdAt)',
+  })
+  @ApiQuery({
+    name: 'sortOrder',
+    required: false,
+    enum: ['asc', 'desc'],
+    description: 'Sort order (default: desc)',
+  })
   @ApiResponse({ status: 200, description: 'Suppliers retrieved successfully' })
   async getSuppliers(
     @CurrentUser() user: JwtPayload,
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
-    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page?: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit?: number,
     @Query('search') search?: string,
     @Query('sortBy') sortBy?: SupplierSortBy,
     @Query('sortOrder') sortOrder?: SupplierSortOrder,

--- a/test/application/inventory/get-suppliers.query-handler.spec.ts
+++ b/test/application/inventory/get-suppliers.query-handler.spec.ts
@@ -40,7 +40,7 @@ describe('GetSuppliersQueryHandler', () => {
     supplierRepository.findByTenantId.mockResolvedValue([]);
 
     const result = await handler.execute(
-      new GetSuppliersQuery('tenant-123', 1, 20),
+      new GetSuppliersQuery('tenant-123', 1, 10),
     );
 
     expect(result.total).toBe(0);
@@ -55,7 +55,7 @@ describe('GetSuppliersQueryHandler', () => {
     ]);
 
     const result = await handler.execute(
-      new GetSuppliersQuery('tenant-123', 1, 20, 'fresh'),
+      new GetSuppliersQuery('tenant-123', 1, 10, 'fresh'),
     );
 
     expect(result.total).toBe(1);
@@ -69,7 +69,7 @@ describe('GetSuppliersQueryHandler', () => {
     ]);
 
     const result = await handler.execute(
-      new GetSuppliersQuery('tenant-123', 1, 20, undefined, 'name', 'asc'),
+      new GetSuppliersQuery('tenant-123', 1, 10, undefined, 'name', 'asc'),
     );
 
     expect(result.suppliers.map((supplier) => supplier.name)).toEqual([
@@ -94,7 +94,7 @@ describe('GetSuppliersQueryHandler', () => {
       new GetSuppliersQuery(
         'tenant-123',
         1,
-        20,
+        10,
         undefined,
         'createdAt',
         'desc',
@@ -105,5 +105,17 @@ describe('GetSuppliersQueryHandler', () => {
       'Newer Supplier',
       'Older Supplier',
     ]);
+  });
+
+  it('defaults to page 1 and limit 10 when not provided', async () => {
+    supplierRepository.findByTenantId.mockResolvedValue([
+      makeSupplier({ name: 'Solo Supplier' }),
+    ]);
+
+    const result = await handler.execute(new GetSuppliersQuery('tenant-123'));
+
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(10);
+    expect(result.suppliers).toHaveLength(1);
   });
 });

--- a/test/presentation/controllers/suppliers.controller.spec.ts
+++ b/test/presentation/controllers/suppliers.controller.spec.ts
@@ -45,14 +45,14 @@ describe('SuppliersController', () => {
       ],
       total: 1,
       page: 1,
-      limit: 20,
+      limit: 10,
       totalPages: 1,
     });
 
     const result = await controller.getSuppliers(
       user,
       1,
-      20,
+      10,
       'fresh',
       'name',
       'asc',
@@ -74,10 +74,26 @@ describe('SuppliersController', () => {
       pagination: {
         total: 1,
         page: 1,
-        limit: 20,
+        limit: 10,
         totalPages: 1,
       },
     });
+  });
+
+  it('uses default pagination when page and limit are omitted', async () => {
+    queryBus.execute.mockResolvedValue({
+      suppliers: [],
+      total: 0,
+      page: 1,
+      limit: 10,
+      totalPages: 0,
+    });
+
+    const result = await controller.getSuppliers(user);
+
+    expect(queryBus.execute).toHaveBeenCalledTimes(1);
+    expect(result.pagination.limit).toBe(10);
+    expect(result.pagination.page).toBe(1);
   });
 
   it('creates a supplier and returns supplier id', async () => {


### PR DESCRIPTION
This pull request updates the default pagination behavior for fetching suppliers, standardizing the default page size to 10 items instead of 20. It also improves API documentation and ensures that both the application logic and tests reflect these changes.

**Pagination and API Improvements:**

* Changed the default `limit` for supplier queries from 20 to 10 in the `GetSuppliersQuery` constructor, the query handler, and the controller, ensuring consistency throughout the application. [[1]](diffhunk://#diff-4e43a43d35a939bc1b6ee4b7cd97f1650dd5d843aa225662ebde733c5c4b3f0dL10-R10) [[2]](diffhunk://#diff-b2f8b7e224e4f33ae02459bfc57bd865e8918c4773f3e80e3ae3327259227553L28-R28) [[3]](diffhunk://#diff-728cb4dc66c27b6c32884d34244ad498d912f1eaf4f5581e832d4258bc57c2d2R61-R95)
* Updated Swagger API documentation in `SuppliersController` to accurately describe the new default pagination and query parameters, making the API easier to use and understand. [[1]](diffhunk://#diff-728cb4dc66c27b6c32884d34244ad498d912f1eaf4f5581e832d4258bc57c2d2R19) [[2]](diffhunk://#diff-728cb4dc66c27b6c32884d34244ad498d912f1eaf4f5581e832d4258bc57c2d2R61-R95)

**Testing Updates:**

* Modified unit tests for the query handler and controller to use the new default limit of 10, ensuring that tests remain accurate and up-to-date. [[1]](diffhunk://#diff-8b953929a2486107eadb899319459bdf776a88af0f403bb6088ccdd90bd097e0L43-R43) [[2]](diffhunk://#diff-8b953929a2486107eadb899319459bdf776a88af0f403bb6088ccdd90bd097e0L58-R58) [[3]](diffhunk://#diff-8b953929a2486107eadb899319459bdf776a88af0f403bb6088ccdd90bd097e0L72-R72) [[4]](diffhunk://#diff-8b953929a2486107eadb899319459bdf776a88af0f403bb6088ccdd90bd097e0L97-R97) [[5]](diffhunk://#diff-062b1bfad71efd3b52120341c28db5ba2497b781ebe6b0f291133fd45712bb93L48-R55) [[6]](diffhunk://#diff-062b1bfad71efd3b52120341c28db5ba2497b781ebe6b0f291133fd45712bb93L77-R98)
* Added new tests to verify that the default pagination values (page 1, limit 10) are correctly applied when not provided by the user. [[1]](diffhunk://#diff-8b953929a2486107eadb899319459bdf776a88af0f403bb6088ccdd90bd097e0R109-R120) [[2]](diffhunk://#diff-062b1bfad71efd3b52120341c28db5ba2497b781ebe6b0f291133fd45712bb93L77-R98)