### PR TITLE
LYMON-847 Update work shift

### DIFF
--- a/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.command.ts
+++ b/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.command.ts
@@ -1,0 +1,9 @@
+export class AssignStaffToShiftCommand {
+  constructor(
+    readonly shiftId: string,
+    readonly tenantId: string,
+    readonly staffMemberIds: string[],
+    readonly actorId: string,
+    readonly actorEmail: string,
+  ) {}
+}

--- a/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts
+++ b/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts
@@ -187,7 +187,7 @@ export class AssignStaffToShiftCommandHandler implements ICommandHandler<AssignS
 
     for (let index = 0; index < staffMembers.length; index += 1) {
       const staffMember = staffMembers[index];
-      if (!staffMember || !staffMember.getTenantId().equals(tenantId)) {
+      if (!staffMember?.getTenantId()?.equals(tenantId)) {
         throw new NotFoundException('Staff member not found for the tenant');
       }
 

--- a/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts
+++ b/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts
@@ -185,8 +185,7 @@ export class AssignStaffToShiftCommandHandler implements ICommandHandler<AssignS
       ),
     );
 
-    for (let index = 0; index < staffMembers.length; index += 1) {
-      const staffMember = staffMembers[index];
+    for (const staffMember of staffMembers) {
       if (!staffMember?.getTenantId()?.equals(tenantId)) {
         throw new NotFoundException('Staff member not found for the tenant');
       }

--- a/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts
+++ b/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts
@@ -1,0 +1,233 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  NotFoundException,
+} from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { AssignStaffToShiftCommand } from './assign-staff-to-shift.command';
+import { AssignStaffToShiftCommandResult } from './assign-staff-to-shift.result';
+import { Shift } from '@/domain/shift/entities/shift.entity';
+import {
+  SHIFT_REPOSITORY,
+  type ShiftRepository,
+} from '@/domain/shift/repositories/shift.repository';
+import {
+  USER_REPOSITORY,
+  type UserRepository,
+} from '@/domain/user/repositories/user.repository';
+import { ShiftNotificationService } from '@/application/shift/services/shift-notification.service';
+import { ShiftAuditDiffService } from '@/domain/shift/services/shift-audit-diff.service';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { ShiftId } from '@/domain/shift/value-objects/shift-id.vo';
+import { UserId } from '@/domain/user/entities/user.entity';
+import {
+  AuditAction,
+  AuditEntityType,
+} from '@/domain/audit/value-objects/audit-action.vo';
+import {
+  AUDIT_LOG_EVENT,
+  AuditLoggedEvent,
+} from '@/infrastructure/audit/events/audit-logged.event';
+
+@CommandHandler(AssignStaffToShiftCommand)
+export class AssignStaffToShiftCommandHandler implements ICommandHandler<AssignStaffToShiftCommand> {
+  constructor(
+    @Inject(SHIFT_REPOSITORY)
+    private readonly shiftRepository: ShiftRepository,
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: UserRepository,
+    private readonly shiftNotificationService: ShiftNotificationService,
+    private readonly auditDiffService: ShiftAuditDiffService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(
+    command: AssignStaffToShiftCommand,
+  ): Promise<AssignStaffToShiftCommandResult> {
+    const tenantId = TenantId.createFromString(command.tenantId);
+    const shiftId = ShiftId.createFromString(command.shiftId);
+
+    // Find shift
+    const shift = await this.shiftRepository.findById(shiftId);
+    if (!shift?.getTenantId?.()?.equals?.(tenantId)) {
+      throw new NotFoundException('Shift not found for the tenant');
+    }
+
+    // Parse new staff member IDs
+    const newStaffMemberIds = this.toDistinctUserIds(command.staffMemberIds);
+    if (newStaffMemberIds.length === 0) {
+      throw new BadRequestException(
+        'At least one staff member ID must be provided',
+      );
+    }
+
+    // Get staff members to validate they exist
+    const staffMembers = await this.getStaffMembers(
+      newStaffMemberIds,
+      tenantId,
+    );
+
+    // Get existing staff member IDs
+    const existingStaffMemberIds = shift.getStaffMemberIds();
+
+    // Merge: add new staff to existing (union, avoid duplicates)
+    const allStaffMemberIds = this.mergeStaffMemberIds(
+      existingStaffMemberIds,
+      newStaffMemberIds,
+    );
+
+    // Check for overlapping shifts for NEW staff members only
+    await this.checkStaffMemberOverlaps(
+      newStaffMemberIds,
+      shift,
+      tenantId,
+      shiftId,
+    );
+
+    // Snapshot before update
+    const previousSnapshot = this.auditDiffService.snapshot(shift);
+
+    // Update shift with merged staff list
+    shift.update(
+      {
+        staffMemberIds: allStaffMemberIds,
+        name: shift.getName(),
+      },
+      new Date(),
+    );
+
+    // Snapshot after update
+    const nextSnapshot = this.auditDiffService.snapshot(shift);
+    const auditDiff = this.auditDiffService.diff(
+      previousSnapshot,
+      nextSnapshot,
+    );
+
+    // Save shift
+    const updatedShiftId = await this.shiftRepository.save(shift);
+
+    // Send notification to newly assigned staff
+    if (staffMembers.length > 0) {
+      await this.shiftNotificationService.sendStaffAssignedToShiftEmail(
+        staffMembers,
+        shift,
+      );
+    }
+
+    // Emit audit log
+    if (command.actorId && command.actorEmail) {
+      this.eventEmitter.emit(
+        AUDIT_LOG_EVENT,
+        new AuditLoggedEvent(
+          command.tenantId,
+          command.actorId,
+          command.actorEmail,
+          AuditAction.SHIFT_UPDATED as AuditAction,
+          AuditEntityType.SHIFT as AuditEntityType,
+          updatedShiftId,
+          {
+            action: 'Staff assigned',
+            newStaffCount: newStaffMemberIds.length,
+            totalStaffCount: allStaffMemberIds.length,
+          },
+          auditDiff.previousValue,
+          auditDiff.newValue,
+        ),
+      );
+    }
+
+    return new AssignStaffToShiftCommandResult(
+      updatedShiftId,
+      allStaffMemberIds.map((id) => id.toString()),
+    );
+  }
+
+  private toDistinctUserIds(values: string[]): UserId[] {
+    if (!values || values.length === 0) {
+      return [];
+    }
+
+    const uniqueValues = [...new Set(values)];
+    return uniqueValues.map((value) => UserId.createFromString(value));
+  }
+
+  private mergeStaffMemberIds(
+    existingIds: UserId[],
+    newIds: UserId[],
+  ): UserId[] {
+    const existingSet = new Set(existingIds.map((id) => id.toString()));
+    const mergedIds = [...existingIds];
+
+    for (const newId of newIds) {
+      if (!existingSet.has(newId.toString())) {
+        mergedIds.push(newId);
+      }
+    }
+
+    return mergedIds;
+  }
+
+  private async getStaffMembers(
+    staffMemberIds: UserId[],
+    tenantId: TenantId,
+  ): Promise<
+    {
+      getTenantId(): TenantId;
+      isOwner(): boolean;
+      getEmail(): { toString(): string };
+    }[]
+  > {
+    const staffMembers = await Promise.all(
+      staffMemberIds.map((staffMemberId) =>
+        this.userRepository.findById(staffMemberId),
+      ),
+    );
+
+    for (let index = 0; index < staffMembers.length; index += 1) {
+      const staffMember = staffMembers[index];
+      if (!staffMember || !staffMember.getTenantId().equals(tenantId)) {
+        throw new NotFoundException('Staff member not found for the tenant');
+      }
+
+      if (staffMember.isOwner()) {
+        throw new BadRequestException(
+          'Shift can only be assigned to a staff member',
+        );
+      }
+    }
+
+    return staffMembers as {
+      getTenantId(): TenantId;
+      isOwner(): boolean;
+      getEmail(): { toString(): string };
+    }[];
+  }
+
+  private async checkStaffMemberOverlaps(
+    staffMemberIds: UserId[],
+    shift: Shift,
+    tenantId: TenantId,
+    shiftId: ShiftId,
+  ): Promise<void> {
+    for (const staffMemberId of staffMemberIds) {
+      const overlappingShift: Shift | null =
+        await this.shiftRepository.findOverlappingByStaffInRange(
+          tenantId,
+          staffMemberId,
+          shift.getStartDate(),
+          shift.getEndDate(),
+          shift.getStartMinutes(),
+          shift.getEndMinutes(),
+          shiftId,
+        );
+
+      if (overlappingShift) {
+        throw new ConflictException(
+          `Staff member ${staffMemberId.toString()} already has an overlapping shift`,
+        );
+      }
+    }
+  }
+}

--- a/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.result.ts
+++ b/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.result.ts
@@ -1,0 +1,6 @@
+export class AssignStaffToShiftCommandResult {
+  constructor(
+    readonly shiftId: string,
+    readonly assignedStaffMemberIds: string[],
+  ) {}
+}

--- a/src/application/shift/services/shift-notification.service.ts
+++ b/src/application/shift/services/shift-notification.service.ts
@@ -56,4 +56,28 @@ export class ShiftNotificationService {
       htmlContent,
     });
   }
