### PR TITLE
LYMON-728-be-expose-created-experience-in-the-landing-page-experiences-read-model

### DIFF
--- a/src/application/experience/experience-application.module.ts
+++ b/src/application/experience/experience-application.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { CreateExperienceHandler } from '@/application/experience/commands/create-experience.handler';
+import { GetExperiencesByTenantQueryHandler } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler';
 
 const CommandHandlers = [CreateExperienceHandler];
+const QueryHandlers = [GetExperiencesByTenantQueryHandler];
 
 @Module({
   imports: [CqrsModule, PersistenceModule],
-  providers: [...CommandHandlers],
-  exports: [...CommandHandlers],
+  providers: [...CommandHandlers, ...QueryHandlers],
+  exports: [...CommandHandlers, ...QueryHandlers],
 })
 export class ExperienceApplicationModule {}

--- a/src/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler.ts
+++ b/src/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler.ts
@@ -1,0 +1,46 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetExperiencesByTenantQuery } from './get-experiences-by-tenant.query';
+import { GetExperiencesByTenantResult } from './get-experiences-by-tenant.result';
+import {
+  EXPERIENCE_REPOSITORY,
+  type ExperienceRepository,
+} from '@/domain/experience/repositories/experience.repository';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { mapExperienceToPublicDto } from '@/application/experience/queries/shared/experience.mapper';
+
+@QueryHandler(GetExperiencesByTenantQuery)
+export class GetExperiencesByTenantQueryHandler implements IQueryHandler<
+  GetExperiencesByTenantQuery,
+  GetExperiencesByTenantResult
+> {
+  constructor(
+    @Inject(EXPERIENCE_REPOSITORY)
+    private readonly experienceRepository: ExperienceRepository,
+  ) {}
+
+  async execute(
+    query: GetExperiencesByTenantQuery,
+  ): Promise<GetExperiencesByTenantResult> {
+    const tenantId = TenantId.createFromString(query.tenantId);
+    const propertyId = query.propertyId
+      ? PropertyId.create(query.propertyId)
+      : undefined;
+
+    const { experiences, total } =
+      await this.experienceRepository.findByTenantIdPaginated(
+        tenantId,
+        query.page,
+        query.limit,
+        propertyId,
+      );
+
+    return new GetExperiencesByTenantResult(
+      experiences.map(mapExperienceToPublicDto),
+      total,
+      query.page,
+      query.limit,
+    );
+  }
+}

--- a/src/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query.ts
+++ b/src/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query.ts
@@ -1,0 +1,10 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class GetExperiencesByTenantQuery implements IQuery {
+  constructor(
+    public readonly tenantId: string,
+    public readonly page: number = 1,
+    public readonly limit: number = 10,
+    public readonly propertyId?: string,
+  ) {}
+}

--- a/src/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.result.ts
+++ b/src/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.result.ts
@@ -1,0 +1,14 @@
+import { PublicExperienceDto } from '@/application/experience/queries/shared/experience-read.dto';
+
+export class GetExperiencesByTenantResult {
+  constructor(
+    public readonly experiences: PublicExperienceDto[],
+    public readonly total: number,
+    public readonly page: number,
+    public readonly limit: number,
+  ) {}
+
+  get totalPages(): number {
+    return Math.ceil(this.total / this.limit);
+  }
+}

