### PR TITLE
fix: change deletedAt property to be non-readonly in Experience class

### DIFF
--- a/src/domain/experience/entities/experience.entity.ts
+++ b/src/domain/experience/entities/experience.entity.ts
@@ -123,7 +123,7 @@ export class Experience {
     private readonly status: ExperienceStatus,
     private readonly createdAt: Date,
     private updatedAt: Date,
-    private readonly deletedAt: Date | null,
+    private deletedAt: Date | null,
   ) {}
 
   static create(props: ExperienceProps): Experience {


### PR DESCRIPTION
This pull request makes a small change to the `Experience` entity, updating the `deletedAt` property so it is no longer read-only. This allows the `deletedAt` field to be modified after the entity is created.