+
+  async sendStaffAssignedToShiftEmail(
+    staffMembers: StaffMember[],
+    shift: ShiftForNotification,
+  ): Promise<void> {
+    const htmlContent = `
+      <div style="font-family: sans-serif; line-height: 1.6;">
+        <p><strong>Shift:</strong> ${shift.getName()}</p>
+        <p>You have been assigned to a shift.</p>
+        <p><strong>Date range:</strong> ${shift.getStartDate().toISOString().split('T')[0]} - ${shift.getEndDate()?.toISOString().split('T')[0] ?? 'No end date'}</p>
+        <p><strong>Time:</strong> ${shift.getStartHour()} - ${shift.getEndHour()}</p>
+        ${shift.getNotes() ? `<p><strong>Notes:</strong> ${shift.getNotes()}</p>` : ''}
+      </div>
+    `;
+
+    await this.emailService.sendEmail({
+      to: staffMembers.map((staffMember) => ({
+        email: staffMember.getEmail().toString(),
+        name: staffMember.getEmail().toString(),
+      })),
+      subject: 'You have been assigned to a shift',
+      htmlContent,
+    });
+  }
 }

--- a/src/application/shift/shift-application.module.ts
+++ b/src/application/shift/shift-application.module.ts
@@ -2,12 +2,17 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { CreateShiftCommandHandler } from '@/application/shift/commands/create-shift/create-shift.handler';
 import { UpdateShiftCommandHandler } from '@/application/shift/commands/update-shift/update-shift.handler';