--- a/src/application/experience/queries/shared/experience-read.dto.ts
+++ b/src/application/experience/queries/shared/experience-read.dto.ts
@@ -1,0 +1,51 @@
+export class PublicExperienceLocationDto {
+  constructor(
+    public readonly label: string,
+    public readonly address: string | undefined,
+    public readonly lat: number,
+    public readonly lng: number,
+  ) {}
+}
+
+export class PublicExperienceRecurrenceDto {
+  constructor(
+    public readonly daysOfWeek: number[],
+    public readonly startTime: string,
+    public readonly endTime: string,
+  ) {}
+}
+
+export class PublicExperienceBlackoutRangeDto {
+  constructor(
+    public readonly startAt: Date,
+    public readonly endAt: Date,
+  ) {}
+}
+
+export class PublicExperienceDto {
+  constructor(
+    public readonly id: string,
+    public readonly tenantId: string,
+    public readonly scope: string,
+    public readonly propertyId: string | null,
+    public readonly unitIds: string[],
+    public readonly name: string,
+    public readonly description: string,
+    public readonly category: string,
+    public readonly priceCop: number,
+    public readonly durationHours: number,
+    public readonly capacity: number,
+    public readonly coverImageUrl: string,
+    public readonly location: PublicExperienceLocationDto,
+    public readonly availabilityType: string,
+    public readonly startAt: Date | null,
+    public readonly endAt: Date | null,
+    public readonly recurrence: PublicExperienceRecurrenceDto | null,
+    public readonly blackoutRanges: PublicExperienceBlackoutRangeDto[],
+    public readonly allowStandalonePurchase: boolean,
+    public readonly allowReservationPurchase: boolean,
+    public readonly minNoticeHours: number,
+    public readonly purchaseCutoffHours: number,
+    public readonly status: string,
+  ) {}
+}

--- a/src/application/experience/queries/shared/experience.mapper.ts
+++ b/src/application/experience/queries/shared/experience.mapper.ts
@@ -1,0 +1,55 @@
+import { Experience } from '@/domain/experience/entities/experience.entity';
+import {
+  PublicExperienceBlackoutRangeDto,
+  PublicExperienceDto,
+  PublicExperienceLocationDto,
+  PublicExperienceRecurrenceDto,
+} from '@/application/experience/queries/shared/experience-read.dto';
+
+export function mapExperienceToPublicDto(
+  experience: Experience,
+): PublicExperienceDto {
+  const recurrence = experience.getRecurrence();
+
+  return new PublicExperienceDto(
+    experience.getId()!.toString(),
+    experience.getTenantId().toString(),
+    experience.getScope().toString(),
+    experience.getPropertyId()?.toString() ?? null,
+    experience.getUnitIds().map((unitId) => unitId.toString()),
+    experience.getName(),
+    experience.getDescription(),
+    experience.getCategory().toString(),
+    experience.getPriceCop(),
+    experience.getDurationHours(),
+    experience.getCapacity(),
+    experience.getCoverImageUrl(),
+    new PublicExperienceLocationDto(
+      experience.getLocation().label,
+      experience.getLocation().address,
+      experience.getLocation().lat,
+      experience.getLocation().lng,
+    ),
+    experience.getAvailabilityType().toString(),
+    experience.getStartAt(),
+    experience.getEndAt(),
+    recurrence
+      ? new PublicExperienceRecurrenceDto(
+          recurrence.daysOfWeek,
+          recurrence.startTime,
+          recurrence.endTime,
+        )
+      : null,
+    experience
+      .getBlackoutRanges()
+      .map(
+        (range) =>
+          new PublicExperienceBlackoutRangeDto(range.startAt, range.endAt),
+      ),
+    experience.getAllowStandalonePurchase(),
+    experience.getAllowReservationPurchase(),
+    experience.getMinNoticeHours(),
+    experience.getPurchaseCutoffHours(),
+    experience.getStatus().toString(),
+  );
+}

--- a/src/domain/experience/repositories/experience.repository.ts
+++ b/src/domain/experience/repositories/experience.repository.ts
@@ -2,6 +2,7 @@ import { Experience } from '@/domain/experience/entities/experience.entity';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TransactionContextData } from '@/domain/shared/transaction-manager.interface';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 
 export const EXPERIENCE_REPOSITORY = 'EXPERIENCE_REPOSITORY';
 
@@ -15,4 +16,10 @@ export interface ExperienceRepository {
     propertyId: PropertyId,
     name: string,
   ): Promise<boolean>;
+  findByTenantIdPaginated(
+    tenantId: TenantId,
+    page: number,
+    limit: number,
+    propertyId?: PropertyId,
+  ): Promise<{ experiences: Experience[]; total: number }>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
@@ -108,6 +108,34 @@ export class MongoExperienceRepository implements ExperienceRepository {
     return !!matched;
   }
 
