### PR TITLE
Lymon 594 filter guest list by status and tags

### DIFF
--- a/src/application/guest/queries/search-guests.query.ts
+++ b/src/application/guest/queries/search-guests.query.ts
@@ -4,6 +4,11 @@ import {
   type GuestRepository,
 } from '@/domain/guest/repositories/guest.repository';
 import { Guest } from '@/domain/guest/entities/guest.entity';
+import { GuestStatusEnum } from '@/domain/guest/entities/guest.types';
+import {
+  GUEST_TAG_REPOSITORY,
+  type GuestTagRepository,
+} from '@/domain/guest-tag/repositories/guest-tag.repository';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 
 @Injectable()
@@ -11,6 +16,8 @@ export class SearchGuestsQuery {
   constructor(
     @Inject(GUEST_REPOSITORY)
     private readonly guestRepository: GuestRepository,
+    @Inject(GUEST_TAG_REPOSITORY)
+    private readonly guestTagRepository: GuestTagRepository,
   ) {}
 
   async execute(
@@ -20,8 +27,24 @@ export class SearchGuestsQuery {
     limit: number,
     sortBy: 'createdAt' | 'fullName' | 'status',
     sortDirection: 'asc' | 'desc',
+    tagNames?: string[],
+    statuses?: GuestStatusEnum[],
   ): Promise<{ guests: Guest[]; total: number }> {
     const sanitizedTerm = term?.trim().toLowerCase();
+
+    let tagIds: string[] | undefined;
+    if (tagNames?.length) {
+      const tags = await this.guestTagRepository.findByNames(
+        tagNames,
+        tenantId.toString(),
+      );
+      if (!tags.length) {
+        return { guests: [], total: 0 };
+      }
+      tagIds = tags.map((t) => t.getId()!.toString());
+    }
+
+    const filters = { statuses, tagIds };
 
     if (!sanitizedTerm) {
       return this.guestRepository.findByTenantIdPaginated(
@@ -30,6 +53,7 @@ export class SearchGuestsQuery {
         limit,
         sortBy,
         sortDirection,
+        filters,
       );
     }
 
@@ -38,6 +62,7 @@ export class SearchGuestsQuery {
       sanitizedTerm,
       page,
       limit,
+      filters,
     );
   }
 }

--- a/src/domain/guest/repositories/guest.repository.ts
+++ b/src/domain/guest/repositories/guest.repository.ts
@@ -1,10 +1,16 @@
 import { Guest } from '@/domain/guest/entities/guest.entity';
+import { GuestStatusEnum } from '@/domain/guest/entities/guest.types';
 import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
 import { TransactionContextData } from '@/domain/shared/transaction-manager.interface';
 
 export const GUEST_REPOSITORY = 'GUEST_REPOSITORY';
+
+export interface GuestFilters {
+  statuses?: GuestStatusEnum[];
+  tagIds?: string[];
+}
 
 export interface GuestRepository {
   save(
@@ -35,11 +41,13 @@ export interface GuestRepository {
     limit: number,
     sortBy: 'createdAt' | 'fullName' | 'status',
     sortDirection: 'asc' | 'desc',
+    filters?: GuestFilters,
   ): Promise<{ guests: Guest[]; total: number }>;
   searchPaginated(
     tenantId: TenantId,
     term: string,
     page: number,
     limit: number,
+    filters?: GuestFilters,
   ): Promise<{ guests: Guest[]; total: number }>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-guest.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-guest.repository.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { ClientSession, Model, Types } from 'mongoose';
 import { Guest } from '@/domain/guest/entities/guest.entity';
-import { GuestRepository } from '@/domain/guest/repositories/guest.repository';
+import {
+  GuestFilters,
+  GuestRepository,
+} from '@/domain/guest/repositories/guest.repository';
 import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
 import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
@@ -172,8 +175,15 @@ export class MongoGuestRepository implements GuestRepository {
     limit: number,
     sortBy: 'createdAt' | 'fullName' | 'status',
     sortDirection: 'asc' | 'desc',
+    filters?: GuestFilters,
   ): Promise<{ guests: Guest[]; total: number }> {
-    const filter = { tenantId: new Types.ObjectId(tenantId.toString()) };
+    const filter = {
+      tenantId: new Types.ObjectId(tenantId.toString()),
+      ...(filters?.statuses?.length ? { status: { $in: filters.statuses } } : {}),
+      ...(filters?.tagIds?.length
+        ? { tags: { $in: filters.tagIds.map((id) => new Types.ObjectId(id)) } }
+        : {}),
+    };
     const sortOrder = sortDirection === 'asc' ? 1 : -1;
     const [total, documents] = await Promise.all([
       this.guestModel.countDocuments(filter),
@@ -197,6 +207,7 @@ export class MongoGuestRepository implements GuestRepository {
     term: string,
     page: number,
     limit: number,
+    filters?: GuestFilters,
   ): Promise<{ guests: Guest[]; total: number }> {
     const escapedTerm = term.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
     const pattern = new RegExp(escapedTerm, 'i');
@@ -211,6 +222,10 @@ export class MongoGuestRepository implements GuestRepository {
         { 'identity.documentNumber': pattern },
         { 'phones.number': pattern },
       ],
+      ...(filters?.statuses?.length ? { status: { $in: filters.statuses } } : {}),
+      ...(filters?.tagIds?.length
+        ? { tags: { $in: filters.tagIds.map((id) => new Types.ObjectId(id)) } }
+        : {}),
     };
     const [total, documents] = await Promise.all([
       this.guestModel.countDocuments(filter),

--- a/src/presentation/controllers/crm.controller.ts
+++ b/src/presentation/controllers/crm.controller.ts
@@ -14,12 +14,14 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseArrayPipe,
   ParseIntPipe,
   Patch,
   Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
+import { GuestStatusEnum } from '@/domain/guest/entities/guest.types';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -76,12 +78,18 @@ export class CrmController {
     enum: ['createdAt', 'fullName', 'status'],
   })
   @ApiQuery({ name: 'sortDirection', required: false, enum: ['asc', 'desc'] })
+  @ApiQuery({ name: 'status', required: false, enum: GuestStatusEnum, isArray: true })
+  @ApiQuery({ name: 'tags', required: false, type: String, isArray: true })
   async getGuests(
     @CurrentUser() user: JwtPayload,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
     @Query('sortBy') sortBy: 'createdAt' | 'fullName' | 'status' = 'createdAt',
     @Query('sortDirection') sortDirection: 'asc' | 'desc' = 'desc',
+    @Query('status', new ParseArrayPipe({ optional: true, separator: ',' }))
+    statuses: GuestStatusEnum[] = [],
+    @Query('tags', new ParseArrayPipe({ optional: true, separator: ',' }))
+    tags: string[] = [],
   ) {
     const { guests, total } = await this.searchGuestsQuery.execute(
       TenantId.createFromString(user.tenantId),
@@ -90,6 +98,8 @@ export class CrmController {
       limit,
       sortBy,
       sortDirection,
+      tags,
+      statuses,
     );
 
     return {

--- a/src/presentation/controllers/crm.controller.ts
+++ b/src/presentation/controllers/crm.controller.ts
@@ -49,6 +49,7 @@ import { SendGuestMessageDto } from '@/presentation/dtos/send-guest-message.dto'
 import { SaveGuestPreferencesCommand } from '@/application/guest/commands/preferences/save-guest-preferences.command';
 import { SaveGuestPreferencesResult } from '@/application/guest/commands/preferences/save-guest-preferences.result';
 import { SaveGuestPreferencesDto } from '@/presentation/dtos/save-guest-preferences.dto';
+import { UpdateTagsDto } from '@/presentation/dtos/update-tags.dto';
 
 @ApiTags('crm')
 @ApiBearerAuth('JWT-auth')
@@ -309,17 +310,15 @@ export class CrmController {
   @UseGuards(PermissionGuard)
   @RequirePermission(Permission.CRM_MANAGE)
   @ApiOperation({ summary: 'Assign tags to a guest' })
-  @ApiResponse({
-    status: 200,
-    description: 'Tags assigned successfully',
-  })
+  @ApiResponse({ status: 200, description: 'Tags assigned successfully' })
+  @ApiResponse({ status: 404, description: 'Guest not found' })
   async assignTags(
     @Param('guestId') guestId: string,
-    @Body('tags') tags: string[],
+    @Body() dto: UpdateTagsDto,
     @CurrentUser() user: JwtPayload,
   ) {
     await this.commandBus.execute(
-      new AssignGuestTagsCommand(guestId, tags, user.tenantId),
+      new AssignGuestTagsCommand(guestId, dto.tags, user.tenantId),
     );
 
     return {

--- a/test/application/guest/search-guests.query.spec.ts
+++ b/test/application/guest/search-guests.query.spec.ts
@@ -1,11 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SearchGuestsQuery } from '@/application/guest/queries/search-guests.query';
 import { GUEST_REPOSITORY } from '@/domain/guest/repositories/guest.repository';
+import { GUEST_TAG_REPOSITORY } from '@/domain/guest-tag/repositories/guest-tag.repository';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 
 describe('SearchGuestsQuery', () => {
   let query: SearchGuestsQuery;
   let mockRepository: any;
+  let mockTagRepository: any;
 
   beforeEach(async () => {
     mockRepository = {
@@ -17,12 +19,20 @@ describe('SearchGuestsQuery', () => {
         .mockResolvedValue({ guests: [], total: 0 }),
     };
 
+    mockTagRepository = {
+      findByNames: jest.fn().mockResolvedValue([]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SearchGuestsQuery,
         {
           provide: GUEST_REPOSITORY,
           useValue: mockRepository,
+        },
+        {
+          provide: GUEST_TAG_REPOSITORY,
+          useValue: mockTagRepository,
         },
       ],
     }).compile();
@@ -41,6 +51,7 @@ describe('SearchGuestsQuery', () => {
       'juan',
       1,
       10,
+      { statuses: undefined, tagIds: undefined },
     );
   });
 
@@ -55,6 +66,25 @@ describe('SearchGuestsQuery', () => {
       10,
       'createdAt',
       'desc',
+      { statuses: undefined, tagIds: undefined },
     );
+  });
+
+  it('should return empty results when requested tags do not exist', async () => {
+    const tenantId = TenantId.createFromString('hotel-123');
+    mockTagRepository.findByNames.mockResolvedValue([]);
+
+    const result = await query.execute(
+      tenantId,
+      '',
+      1,
+      10,
+      'createdAt',
+      'desc',
+      ['white'],
+    );
+
+    expect(result).toEqual({ guests: [], total: 0 });
+    expect(mockRepository.findByTenantIdPaginated).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Summary
                                                                                                                                                                                                               
  - Add GuestFilters interface (statuses, tagIds) to GuestRepository domain interface                                                                                                                          
  - Wire $in filters into MongoGuestRepository for both paginated query methods
  - SearchGuestsQuery resolves tag names → ObjectIds via GuestTagRepository before querying; short-circuits with empty results when requested tags don't exist in the catalog                                  
  - Expose status and tags as optional comma-separated array query params on GET /crm/guests                                                                                                                   
                                                                                                                                                                                                               
  Usage                                                                                                                                                                                                        
                                                                                                                                                                                                               
  GET /crm/guests?status=active,blocked                                                                                                                                                                      
  GET /crm/guests?tags=VIP,Regular                                                                                                                                                                             
  GET /crm/guests?status=active&tags=VIP
                                                                                                                                                                                                               
  Test plan                                                                                                                                                                                                                                                                                                                                                                           
  - GET /crm/guests?status=active returns only active guests
  - GET /crm/guests?tags=VIP,Regular returns guests with VIP or Regular tag                                                                                                                                    
  - GET /crm/guests?tags=nonexistent returns empty results, not all guests
  - GET /crm/guests (no filters) unchanged behaviour       