+import { AssignStaffToShiftCommandHandler } from '@/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { EmailModule } from '@/infrastructure/email/email.module';
 import { ShiftNotificationService } from '@/application/shift/services/shift-notification.service';
 import { ShiftAuditDiffService } from '@/domain/shift/services/shift-audit-diff.service';
 
-const CommandHandlers = [CreateShiftCommandHandler, UpdateShiftCommandHandler];
+const CommandHandlers = [
+  CreateShiftCommandHandler,
+  UpdateShiftCommandHandler,
+  AssignStaffToShiftCommandHandler,
+];
 const ApplicationServices = [ShiftNotificationService];
 const DomainServices = [ShiftAuditDiffService];
 

--- a/src/presentation/controllers/shifts.controller.ts
+++ b/src/presentation/controllers/shifts.controller.ts
@@ -15,6 +15,9 @@ import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
 import { CreateShiftDto } from '@/presentation/dtos/create-shift.dto';
 import { GetShiftsDto } from '@/presentation/dtos/get-shifts.dto';
 import { UpdateShiftDto } from '@/presentation/dtos/update-shift.dto';
+import { AssignStaffToShiftDto } from '@/presentation/dtos/assign-staff-to-shift.dto';
+import { AssignStaffToShiftCommand } from '@/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.command';
+import { AssignStaffToShiftCommandResult } from '@/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.result';
 import {
   Body,
   Controller,
@@ -158,6 +161,37 @@ export class ShiftsController {
 
     return {
       message: 'Shift deleted successfully',
+      data: result,
+    };
+  }
+
+  @Patch(':id/assign-staff')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.TENANT_USERS_MANAGE)
+  @ApiOperation({
+    summary: 'Assign staff members to an existing shift (additive)',
+  })
+  @ApiResponse({ status: 200, description: 'Staff assigned successfully' })
+  async assignStaffToShift(
+    @CurrentUser() user: JwtPayload,
+    @Param('id') shiftId: string,
+    @Body() dto: AssignStaffToShiftDto,
+  ) {
+    const result = await this.commandBus.execute<
+      AssignStaffToShiftCommand,
+      AssignStaffToShiftCommandResult
+    >(
+      new AssignStaffToShiftCommand(
+        shiftId,
+        user.tenantId,
+        dto.staffMemberIds,
+        user.userId,
+        user.email,
+      ),
+    );
+
+    return {
+      message: 'Staff assigned successfully',
       data: result,
     };
   }

