### PR TITLE
Lymon 591 add explicit edit and delete actions to guest note cards

### DIFF
--- a/src/application/guest-note/commands/delete-guest-note.command.ts
+++ b/src/application/guest-note/commands/delete-guest-note.command.ts
@@ -1,0 +1,7 @@
+export class DeleteGuestNoteCommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly noteId: string,
+    public readonly actorId: string,
+  ) {}
+}

--- a/src/application/guest-note/commands/delete-guest-note.handler.ts
+++ b/src/application/guest-note/commands/delete-guest-note.handler.ts
@@ -1,0 +1,31 @@
+import { Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { DeleteGuestNoteCommand } from './delete-guest-note.command';
+import {
+  GUEST_NOTE_REPOSITORY,
+  type GuestNoteRepository,
+} from '@/domain/guest-note/repositories/guest-note.repository';
+import { GuestNoteId } from '@/domain/guest-note/value-objects/guest-note-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+
+@CommandHandler(DeleteGuestNoteCommand)
+export class DeleteGuestNoteHandler
+  implements ICommandHandler<DeleteGuestNoteCommand, void>
+{
+  constructor(
+    @Inject(GUEST_NOTE_REPOSITORY)
+    private readonly guestNoteRepository: GuestNoteRepository,
+  ) {}
+
+  async execute(command: DeleteGuestNoteCommand): Promise<void> {
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const noteId = GuestNoteId.createFromString(command.noteId);
+
+    const guestNote = await this.guestNoteRepository.findById(noteId, tenantId);
+    if (!guestNote) {
+      throw new NotFoundException('Guest note not found');
+    }
+
+    await this.guestNoteRepository.delete(noteId, tenantId);
+  }
+}

--- a/src/application/guest-note/commands/toggle-pin-guest-note.command.ts
+++ b/src/application/guest-note/commands/toggle-pin-guest-note.command.ts
@@ -1,0 +1,7 @@
+export class TogglePinGuestNoteCommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly noteId: string,
+    public readonly actorId: string,
+  ) {}
+}

--- a/src/application/guest-note/commands/toggle-pin-guest-note.handler.ts
+++ b/src/application/guest-note/commands/toggle-pin-guest-note.handler.ts
@@ -1,0 +1,32 @@
+import { Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { TogglePinGuestNoteCommand } from './toggle-pin-guest-note.command';
+import {
+  GUEST_NOTE_REPOSITORY,
+  type GuestNoteRepository,
+} from '@/domain/guest-note/repositories/guest-note.repository';
+import { GuestNoteId } from '@/domain/guest-note/value-objects/guest-note-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+
+@CommandHandler(TogglePinGuestNoteCommand)
+export class TogglePinGuestNoteHandler
+  implements ICommandHandler<TogglePinGuestNoteCommand, void>
+{
+  constructor(
+    @Inject(GUEST_NOTE_REPOSITORY)
+    private readonly guestNoteRepository: GuestNoteRepository,
+  ) {}
+
+  async execute(command: TogglePinGuestNoteCommand): Promise<void> {
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const noteId = GuestNoteId.createFromString(command.noteId);
+
+    const guestNote = await this.guestNoteRepository.findById(noteId, tenantId);
+    if (!guestNote) {
+      throw new NotFoundException('Guest note not found');
+    }
+
+    guestNote.togglePin();
+    await this.guestNoteRepository.save(guestNote);
+  }
+}

--- a/src/application/guest-note/commands/update-guest-note.command.ts
+++ b/src/application/guest-note/commands/update-guest-note.command.ts
@@ -1,0 +1,11 @@
+import { GuestNoteTypeEnum } from '@/domain/guest-note/value-objects/guest-node-type.vo';
+
+export class UpdateGuestNoteCommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly noteId: string,
+    public readonly actorId: string,
+    public readonly note: string | undefined,
+    public readonly type: GuestNoteTypeEnum | undefined,
+  ) {}
+}

