### PR TITLE
LYMON-863 Add filter to min guests on unit retrieval

### DIFF
--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
@@ -22,6 +22,7 @@ export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
     const { units, total } = await this.unitRepository.findAllPaginated(
       query.page,
       query.limit,
+      query.minGuests,
     );
     const dtos = units.map(mapUnitToPublicDto);
 

--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query.ts
@@ -4,5 +4,6 @@ export class GetAllPublicUnitsQuery implements IQuery {
   constructor(
     public readonly page: number = 1,
     public readonly limit: number = 10,
+    public readonly minGuests?: number,
   ) {}
 }

--- a/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler.ts
+++ b/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler.ts
@@ -31,6 +31,7 @@ export class GetPublicUnitsByTenantQueryHandler implements IQueryHandler<
       tenantId,
       query.page,
       query.limit,
+      query.minGuests,
     );
     const dtos = units.map(mapUnitToPublicDto);
 

--- a/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query.ts
+++ b/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query.ts
@@ -5,5 +5,6 @@ export class GetPublicUnitsByTenantQuery implements IQuery {
     public readonly tenantId: string,
     public readonly page: number = 1,
     public readonly limit: number = 10,
+    public readonly minGuests?: number,
   ) {}
 }

--- a/src/domain/unit/repositories/unit.repository.ts
+++ b/src/domain/unit/repositories/unit.repository.ts
@@ -20,9 +20,11 @@ export interface UnitRepository {
     tenantId: TenantId,
     page: number,
     limit: number,
+    minGuests?: number,
   ): Promise<{ units: Unit[]; total: number }>;
   findAllPaginated(
     page: number,
     limit: number,
+    minGuests?: number,
   ): Promise<{ units: Unit[]; total: number }>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
@@ -97,11 +97,15 @@ export class MongoUnitRepository implements UnitRepository {
     tenantId: TenantId,
     page: number,
     limit: number,
+    minGuests?: number,
   ): Promise<{ units: Unit[]; total: number }> {
-    const filter = {
+    const filter: any = {
       tenantId: new Types.ObjectId(tenantId.toString()),
       deletedAt: null,
     };
+    if (minGuests !== undefined) {
+      filter.maxGuests = { $gte: minGuests };
+    }
     const total = await this.unitModel.countDocuments(filter);
     const documents = await this.unitModel
       .find(filter)
@@ -117,8 +121,12 @@ export class MongoUnitRepository implements UnitRepository {
   async findAllPaginated(
     page: number,
     limit: number,
+    minGuests?: number,
   ): Promise<{ units: Unit[]; total: number }> {
-    const filter = { deletedAt: null };
+    const filter: any = { deletedAt: null };
+    if (minGuests !== undefined) {
+      filter.maxGuests = { $gte: minGuests };
+    }
     const total = await this.unitModel.countDocuments(filter);
     const documents = await this.unitModel
       .find(filter)

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -157,12 +157,20 @@ export class UnitController {
     type: Number,
     description: 'Items per page (default: 10)',
   })
+  @ApiQuery({
+    name: 'minGuests',
+    required: false,
+    type: Number,
+    description: 'Filter units by minimum number of guests (maxGuests)',
+  })
   @ApiResponse({ status: 200, description: 'Units retrieved successfully' })
   async getAllPublic(
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+    @Query('minGuests') minGuests?: string,
   ) {
-    const query = new GetAllPublicUnitsQuery(page, limit);
+    const minGuestsNum = minGuests ? parseInt(minGuests, 10) : undefined;
+    const query = new GetAllPublicUnitsQuery(page, limit, minGuestsNum);
 
     const result = await this.queryBus.execute<
       GetAllPublicUnitsQuery,
@@ -200,13 +208,26 @@ export class UnitController {
     type: Number,
     description: 'Items per page (default: 10)',
   })
+  @ApiQuery({
+    name: 'minGuests',
+    required: false,
+    type: Number,
+    description: 'Filter units by minimum number of guests (maxGuests)',
+  })
   @ApiResponse({ status: 200, description: 'Units retrieved successfully' })
   async getPublicByTenant(
     @Param('tenantId') tenantId: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+    @Query('minGuests') minGuests?: string,
   ) {
-    const query = new GetPublicUnitsByTenantQuery(tenantId, page, limit);
+    const minGuestsNum = minGuests ? parseInt(minGuests, 10) : undefined;
+    const query = new GetPublicUnitsByTenantQuery(
+      tenantId,
+      page,
+      limit,
+      minGuestsNum,
+    );
 
     const result = await this.queryBus.execute<
       GetPublicUnitsByTenantQuery,


### PR DESCRIPTION
This pull request adds support for filtering units by a minimum number of guests (`minGuests`) in both the "get all public units" and "get public units by tenant" endpoints. The changes introduce a new optional query parameter, update the query handlers and repository interfaces to accept this filter, and implement the filtering logic in the MongoDB repository.

**API Enhancements:**

* Added an optional `minGuests` query parameter to the `getAllPublic` and `getPublicByTenant` endpoints in `UnitController`, allowing clients to filter units by minimum guest capacity. [[1]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR160-R173) [[2]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR211-R230)

**Application Layer Updates:**

* Extended the `GetAllPublicUnitsQuery` and `GetPublicUnitsByTenantQuery` classes and their handlers to accept and forward the `minGuests` filter. [[1]](diffhunk://#diff-225b362a8cb83658eb6295c0337fa524b0a617391aa5b11ca57f66fd17ecad21R7) [[2]](diffhunk://#diff-036ef6a1d79243557e5919682a9c82b2a333a424fe438478078d06906672fdfbR8) [[3]](diffhunk://#diff-07ee2a3f4618a145d888c7d35c22716a1a6c22880367151ade0046f669ea7c4eR25) [[4]](diffhunk://#diff-1cff0ad7207f8d37a477681bab7440b43f5bc02c1bf35411ee5fd7671487bd97R34)

**Domain and Persistence Layer Changes:**

* Updated the `UnitRepository` interface and its MongoDB implementation to support the optional `minGuests` parameter for both paginated queries. [[1]](diffhunk://#diff-f6a9cfd3d8ce8c6058316a38122485bb7b230ab51f9553ffdb2cbf7f8eafbb0fR23-R28) [[2]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R100-R108) [[3]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R124-R129)
* Implemented filtering logic in `MongoUnitRepository` to return only units where `maxGuests >= minGuests` when the filter is provided. [[1]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R100-R108) [[2]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R124-R129)