### PR TITLE
LYMON-449: refactor get endpoint to retrieve more information

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@nestjs/core': true
+  '@scarf/scarf': true
+  bcrypt: true
+  cypress: true
+  unrs-resolver: true

--- a/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.handler.ts
+++ b/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.handler.ts
@@ -1,11 +1,24 @@
 import { Inject } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { GetStaffByTenantQuery } from './get-staff-by-tenant.query';
-import { GetStaffByTenantResult, StaffDto } from './get-staff-by-tenant.result';
+import {
+  GetStaffByTenantResult,
+  StaffDto,
+  StaffScopeDto,
+} from './get-staff-by-tenant.result';
 import {
   USER_REPOSITORY,
   type UserRepository,
 } from '@/domain/user/repositories/user.repository';
+import {
+  PROPERTY_REPOSITORY,
+  type PropertyRepository,
+} from '@/domain/property/repositories/property.repository';
+import {
+  UNIT_REPOSITORY,
+  type UnitRepository,
+} from '@/domain/unit/repositories/unit.repository';
+import type { UserScope } from '@/domain/user/entities/user.entity';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 
 @QueryHandler(GetStaffByTenantQuery)
@@ -16,6 +29,10 @@ export class GetStaffByTenantHandler implements IQueryHandler<
   constructor(
     @Inject(USER_REPOSITORY)
     private readonly userRepository: UserRepository,
+    @Inject(PROPERTY_REPOSITORY)
+    private readonly propertyRepository: PropertyRepository,
+    @Inject(UNIT_REPOSITORY)
+    private readonly unitRepository: UnitRepository,
   ) {}
 
   async execute(query: GetStaffByTenantQuery): Promise<GetStaffByTenantResult> {
@@ -27,6 +44,18 @@ export class GetStaffByTenantHandler implements IQueryHandler<
     }
 
     const users = await this.userRepository.findByTenantId(tid);
+    const properties = await this.propertyRepository.findByTenantId(tid);
+    const units = await this.unitRepository.findByTenantId(tid);
+
+    const propertyNameById = new Map(
+      properties.map((property) => [
+        property.getId()?.toString() ?? '',
+        property.getName(),
+      ]),
+    );
+    const unitNameById = new Map(
+      units.map((unit) => [unit.getId()?.toString() ?? '', unit.getName()]),
+    );
 
     const items: StaffDto[] = users
       .filter((u) => !u.isOwner())
@@ -35,9 +64,58 @@ export class GetStaffByTenantHandler implements IQueryHandler<
         email: u.getEmail().toString(),
         isOwner: u.isOwner(),
         emailVerified: u.isEmailVerified(),
-        roleAssignments: u.getRoleAssignments(),
+        roleAssignments: u.getRoleAssignments().map((assignment) => ({
+          roleId: assignment.roleId,
+          scope: this.mapScope(
+            assignment.scope,
+            propertyNameById,
+            unitNameById,
+          ),
+        })),
       }));
 
     return { items };
+  }
+
+  private mapScope(
+    scope: UserScope,
+    propertyNameById: Map<string, string>,
+    unitNameById: Map<string, string>,
+  ): StaffScopeDto {
+    if (scope.type === 'TENANT') {
+      return { type: 'TENANT' };
+    }
+
+    if (scope.type === 'UNIT') {
+      return {
+        type: 'UNIT',
+        resourceIds: [...scope.resourceIds],
+        resources: scope.resourceIds
+          .map((id) => {
+            const name = unitNameById.get(id);
+            if (!name) return null;
+            return { id, name };
+          })
+          .filter(
+            (resource): resource is { id: string; name: string } =>
+              resource !== null,
+          ),
+      };
+    }
+
+    return {
+      type: 'PROPERTY',
+      resourceIds: [...scope.resourceIds],
+      resources: scope.resourceIds
+        .map((id) => {
+          const name = propertyNameById.get(id);
+          if (!name) return null;
+          return { id, name };
+        })
+        .filter(
+          (resource): resource is { id: string; name: string } =>
+            resource !== null,
+        ),
+    };
   }
 }