--- a/src/application/guest-note/commands/update-guest-note.handler.ts
+++ b/src/application/guest-note/commands/update-guest-note.handler.ts
@@ -1,0 +1,45 @@
+import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { UpdateGuestNoteCommand } from './update-guest-note.command';
+import {
+  GUEST_NOTE_REPOSITORY,
+  type GuestNoteRepository,
+} from '@/domain/guest-note/repositories/guest-note.repository';
+import { GuestNoteId } from '@/domain/guest-note/value-objects/guest-note-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+
+@CommandHandler(UpdateGuestNoteCommand)
+export class UpdateGuestNoteHandler
+  implements ICommandHandler<UpdateGuestNoteCommand, void>
+{
+  constructor(
+    @Inject(GUEST_NOTE_REPOSITORY)
+    private readonly guestNoteRepository: GuestNoteRepository,
+  ) {}
+
+  async execute(command: UpdateGuestNoteCommand): Promise<void> {
+    if (command.note === undefined && command.type === undefined) {
+      throw new BadRequestException(
+        'At least one field (note or type) must be provided',
+      );
+    }
+
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const noteId = GuestNoteId.createFromString(command.noteId);
+
+    const guestNote = await this.guestNoteRepository.findById(noteId, tenantId);
+    if (!guestNote) {
+      throw new NotFoundException('Guest note not found');
+    }
+
+    if (command.note !== undefined) {
+      guestNote.updateContent(command.note);
+    }
+
+    if (command.type !== undefined) {
+      guestNote.changeType(command.type);
+    }
+
+    await this.guestNoteRepository.save(guestNote);
+  }
+}

--- a/src/application/guest-note/guest-note-application.module.ts
+++ b/src/application/guest-note/guest-note-application.module.ts
@@ -2,9 +2,17 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { CreateGuestNoteHandler } from '@/application/guest-note/commands/create-guest-note.handler';
+import { UpdateGuestNoteHandler } from '@/application/guest-note/commands/update-guest-note.handler';
+import { DeleteGuestNoteHandler } from '@/application/guest-note/commands/delete-guest-note.handler';
+import { TogglePinGuestNoteHandler } from '@/application/guest-note/commands/toggle-pin-guest-note.handler';
 import { GetGuestNotesByGuestIdHandler } from '@/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.handler';
 
