### PR TITLE
feat(tests): add performance and security test scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,17 @@
     "test:cov:scope": "jest --coverage --coverageDirectory=coverage/scope --testPathPatterns=\"test/application/(incident-report/(create-incident-report|get-incident-reports-by-property|update-incident-report)|tenant/(update-tenant-profile|get-tenant-profile)|auth/login|property/(create-property|get-properties-by-tenant)|tenant/register-tenant|user/verify-email|role/get-system-roles|guest-auth/(recover-guest-password|verify-guest-email|login-guest|register-guest-account))|test/infrastructure/(auth/guards/(jwt-auth|permission)|persistence/repositories/(mongo-incident-report|mongo-tenant|mongo-role|mongo-guest-account))|test/presentation/controllers/(incident-report|tenant|role|guest-auth)|test/domain/(tenant/value-objects/plan-type|guest-account/entities/guest-account.entity|guest-account/value-objects/guest-account-id)\"",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:security": "cypress run --spec 'cypress/security/**/*.cy.ts'",
+    "test:security:open": "cypress open",
+    "test:perf:properties": "node performance/k6/run-k6.mjs performance/k6/dist/load-properties.js",
+    "test:perf:units": "node performance/k6/run-k6.mjs performance/k6/dist/load-units.js",
+    "test:perf:inventory": "node performance/k6/run-k6.mjs performance/k6/dist/load-inventory-items.js",
+    "test:perf:audit-logs": "node performance/k6/run-k6.mjs performance/k6/dist/load-audit-logs.js",
+    "test:perf:incident-reports": "node performance/k6/run-k6.mjs performance/k6/dist/load-incident-reports.js",
+    "test:perf:reservations": "node performance/k6/run-k6.mjs performance/k6/dist/load-reservations-list.js",
+    "test:perf:smoke": "node performance/k6/run-k6.mjs performance/k6/dist/smoke-auth-login.js",
+    "test:performance": "pnpm run test:perf:smoke && pnpm run test:perf:properties && pnpm run test:perf:units && pnpm run test:perf:inventory && pnpm run test:perf:audit-logs && pnpm run test:perf:incident-reports && pnpm run test:perf:reservations",
+    "test:all": "pnpm run test && pnpm run test:security && pnpm run test:performance",
     "sonar": "jest --coverage && node -e \"const { execSync } = require('child_process'); execSync('docker run --rm -v ' + process.cwd() + ':/usr/src sonarsource/sonar-scanner-cli', {stdio: 'inherit'})\""
   },
   "dependencies": {


### PR DESCRIPTION
This pull request adds several new npm scripts to `package.json` to enhance the project's testing capabilities, including security and performance testing. These scripts make it easier to run different categories of tests individually or all together.

**New testing scripts:**

*Security testing:*
- Added `test:security` to run Cypress security tests located in the `cypress/security` directory.
- Added `test:security:open` to open the Cypress test runner for security tests.

*Performance testing:*
- Added multiple scripts (`test:perf:properties`, `test:perf:units`, `test:perf:inventory`, `test:perf:audit-logs`, `test:perf:incident-reports`, `test:perf:reservations`, `test:perf:smoke`) to run specific performance tests using K6 scripts.
- Added `test:performance` to run all the individual performance tests in sequence.

*Combined testing:*
- Added `test:all` to run unit tests, security tests, and all performance tests together.