### PR TITLE
LYMON-860 Invite staff to the current tenant

### DIFF
--- a/src/application/user/commands/invite-staff/invite-staff.command.ts
+++ b/src/application/user/commands/invite-staff/invite-staff.command.ts
@@ -8,5 +8,7 @@ export class InviteStaffCommand {
     public readonly roleAssignments: RoleAssignment[],
     public readonly actorId: string,
     public readonly actorEmail: string,
+    public readonly fullName: string,
+    public readonly document: string,
   ) {}
 }

--- a/src/application/user/commands/invite-staff/invite-staff.handler.ts
+++ b/src/application/user/commands/invite-staff/invite-staff.handler.ts
@@ -94,6 +94,8 @@ export class InviteStaffHandler implements ICommandHandler<InviteStaffCommand> {
       passwordHash,
       tenantId,
       command.roleAssignments,
+      command.fullName,
+      command.document,
     );
     await this.userRepository.save(staffUser);
 

--- a/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.handler.ts
+++ b/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.handler.ts
@@ -62,6 +62,8 @@ export class GetStaffByTenantHandler implements IQueryHandler<
       .map((u) => ({
         id: u.getId()?.toString() ?? '',
         email: u.getEmail().toString(),
+        fullName: u.getFullName(),
+        document: u.getDocument(),
         isOwner: u.isOwner(),
         emailVerified: u.isEmailVerified(),
         roleAssignments: u.getRoleAssignments().map((assignment) => ({

--- a/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.result.ts
+++ b/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.result.ts
@@ -19,6 +19,8 @@ export type StaffScopeDto =
 export interface StaffDto {
   id: string;
   email: string;
+  fullName?: string;
+  document?: string;
   isOwner: boolean;
   emailVerified: boolean;
   roleAssignments: Array<{ roleId: string; scope: StaffScopeDto }>;

--- a/src/domain/user/entities/user.entity.ts
+++ b/src/domain/user/entities/user.entity.ts
@@ -29,8 +29,8 @@ export interface UserReconstitutionData {
   resetPasswordExpires?: Date;
   passwordChangedAt?: Date;
   deletedAt?: Date | null;
-  fullName?: string;
-  document?: string;
+  readonly fullName?: string;
+  readonly document?: string;
 }
 
 /** Kept for OWNER identity checks only. Staff roles are managed via RoleAssignment. */

--- a/src/domain/user/entities/user.entity.ts
+++ b/src/domain/user/entities/user.entity.ts
@@ -29,6 +29,8 @@ export interface UserReconstitutionData {
   resetPasswordExpires?: Date;
   passwordChangedAt?: Date;
   deletedAt?: Date | null;
+  fullName?: string;
+  document?: string;
 }
 
 /** Kept for OWNER identity checks only. Staff roles are managed via RoleAssignment. */
@@ -75,6 +77,8 @@ export class User {
     private resetPasswordExpires?: Date,
     private passwordChangedAt?: Date,
     private deletedAt: Date | null = null,
+    private fullName?: string,
+    private document?: string,
   ) {}
 
   static createOwner(
@@ -100,6 +104,8 @@ export class User {
     passwordHash: string,
     tenantId: TenantId,
     roleAssignments: RoleAssignment[],
+    fullName?: string,
+    document?: string,
   ): User {
     return new User(
       null,
@@ -111,6 +117,12 @@ export class User {
       false,
       new Date(),
       new Date(),
+      undefined,
+      undefined,
+      undefined,
+      null,
+      fullName,
+      document,
     );
   }
 
@@ -133,6 +145,8 @@ export class User {
       data.resetPasswordExpires,
       data.passwordChangedAt,
       data.deletedAt,
+      data.fullName,
+      data.document,
     );
   }
 
@@ -169,6 +183,14 @@ export class User {
 
   getEmail(): Email {
     return this.email;
+  }
+
+  getFullName(): string | undefined {
+    return this.fullName;
+  }
+
+  getDocument(): string | undefined {
+    return this.document;
   }
 
   getPasswordHash(): string {

--- a/src/infrastructure/persistence/repositories/mongo-user.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-user.repository.ts
@@ -21,62 +21,10 @@ export class MongoUserRepository implements UserRepository {
   async save(user: User): Promise<void> {
     try {
       const id = user.getId()?.toString();
-
-      const document: Partial<UserDocument> = {
-        email: user.getEmail().toString(),
-        passwordHash: user.getPasswordHash(),
-        tenantId: user.getTenantId().toString(),
-        isOwner: user.isOwner(),
-        roleAssignments: user.getRoleAssignments(),
-        emailVerified: user.isEmailVerified(),
-        updatedAt: new Date(),
-        deletedAt: user.getDeletedAt(),
-      };
-
-      const resetPasswordToken = user.getResetPasswordToken();
-      const resetPasswordExpires = user.getResetPasswordExpires();
-      const passwordChangedAt = user.getPasswordChangedAt();
-      const fullName = user.getFullName();
-      const documentNumber = user.getDocument();
-
-      // Set or unset optional fields
-      if (resetPasswordToken !== undefined) {
-        document.resetPasswordToken = resetPasswordToken;
-      }
-      if (resetPasswordExpires !== undefined) {
-        document.resetPasswordExpires = resetPasswordExpires;
-      }
-      if (passwordChangedAt !== undefined) {
-        document.passwordChangedAt = passwordChangedAt;
-      }
-      if (fullName !== undefined) {
-        document.fullName = fullName;
-      }
-      if (documentNumber !== undefined) {
-        document.document = documentNumber;
-      }
+      const document = this.buildDocument(user);
 
       if (id) {
-        const updateOperation: {
-          $set: Partial<UserDocument>;
-          $unset?: Record<string, string>;
-        } = { $set: document };
-
-        const unsetFields: Record<string, string> = {};
-        if (resetPasswordToken === undefined) {
-          unsetFields.resetPasswordToken = '';
-        }
-        if (resetPasswordExpires === undefined) {
-          unsetFields.resetPasswordExpires = '';
-        }
-
-        if (Object.keys(unsetFields).length > 0) {
-          updateOperation.$unset = unsetFields;
-        }
-
-        await this.userModel.findByIdAndUpdate(id, updateOperation, {
-          new: true,
-        });
+        await this.updateUser(id, document, user);
       } else {
         await this.userModel.create({ ...document, createdAt: new Date() });
       }
@@ -89,6 +37,60 @@ export class MongoUserRepository implements UserRepository {
 
       throw error;
     }
+  }
+
+  private buildDocument(user: User): Partial<UserDocument> {
+    const document: Partial<UserDocument> = {
+      email: user.getEmail().toString(),
+      passwordHash: user.getPasswordHash(),
+      tenantId: user.getTenantId().toString(),
+      isOwner: user.isOwner(),
+      roleAssignments: user.getRoleAssignments(),
+      emailVerified: user.isEmailVerified(),
+      updatedAt: new Date(),
+      deletedAt: user.getDeletedAt(),
+    };
+
+    const optionalFields = [
+      { key: 'resetPasswordToken', value: user.getResetPasswordToken() },
+      { key: 'resetPasswordExpires', value: user.getResetPasswordExpires() },
+      { key: 'passwordChangedAt', value: user.getPasswordChangedAt() },
+      { key: 'fullName', value: user.getFullName() },
+      { key: 'document', value: user.getDocument() },
+    ];
+
+    for (const field of optionalFields) {
+      if (field.value !== undefined) {
+        document[field.key as keyof Partial<UserDocument>] = field.value as any;
+      }
+    }
+
+    return document;
+  }
+
+  private async updateUser(
+    id: string,
+    document: Partial<UserDocument>,
+    user: User,
+  ): Promise<void> {
+    const updateOperation: {
+      $set: Partial<UserDocument>;
+      $unset?: Record<string, string>;
+    } = { $set: document };
+
+    const unsetFields: Record<string, string> = {};
+    if (user.getResetPasswordToken() === undefined) {
+      unsetFields.resetPasswordToken = '';
+    }
+    if (user.getResetPasswordExpires() === undefined) {
+      unsetFields.resetPasswordExpires = '';
+    }
+
+    if (Object.keys(unsetFields).length > 0) {
+      updateOperation.$unset = unsetFields;
+    }
+
+    await this.userModel.findByIdAndUpdate(id, updateOperation, { new: true });
   }
 
   async findById(id: UserId): Promise<User | null> {

--- a/src/infrastructure/persistence/repositories/mongo-user.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-user.repository.ts
@@ -36,6 +36,8 @@ export class MongoUserRepository implements UserRepository {
       const resetPasswordToken = user.getResetPasswordToken();
       const resetPasswordExpires = user.getResetPasswordExpires();
       const passwordChangedAt = user.getPasswordChangedAt();
+      const fullName = user.getFullName();
+      const documentNumber = user.getDocument();
 
       // Set or unset optional fields
       if (resetPasswordToken !== undefined) {
@@ -46,6 +48,12 @@ export class MongoUserRepository implements UserRepository {
       }
       if (passwordChangedAt !== undefined) {
         document.passwordChangedAt = passwordChangedAt;
+      }
+      if (fullName !== undefined) {
+        document.fullName = fullName;
+      }
+      if (documentNumber !== undefined) {
+        document.document = documentNumber;
       }
 
       if (id) {
@@ -142,6 +150,8 @@ export class MongoUserRepository implements UserRepository {
       resetPasswordExpires: doc.resetPasswordExpires,
       passwordChangedAt: doc.passwordChangedAt,
       deletedAt: doc.deletedAt,
+      fullName: doc.fullName,
+      document: doc.document,
     });
   }
 }

--- a/src/infrastructure/persistence/schemas/user.schema.ts
+++ b/src/infrastructure/persistence/schemas/user.schema.ts
@@ -43,6 +43,12 @@ export class UserDocument extends Document {
 
   @Prop({ type: Date, default: null })
   deletedAt: Date | null;
+
+  @Prop()
+  fullName?: string;
+
+  @Prop()
+  document?: string;
 }
 
 export const UserSchema = SchemaFactory.createForClass(UserDocument);

--- a/src/presentation/controllers/user.controller.ts
+++ b/src/presentation/controllers/user.controller.ts
@@ -91,6 +91,8 @@ export class UserController {
       dto.roleAssignments as unknown as RoleAssignment[],
       jwtPayload.userId,
       jwtPayload.email,
+      dto.fullName,
+      dto.document,
     );
 
     await this.commandBus.execute(command);

--- a/src/presentation/dtos/invite-staff.dto.ts
+++ b/src/presentation/dtos/invite-staff.dto.ts
@@ -90,6 +90,14 @@ export class InviteStaffDto {
   @MinLength(8, { message: 'Password must be at least 8 characters long' })
   password: string;
 
+  @ApiProperty({ example: 'Juan Pérez' })
+  @IsString()
+  fullName: string;
+
+  @ApiProperty({ example: '1234567890' })
+  @IsString()
+  document: string;
+
   @ApiProperty({
     type: [RoleAssignmentDto],
     description: 'One or more role assignments for the staff member',


### PR DESCRIPTION
This pull request adds support for storing and handling staff members' full names and document numbers throughout the invite and user management flows. The changes ensure that these fields are captured when inviting staff, persisted in the database, exposed in API DTOs, and included in query results.

**Domain and persistence model updates:**

* Added `fullName` and `document` fields to the `User` entity, its reconstitution data, and the corresponding getter methods. These fields are now set during staff creation and reconstitution. [[1]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR32-R33) [[2]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR80-R81) [[3]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR107-R108) [[4]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR120-R125) [[5]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR148-R149) [[6]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR188-R195)
* Updated the MongoDB schema (`UserDocument`) and repository to persist and retrieve the new `fullName` and `document` fields. [[1]](diffhunk://#diff-e195548b2cb2f55b25ffb3ca8a40022dd733df9e83bc531ff21e3e51ba3b030dR46-R51) [[2]](diffhunk://#diff-2f09f54a7de95399179b03b0961a21e91e1c66ceb51f86b33f862864a0898186R39-R40) [[3]](diffhunk://#diff-2f09f54a7de95399179b03b0961a21e91e1c66ceb51f86b33f862864a0898186R52-R57) [[4]](diffhunk://#diff-2f09f54a7de95399179b03b0961a21e91e1c66ceb51f86b33f862864a0898186R153-R154)

**Application and API layer changes:**

* Modified the invite staff command, handler, and controller to accept and pass through `fullName` and `document` when inviting a staff member. [[1]](diffhunk://#diff-2610b48c44ef518b136bd6399c8ff5d07079d70d54e0748eed68de01c671b784R11-R12) [[2]](diffhunk://#diff-05573551bbcc8f3633367d277e6a1d43e8690c9dc22055a7037f725f8d57bc28R97-R98) [[3]](diffhunk://#diff-6db978913882dad9b948903f0e33cf417c214694aa561bb43ff3f292ba057ed5R94-R95)
* Updated the `InviteStaffDto` to require `fullName` and `document` fields with appropriate validation and API documentation.

**Query and DTO updates:**

* Extended the `GetStaffByTenantHandler` and `StaffDto` to include `fullName` and `document` in staff listings. [[1]](diffhunk://#diff-cc8d5605d141d0cf9ba1948fb509315c7317142aa1f9923e571a498a7e1bb24fR65-R66) [[2]](diffhunk://#diff-97bc012f633f18e2a130fd46f2ea335f6367033749f853141476ab7f06544ea4R22-R23)