--- a/src/presentation/dtos/assign-staff-to-shift.dto.ts
+++ b/src/presentation/dtos/assign-staff-to-shift.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNotEmpty, IsString } from 'class-validator';
+
+export class AssignStaffToShiftDto {
+  @ApiProperty({
+    example: ['680c79f38b4f98f4f6383b12', '680c79f38b4f98f4f6383b14'],
+    description: 'Staff member IDs to assign to the shift (additive)',
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  staffMemberIds!: string[];
+}


### PR DESCRIPTION
This pull request introduces a new feature that allows staff members to be assigned to an existing shift through an additive operation. The implementation includes a new command, handler, result class, DTO, service method for notifications, and an endpoint in the controller. The changes ensure proper validation, audit logging, and notification of assigned staff, while enforcing permissions and preventing overlapping shift assignments.

**New Command and Handler for Assigning Staff:**

- Added `AssignStaffToShiftCommand`, `AssignStaffToShiftCommandHandler`, and `AssignStaffToShiftCommandResult` to encapsulate the logic for assigning staff to a shift, including validation (existence, tenant, role), prevention of overlapping shifts, updating the shift, audit logging, and notifications. [[1]](diffhunk://#diff-30c763adf756c9dca1281face073c831e8d03b3de1a8b285144a935b4c5e2ba4R1-R9) [[2]](diffhunk://#diff-86633a43c36c165339fed2aea873252e6c92e37af374c2021e8547aabbfaac1aR1-R233) [[3]](diffhunk://#diff-fac3fece0529bd9b985aa660bfba0f074ec6189c88d64fd4249f603464561db3R1-R6)

**Notification Enhancements:**

- Introduced `sendStaffAssignedToShiftEmail` method in `ShiftNotificationService` to notify newly assigned staff via email.

**API and Controller Updates:**

- Added new DTO `AssignStaffToShiftDto` for request validation and documentation.
- Updated `ShiftsController` to expose a new PATCH endpoint (`:id/assign-staff`) for assigning staff to a shift, with appropriate permission checks and response structure. [[1]](diffhunk://#diff-a23a43cccdd49954f0e60cd5163a8f2f8433953e07f1301765513ba385305bb0R18-R20) [[2]](diffhunk://#diff-a23a43cccdd49954f0e60cd5163a8f2f8433953e07f1301765513ba385305bb0R167-R197)

**Module Registration:**

- Registered the new command handler in `ShiftApplicationModule` to ensure it is available for command dispatching.