-const CommandHandlers = [CreateGuestNoteHandler];
+const CommandHandlers = [
+  CreateGuestNoteHandler,
+  UpdateGuestNoteHandler,
+  DeleteGuestNoteHandler,
+  TogglePinGuestNoteHandler,
+];
 const QueryHandlers = [GetGuestNotesByGuestIdHandler];
 
 @Module({

--- a/src/domain/guest-note/entities/guest-note.entity.ts
+++ b/src/domain/guest-note/entities/guest-note.entity.ts
@@ -125,8 +125,15 @@ export class GuestNote {
     this.touch();
   }
 
+  togglePin(): void {
+    this.status =
+      this.status === GuestNoteStatusEnum.IS_PINNED
+        ? GuestNoteStatusEnum.NOT_PINNED
+        : GuestNoteStatusEnum.IS_PINNED;
+    this.touch();
+  }
+
   softDelete(): void {
-    this.status = GuestNoteStatusEnum.IS_PINNED;
     this.deletedAt = new Date();
     this.touch();
   }

--- a/src/infrastructure/persistence/repositories/mongo-guest-note.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-guest-note.repository.ts
@@ -47,6 +47,7 @@ export class MongoGuestNoteRepository implements GuestNoteRepository {
     const doc = await this.noteModel.findOne({
       _id: new Types.ObjectId(id.toString()),
       tenantId: new Types.ObjectId(tenantId.toString()),
+      deletedAt: null,
     });
 
     return doc ? this.toDomain(doc) : null;
@@ -90,10 +91,13 @@ export class MongoGuestNoteRepository implements GuestNoteRepository {
   }
 
   async delete(id: GuestNoteId, tenantId: TenantId): Promise<void> {
-    await this.noteModel.deleteOne({
-      _id: new Types.ObjectId(id.toString()),
-      tenantId: new Types.ObjectId(tenantId.toString()),
-    });
+    await this.noteModel.findOneAndUpdate(
+      {
+        _id: new Types.ObjectId(id.toString()),
+        tenantId: new Types.ObjectId(tenantId.toString()),
+      },
+      { deletedAt: new Date(), updatedAt: new Date() },
+    );
   }
 
   private toDomain(doc: GuestNoteDocument): GuestNote {

--- a/src/presentation/controllers/crm.controller.ts
+++ b/src/presentation/controllers/crm.controller.ts
@@ -9,7 +9,10 @@ import {
   Body,
   Controller,
   DefaultValuePipe,
+  Delete,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   ParseIntPipe,
   Patch,
@@ -28,7 +31,11 @@ import { AssignGuestTagsCommand } from '@/application/guest/commands/assign-gues
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { CreateGuestNoteCommand } from '@/application/guest-note/commands/create-guest-note.command';
 import { CreateGuestNoteResult } from '@/application/guest-note/commands/create-guest-note.result';
+import { UpdateGuestNoteCommand } from '@/application/guest-note/commands/update-guest-note.command';
+import { DeleteGuestNoteCommand } from '@/application/guest-note/commands/delete-guest-note.command';
+import { TogglePinGuestNoteCommand } from '@/application/guest-note/commands/toggle-pin-guest-note.command';
 import { CreateGuestNoteDto } from '@/presentation/dtos/create-guest-note.dto';
+import { UpdateGuestNoteDto } from '@/presentation/dtos/update-guest-note.dto';
 import { GetGuestBookingsQuery } from '@/application/guest/queries/get-guest-bookings/get-guest-bookings.query';
 import { GetGuestBookingsResult } from '@/application/guest/queries/get-guest-bookings/get-guest-bookings.result';
 import { GetGuestNotesByGuestIdQuery } from '@/application/guest-note/queries/get-guest-notes-by-guest-id/get-guest-notes-by-guest-id.query';
@@ -139,6 +146,62 @@ export class CrmController {
       message: 'Internal note added successfully',
       data: result,
     };
+  }
+
+  @Patch('guests/:guestId/notes/:noteId')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.CRM_MANAGE)
+  @ApiOperation({ summary: 'Edit a guest note' })
+  @ApiResponse({ status: 200, description: 'Guest note updated successfully' })
+  @ApiResponse({ status: 400, description: 'No fields provided or invalid type' })
+  @ApiResponse({ status: 404, description: 'Guest note not found' })
+  async updateGuestNote(
+    @Param('noteId') noteId: string,
+    @Body() dto: UpdateGuestNoteDto,
+    @CurrentUser() user: JwtPayload,
+  ) {
+    await this.commandBus.execute<UpdateGuestNoteCommand, void>(
+      new UpdateGuestNoteCommand(
+        user.tenantId,
+        noteId,
+        user.userId,
+        dto.note,
+        dto.type,
+      ),
+    );
+    return { message: 'Guest note updated successfully' };
+  }
+
+  @Delete('guests/:guestId/notes/:noteId')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.CRM_MANAGE)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Soft delete a guest note' })
+  @ApiResponse({ status: 204, description: 'Guest note deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Guest note not found' })
+  async deleteGuestNote(
+    @Param('noteId') noteId: string,
+    @CurrentUser() user: JwtPayload,
+  ) {
+    await this.commandBus.execute<DeleteGuestNoteCommand, void>(
+      new DeleteGuestNoteCommand(user.tenantId, noteId, user.userId),
+    );
+  }
+
+  @Patch('guests/:guestId/notes/:noteId/pin')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.CRM_MANAGE)
+  @ApiOperation({ summary: 'Toggle pin/unpin on a guest note' })
+  @ApiResponse({ status: 200, description: 'Guest note pin status toggled' })
+  @ApiResponse({ status: 404, description: 'Guest note not found' })
+  async togglePinGuestNote(
+    @Param('noteId') noteId: string,
+    @CurrentUser() user: JwtPayload,
+  ) {
+    await this.commandBus.execute<TogglePinGuestNoteCommand, void>(
+      new TogglePinGuestNoteCommand(user.tenantId, noteId, user.userId),
+    );
+    return { message: 'Guest note pin status toggled' };
   }
 
   @Get('guests/:guestId/notes')

--- a/src/presentation/dtos/update-guest-note.dto.ts
+++ b/src/presentation/dtos/update-guest-note.dto.ts
@@ -1,0 +1,23 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, MinLength } from 'class-validator';
+import { GuestNoteTypeEnum } from '@/domain/guest-note/value-objects/guest-node-type.vo';
+
+export class UpdateGuestNoteDto {
+  @ApiPropertyOptional({
+    example: 'Guest requested extra towels at check-in',
+    description: 'Updated note content',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  note?: string;
+
+  @ApiPropertyOptional({
+    enum: GuestNoteTypeEnum,
+    example: GuestNoteTypeEnum.PREFERENCE,
+    description: 'Updated note category',
+  })
+  @IsOptional()
+  @IsEnum(GuestNoteTypeEnum)
+  type?: GuestNoteTypeEnum;
+}

--- a/test/application/guest-note/delete-guest-note.handler.spec.ts
+++ b/test/application/guest-note/delete-guest-note.handler.spec.ts
@@ -1,0 +1,55 @@
+import { NotFoundException } from '@nestjs/common';
+import { DeleteGuestNoteHandler } from '@/application/guest-note/commands/delete-guest-note.handler';
+import { DeleteGuestNoteCommand } from '@/application/guest-note/commands/delete-guest-note.command';
+import { GuestNoteRepository } from '@/domain/guest-note/repositories/guest-note.repository';
+import { createGuestNoteRepositoryMock } from '@test/shared/mocks/repositories/guest-note-repository.mock';
+import {
+  makeGuestNote,
+  GUEST_NOTE_FIXTURE_DEFAULTS,
+} from '@test/shared/fixtures/guest-note.fixture';
+
+describe('DeleteGuestNoteHandler', () => {
+  let handler: DeleteGuestNoteHandler;
+  let guestNoteRepository: jest.Mocked<GuestNoteRepository>;
+
+  beforeEach(() => {
+    guestNoteRepository = createGuestNoteRepositoryMock();
+    handler = new DeleteGuestNoteHandler(guestNoteRepository);
+  });
+
+  describe('when the note does not exist', () => {
+    it('throws NotFoundException and does not call delete', async () => {
+      guestNoteRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        handler.execute(
+          new DeleteGuestNoteCommand(
+            GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+            GUEST_NOTE_FIXTURE_DEFAULTS.id,
+            'user-456',
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(guestNoteRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the note exists', () => {
+    it('calls repository.delete and resolves without a return value', async () => {
+      guestNoteRepository.findById.mockResolvedValue(makeGuestNote());
+
+      await expect(
+        handler.execute(
+          new DeleteGuestNoteCommand(
+            GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+            GUEST_NOTE_FIXTURE_DEFAULTS.id,
+            'user-456',
+          ),
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(guestNoteRepository.delete).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/application/guest-note/toggle-pin-guest-note.handler.spec.ts
+++ b/test/application/guest-note/toggle-pin-guest-note.handler.spec.ts
@@ -1,0 +1,76 @@
+import { NotFoundException } from '@nestjs/common';
+import { TogglePinGuestNoteHandler } from '@/application/guest-note/commands/toggle-pin-guest-note.handler';
+import { TogglePinGuestNoteCommand } from '@/application/guest-note/commands/toggle-pin-guest-note.command';
+import { GuestNoteRepository } from '@/domain/guest-note/repositories/guest-note.repository';
+import { GuestNoteStatusEnum } from '@/domain/guest-note/value-objects/guest-node-status.vo';
+import { createGuestNoteRepositoryMock } from '@test/shared/mocks/repositories/guest-note-repository.mock';
+import {
+  makeGuestNote,
+  GUEST_NOTE_FIXTURE_DEFAULTS,
+} from '@test/shared/fixtures/guest-note.fixture';
+
+describe('TogglePinGuestNoteHandler', () => {
+  let handler: TogglePinGuestNoteHandler;
+  let guestNoteRepository: jest.Mocked<GuestNoteRepository>;
+
+  beforeEach(() => {
+    guestNoteRepository = createGuestNoteRepositoryMock();
+    handler = new TogglePinGuestNoteHandler(guestNoteRepository);
+  });
+
+  describe('when the note does not exist', () => {
+    it('throws NotFoundException and does not call save', async () => {
+      guestNoteRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        handler.execute(
+          new TogglePinGuestNoteCommand(
+            GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+            GUEST_NOTE_FIXTURE_DEFAULTS.id,
+            'user-456',
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(guestNoteRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the note is NOT_PINNED', () => {
+    it('pins the note and saves', async () => {
+      const guestNote = makeGuestNote({ status: GuestNoteStatusEnum.NOT_PINNED });
+      guestNoteRepository.findById.mockResolvedValue(guestNote);
+
+      await handler.execute(
+        new TogglePinGuestNoteCommand(
+          GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+          GUEST_NOTE_FIXTURE_DEFAULTS.id,
+          'user-456',
+        ),
+      );
+
+      expect(guestNoteRepository.save).toHaveBeenCalledTimes(1);
+      const saved = guestNoteRepository.save.mock.calls[0][0];
+      expect(saved.getStatus()).toBe(GuestNoteStatusEnum.IS_PINNED);
+    });
+  });
+
+  describe('when the note is IS_PINNED', () => {
+    it('unpins the note and saves', async () => {
+      const guestNote = makeGuestNote({ status: GuestNoteStatusEnum.IS_PINNED });
+      guestNoteRepository.findById.mockResolvedValue(guestNote);
+
+      await handler.execute(
+        new TogglePinGuestNoteCommand(
+          GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+          GUEST_NOTE_FIXTURE_DEFAULTS.id,
+          'user-456',
+        ),
+      );
+
+      expect(guestNoteRepository.save).toHaveBeenCalledTimes(1);
+      const saved = guestNoteRepository.save.mock.calls[0][0];
+      expect(saved.getStatus()).toBe(GuestNoteStatusEnum.NOT_PINNED);
+    });
+  });
+});

--- a/test/application/guest-note/update-guest-note.handler.spec.ts
+++ b/test/application/guest-note/update-guest-note.handler.spec.ts
@@ -1,0 +1,124 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { UpdateGuestNoteHandler } from '@/application/guest-note/commands/update-guest-note.handler';
+import { UpdateGuestNoteCommand } from '@/application/guest-note/commands/update-guest-note.command';
+import { GuestNoteRepository } from '@/domain/guest-note/repositories/guest-note.repository';
+import { GuestNoteTypeEnum } from '@/domain/guest-note/value-objects/guest-node-type.vo';
+import { createGuestNoteRepositoryMock } from '@test/shared/mocks/repositories/guest-note-repository.mock';
+import {
+  makeGuestNote,
+  GUEST_NOTE_FIXTURE_DEFAULTS,
+} from '@test/shared/fixtures/guest-note.fixture';
+
+describe('UpdateGuestNoteHandler', () => {
+  let handler: UpdateGuestNoteHandler;
+  let guestNoteRepository: jest.Mocked<GuestNoteRepository>;
+
+  beforeEach(() => {
+    guestNoteRepository = createGuestNoteRepositoryMock();
+    handler = new UpdateGuestNoteHandler(guestNoteRepository);
+  });
+
+  describe('when no fields are provided', () => {
+    it('throws BadRequestException', async () => {
+      await expect(
+        handler.execute(
+          new UpdateGuestNoteCommand(
+            GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+            GUEST_NOTE_FIXTURE_DEFAULTS.id,
+            'user-456',
+            undefined,
+            undefined,
+          ),
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(guestNoteRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the note does not exist', () => {
+    it('throws NotFoundException', async () => {
+      guestNoteRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        handler.execute(
+          new UpdateGuestNoteCommand(
+            GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+            GUEST_NOTE_FIXTURE_DEFAULTS.id,
+            'user-456',
+            'Updated content',
+            undefined,
+          ),
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(guestNoteRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when only note text is updated', () => {
+    it('updates the note content and saves', async () => {
+      const guestNote = makeGuestNote();
+      guestNoteRepository.findById.mockResolvedValue(guestNote);
+
+      await handler.execute(
+        new UpdateGuestNoteCommand(
+          GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+          GUEST_NOTE_FIXTURE_DEFAULTS.id,
+          'user-456',
+          'New note content',
+          undefined,
+        ),
+      );
+
+      expect(guestNoteRepository.save).toHaveBeenCalledTimes(1);
+      const saved = guestNoteRepository.save.mock.calls[0][0];
+      expect(saved.getNote()).toBe('New note content');
+      expect(saved.getType()).toBe(GUEST_NOTE_FIXTURE_DEFAULTS.type);
+    });
+  });
+
+  describe('when only type is updated', () => {
+    it('updates the note type and saves', async () => {
+      const guestNote = makeGuestNote();
+      guestNoteRepository.findById.mockResolvedValue(guestNote);
+
+      await handler.execute(
+        new UpdateGuestNoteCommand(
+          GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+          GUEST_NOTE_FIXTURE_DEFAULTS.id,
+          'user-456',
+          undefined,
+          GuestNoteTypeEnum.INCIDENT,
+        ),
+      );
+
+      expect(guestNoteRepository.save).toHaveBeenCalledTimes(1);
+      const saved = guestNoteRepository.save.mock.calls[0][0];
+      expect(saved.getType()).toBe(GuestNoteTypeEnum.INCIDENT);
+      expect(saved.getNote()).toBe(GUEST_NOTE_FIXTURE_DEFAULTS.note);
+    });
+  });
+
+  describe('when both note and type are updated', () => {
+    it('updates both fields and saves once', async () => {
+      const guestNote = makeGuestNote();
+      guestNoteRepository.findById.mockResolvedValue(guestNote);
+
+      await handler.execute(
+        new UpdateGuestNoteCommand(
+          GUEST_NOTE_FIXTURE_DEFAULTS.tenantId,
+          GUEST_NOTE_FIXTURE_DEFAULTS.id,
+          'user-456',
+          'Updated note text',
+          GuestNoteTypeEnum.BEHAVIOR,
+        ),
+      );
+
+      expect(guestNoteRepository.save).toHaveBeenCalledTimes(1);
+      const saved = guestNoteRepository.save.mock.calls[0][0];
+      expect(saved.getNote()).toBe('Updated note text');
+      expect(saved.getType()).toBe(GuestNoteTypeEnum.BEHAVIOR);
+    });
+  });
+});

--- a/test/shared/fixtures/guest-note.fixture.ts
+++ b/test/shared/fixtures/guest-note.fixture.ts
@@ -1,0 +1,35 @@
+import { GuestNote } from '@/domain/guest-note/entities/guest-note.entity';
+import { GuestNoteId } from '@/domain/guest-note/value-objects/guest-note-id.vo';
+import { GuestNoteTypeEnum } from '@/domain/guest-note/value-objects/guest-node-type.vo';
+import { GuestNoteStatusEnum } from '@/domain/guest-note/value-objects/guest-node-status.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
+
+export const GUEST_NOTE_FIXTURE_DEFAULTS = {
+  id: '65f1a1a2b3c4d5e6f7a8b9c1',
+  tenantId: 'tenant-123',
+  guestId: '65f1a1a2b3c4d5e6f7a8b9d1',
+  note: 'Guest always requests extra pillows',
+  type: GuestNoteTypeEnum.PREFERENCE,
+  status: GuestNoteStatusEnum.NOT_PINNED,
+  createdBy: 'user-456',
+};
+
+export function makeGuestNote(
+  overrides?: Partial<typeof GUEST_NOTE_FIXTURE_DEFAULTS>,
+): GuestNote {
+  const merged = { ...GUEST_NOTE_FIXTURE_DEFAULTS, ...overrides };
+
+  return GuestNote.reconstitute(
+    GuestNoteId.createFromString(merged.id),
+    TenantId.createFromString(merged.tenantId),
+    GuestId.createFromString(merged.guestId),
+    merged.note,
+    merged.type,
+    merged.status,
+    merged.createdBy,
+    new Date(),
+    new Date(),
+    null,
+  );
+}

--- a/test/shared/mocks/repositories/guest-note-repository.mock.ts
+++ b/test/shared/mocks/repositories/guest-note-repository.mock.ts
@@ -1,0 +1,11 @@
+import { GuestNoteRepository } from '@/domain/guest-note/repositories/guest-note.repository';
+
+export function createGuestNoteRepositoryMock(): jest.Mocked<GuestNoteRepository> {
+  return {
+    save: jest.fn(),
+    findById: jest.fn(),
+    findByGuestId: jest.fn(),
+    findByGuestIdPaginated: jest.fn(),
+    delete: jest.fn(),
+  };
+}


### PR DESCRIPTION
Summary         
                                                                                                                                                
  - Fixed soft-delete bugs in the GuestNote entity and MongoGuestNoteRepository:                                                                
    - softDelete() was incorrectly setting status = IS_PINNED instead of only setting deletedAt
    - findById was not filtering out soft-deleted records (deletedAt: null condition missing)                                                   
    - delete() was performing a hard delete (deleteOne); replaced with a soft delete via findOneAndUpdate                                       
  - Added togglePin() domain method to GuestNote entity — flips between IS_PINNED and NOT_PINNED status                                         
  - Added three CQRS commands with handlers:                                                                                                    
    - UpdateGuestNoteCommand — updates note content and/or type (requires at least one field)                                                   
    - DeleteGuestNoteCommand — soft-deletes a note by ID scoped to tenant                                                                       
    - TogglePinGuestNoteCommand — toggles the pin status of a note                                                                              
  - Added three endpoints to CrmController (all guarded by CRM_MANAGE permission):                                                              
    - PATCH /guests/:guestId/notes/:noteId — edit a guest note                                                                                  
    - DELETE /guests/:guestId/notes/:noteId — delete a guest note (204)                                                                         
    - PATCH /guests/:guestId/notes/:noteId/toggle-pin — toggle pin status (204)                                                                 
  - Added UpdateGuestNoteDto with optional note and type fields                                                                                 
                                                                                                                                                
  Tests           
                                                                                                                                                
  Unit tests added for all three new command handlers, covering success paths and edge cases (note not found, no fields provided). Shared       
  GuestNote fixture and repository mock extended to support the new operations.
                                                                                                                                                
  Test plan       

  - PATCH /notes/:noteId updates content and/or type; rejects with 400 if no fields sent                                                        
  - DELETE /notes/:noteId soft-deletes — note no longer appears in GET /notes but record persists in DB
  - PATCH /notes/:noteId/toggle-pin flips IS_PINNED ↔ NOT_PINNED on each call                                                                   
  - All three endpoints return 404 for unknown or already-deleted notes