+  async findByTenantIdPaginated(
+    tenantId: TenantId,
+    page: number,
+    limit: number,
+    propertyId?: PropertyId,
+  ): Promise<{ experiences: Experience[]; total: number }> {
+    const filter: Record<string, unknown> = {
+      tenantId: new Types.ObjectId(tenantId.toString()),
+      deletedAt: null,
+    };
+
+    if (propertyId) {
+      filter.propertyId = new Types.ObjectId(propertyId.toString());
+    }
+
+    const total = await this.experienceModel.countDocuments(filter);
+    const documents = await this.experienceModel
+      .find(filter)
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit);
+
+    return {
+      experiences: documents.map((document) => this.toDomain(document)),
+      total,
+    };
+  }
+
   private toDomain(document: ExperienceDocument): Experience {
     return Experience.reconstitute({
       id: ExperienceId.create(document._id.toString()),

--- a/src/presentation/controllers/experience.controller.ts
+++ b/src/presentation/controllers/experience.controller.ts
@@ -1,5 +1,7 @@
 import { CreateExperienceCommand } from '@/application/experience/commands/create-experience.command';
 import { CreateExperienceResult } from '@/application/experience/commands/create-experience.result';
+import { GetExperiencesByTenantQuery } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query';
+import { GetExperiencesByTenantResult } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.result';
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { Permission } from '@/domain/role/value-objects/permission.vo';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
@@ -7,12 +9,22 @@ import { RequirePermission } from '@/infrastructure/auth/decorators/require-perm
 import { JwtAuthGuard } from '@/infrastructure/auth/guards/jwt-auth.guard';
 import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
 import { CreateExperienceDto } from '@/presentation/dtos/create-experience.dto';
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
-import { CommandBus } from '@nestjs/cqrs';
+import {
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBody,
   ApiBearerAuth,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -21,7 +33,62 @@ import {
 @ApiBearerAuth('JWT-auth')
 @Controller('experiences')
 export class ExperienceController {
-  constructor(private readonly commandBus: CommandBus) {}
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
+  ) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_VIEW)
+  @ApiOperation({ summary: 'List all experiences for current tenant' })
+  @ApiQuery({
+    name: 'propertyId',
+    required: false,
+    type: String,
+    description: 'Optional property filter',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number for pagination',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page (default: 10)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Experiences retrieved successfully',
+  })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getAll(
+    @CurrentUser() user: JwtPayload,
+    @Query('propertyId') propertyId: string | undefined,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    const result = await this.queryBus.execute<
+      GetExperiencesByTenantQuery,
+      GetExperiencesByTenantResult
+    >(new GetExperiencesByTenantQuery(user.tenantId, page, limit, propertyId));
+
+    return {
+      message: 'Experiences retrieved successfully',
+      data: {
+        experiences: result.experiences,
+        pagination: {
+          total: result.total,
+          page: result.page,
+          limit: result.limit,
+          totalPages: result.totalPages,
+        },
+      },
+    };
+  }
 
   @Post()
   @UseGuards(JwtAuthGuard, PermissionGuard)

--- a/test/application/experience/get-experiences-by-tenant.spec.ts
+++ b/test/application/experience/get-experiences-by-tenant.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { Experience } from '@/domain/experience/entities/experience.entity';
+import type { ExperienceRepository } from '@/domain/experience/repositories/experience.repository';
+import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
+import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
+import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
+import { ExperienceScope } from '@/domain/experience/value-objects/experience-scope.vo';
+import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { createExperienceRepositoryMock } from '@test/shared/mocks/repositories/experience-repository.mock';
+import { ExperienceController } from '@/presentation/controllers/experience.controller';
+import { GetExperiencesByTenantQuery } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query';
+import { GetExperiencesByTenantQueryHandler } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler';
+import { GetExperiencesByTenantResult } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.result';
+
+const TENANT_ID = 'tenant-123';
+const EXPERIENCE_ID = 'experience-123';
+
+function makeExperience(overrides?: Partial<{ id: string }>) {
+  return Experience.reconstitute({
+    id: ExperienceId.create(overrides?.id ?? EXPERIENCE_ID),
+    tenantId: TenantId.createFromString(TENANT_ID),
+    scope: ExperienceScope.create('PROPERTY'),
+    propertyId: PropertyId.create('property-123'),
+    unitIds: [UnitId.create('unit-123')],
+    name: 'Airport transfer',
+    description: 'Private transfer service',
+    category: ExperienceCategory.create('TRANSPORTATION'),
+    priceCop: 120000,
+    durationHours: 2,
+    capacity: 8,
+    coverImageUrl: 'https://image.example.com/cover.jpg',
+    location: {
+      label: 'Main lobby',
+      address: 'Cra 10 #20-30, Bogota',
+      lat: 4.6097,
+      lng: -74.0817,
+    },
+    availabilityType: ExperienceAvailabilityType.create('DATE_RANGE'),
+    startAt: new Date('2099-01-10T10:00:00.000Z'),
+    endAt: new Date('2099-01-20T10:00:00.000Z'),
+    recurrence: undefined,
+    blackoutRanges: [],
+    allowStandalonePurchase: true,
+    allowReservationPurchase: true,
+    minNoticeHours: 2,
+    purchaseCutoffHours: 24,
+    status: ExperienceStatus.create('ACTIVE'),
+    createdAt: new Date('2099-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2099-01-01T00:00:00.000Z'),
+    deletedAt: null,
+  });
+}
+
+describe('GetExperiencesByTenant', () => {
+  let handler: GetExperiencesByTenantQueryHandler;
+  let experienceRepository: jest.Mocked<ExperienceRepository>;
+  let controller: ExperienceController;
+  let queryBus: QueryBus;
+
+  beforeEach(async () => {
+    experienceRepository = createExperienceRepositoryMock();
+
+    handler = new GetExperiencesByTenantQueryHandler(experienceRepository);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExperienceController],
+      providers: [
+        {
+          provide: QueryBus,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: CommandBus,
+          useValue: { execute: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ExperienceController>(ExperienceController);
+    queryBus = module.get<QueryBus>(QueryBus);
+  });
+
+  it('handler returns paginated tenant experiences mapped as DTOs', async () => {
+    experienceRepository.findByTenantIdPaginated.mockResolvedValue({
+      experiences: [makeExperience()],
+      total: 1,
+    });
+
+    const result = await handler.execute(
+      new GetExperiencesByTenantQuery(TENANT_ID, 1, 10),
+    );
+
+    expect(result).toBeInstanceOf(GetExperiencesByTenantResult);
+    expect(result.experiences).toHaveLength(1);
+    expect(result.experiences[0].id).toBe(EXPERIENCE_ID);
+  });
+
+  it('controller executes query bus with current tenant', async () => {
+    const mockResult = new GetExperiencesByTenantResult(
+      [
+        {
+          id: EXPERIENCE_ID,
+          name: 'Airport transfer',
+        } as any,
+      ],
+      1,
+      1,
+      10,
+    );
+
+    (queryBus.execute as jest.Mock).mockResolvedValue(mockResult);
+
+    const response = await controller.getAll(
+      {
+        tenantId: TENANT_ID,
+      } as any,
+      undefined,
+      1,
+      10,
+    );
+
+    expect(queryBus.execute).toHaveBeenCalledWith(
+      expect.any(GetExperiencesByTenantQuery),
+    );
+    expect(response.data.experiences[0].id).toBe(EXPERIENCE_ID);
+  });
+});

--- a/test/shared/mocks/repositories/experience-repository.mock.ts
+++ b/test/shared/mocks/repositories/experience-repository.mock.ts
@@ -5,5 +5,6 @@ export function createExperienceRepositoryMock(): jest.Mocked<ExperienceReposito
     save: jest.fn(),
     findById: jest.fn(),
     existsByPropertyIdAndName: jest.fn(),
+    findByTenantIdPaginated: jest.fn(),
   };
 }


### PR DESCRIPTION
Implemented Changes:

- The GET /experiences endpoint is exposed to retrieve all created experiences, following clean architecture principles.
- The experience controller handles queries for all experiences without requiring parameters; however, it searches by the current tenant.
- A query handler is implemented in the application layer to retrieve all experiences from the repository.
- A mapper is used to transform experience entities into DTOs suitable for the API response.
- Unit and integration tests are added and maintained for the GET /experiences endpoint, ensuring its correct operation.
- The experience repository mock is updated to support the new test cases.

Notes:

- The code and tests reflect only the current functionality for exposing experiences on the landing page, according to the acceptance criteria and the project architecture.
- All implementations meet quality standards and pass linting and testing validations.