--- a/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.result.ts
+++ b/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.result.ts
@@ -1,9 +1,27 @@
+export interface StaffScopedResourceDto {
+  id: string;
+  name: string;
+}
+
+export type StaffScopeDto =
+  | { type: 'TENANT' }
+  | {
+      type: 'PROPERTY';
+      resourceIds: string[];
+      resources: StaffScopedResourceDto[];
+    }
+  | {
+      type: 'UNIT';
+      resourceIds: string[];
+      resources: StaffScopedResourceDto[];
+    };
+
 export interface StaffDto {
   id: string;
   email: string;
   isOwner: boolean;
   emailVerified: boolean;
-  roleAssignments: Array<{ roleId: string; scope: any }>;
+  roleAssignments: Array<{ roleId: string; scope: StaffScopeDto }>;
 }
 
 export interface GetStaffByTenantResult {

--- a/src/presentation/controllers/user.controller.ts
+++ b/src/presentation/controllers/user.controller.ts
@@ -103,10 +103,83 @@ export class UserController {
   @UseGuards(JwtAuthGuard)
   @Get('staff')
   @ApiBearerAuth('JWT-auth')
-  @ApiOperation({ summary: 'List invited staff for the current tenant' })
+  @ApiOperation({
+    summary: 'List invited staff for the current tenant',
+    description:
+      'Retrieves a list of staff members associated with the current tenant, including their assigned roles and access scopes (TENANT, PROPERTY, or UNIT). Contains detailed information about accessible resources like property or unit IDs and names.',
+  })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Staff retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string', example: 'Staff retrieved successfully' },
+        total: { type: 'number', example: 1 },
+        data: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+                format: 'uuid',
+                example: '123e4567-e89b-12d3-a456-426614174000',
+              },
+              email: {
+                type: 'string',
+                format: 'email',
+                example: 'staff@example.com',
+              },
+              isOwner: { type: 'boolean', example: false },
+              emailVerified: { type: 'boolean', example: true },
+              roleAssignments: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    roleId: { type: 'string', example: 'staff-role-id' },
+                    scope: {
+                      type: 'object',
+                      properties: {
+                        type: {
+                          type: 'string',
+                          enum: ['TENANT', 'PROPERTY', 'UNIT'],
+                          example: 'PROPERTY',
+                        },
+                        resourceIds: {
+                          type: 'array',
+                          items: { type: 'string', format: 'uuid' },
+                          example: ['987e6543-e21b-34d3-a456-426614174111'],
+                        },
+                        resources: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              id: {
+                                type: 'string',
+                                format: 'uuid',
+                                example: '987e6543-e21b-34d3-a456-426614174111',
+                              },
+                              name: { type: 'string', example: 'Sunset Villa' },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Unauthorized - Invalid or missing JWT token',
   })
   async getStaff(
     @CurrentUser() jwtPayload: JwtPayload,


### PR DESCRIPTION
This pull request enhances the staff retrieval functionality for tenants by providing more detailed information about each staff member's role assignments and access scopes. The changes include enriching the returned data structure with resource names for properties and units, updating the API response documentation, and refactoring the handler logic to support these improvements.

**API Enhancements and Documentation:**

- Expanded the API response for the `GET /staff` endpoint to include detailed information about each staff member's role assignments and access scopes (TENANT, PROPERTY, or UNIT), including resource IDs and names. The OpenAPI documentation now accurately reflects the enriched response structure, improving clarity for API consumers.

**Handler Logic and Data Structure Improvements:**

- Refactored `GetStaffByTenantHandler` to:
  - Inject `PropertyRepository` and `UnitRepository` to fetch all properties and units for the tenant. [[1]](diffhunk://#diff-cc8d5605d141d0cf9ba1948fb509315c7317142aa1f9923e571a498a7e1bb24fL4-R21) [[2]](diffhunk://#diff-cc8d5605d141d0cf9ba1948fb509315c7317142aa1f9923e571a498a7e1bb24fR32-R35)
  - Map property and unit IDs to their names, allowing the response to include both IDs and human-readable names for resources in staff role assignments.
  - Add a `mapScope` method to transform internal scope representations into a new DTO format that includes resource names, improving the clarity and usefulness of the API response.

**Type and DTO Updates:**

- Introduced `StaffScopedResourceDto` and `StaffScopeDto` types in `get-staff-by-tenant.result.ts` to standardize the structure of scope information, supporting TENANT, PROPERTY, and UNIT scopes with associated resource details. Updated `StaffDto` to use these new types.

**Build Configuration:**

- Updated `pnpm-workspace.yaml` to allow builds for additional dependencies, ensuring all required packages can be built in the workspace.