### PR TITLE
feat: Modifications to various endpoints

### DIFF
--- a/src/application/reservation/queries/get-unit-occupancy/get-unit-occupancy.query-handler.ts
+++ b/src/application/reservation/queries/get-unit-occupancy/get-unit-occupancy.query-handler.ts
@@ -1,0 +1,45 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetUnitOccupancyQuery } from './get-unit-occupancy.query';
+import {
+  RESERVATION_REPOSITORY,
+  type ReservationRepository,
+} from '@/domain/reservation/repositories/reservation.repository';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { DateRange } from '@/domain/reservation/value-objects/date-range.vo';
+import { ReservationStatusEnum } from '@/domain/reservation/value-objects/reservation-status.vo';
+
+@QueryHandler(GetUnitOccupancyQuery)
+export class GetUnitOccupancyHandler
+  implements IQueryHandler<GetUnitOccupancyQuery, { checkIn: Date; checkOut: Date }[]>
+{
+  constructor(
+    @Inject(RESERVATION_REPOSITORY)
+    private readonly reservationRepository: ReservationRepository,
+  ) {}
+
+  async execute(query: GetUnitOccupancyQuery) {
+    const unitId = UnitId.create(query.unitId);
+
+    // Reconstitute date range to avoid "past date" validation during querying
+    const searchRange = DateRange.reconstitute(query.startDate, query.endDate);
+
+    const reservations = await this.reservationRepository.findByUnitAndDateRange(
+      unitId,
+      searchRange,
+    );
+
+    const INACTIVE_STATUSES = new Set<ReservationStatusEnum>([
+      ReservationStatusEnum.CANCELLED,
+      ReservationStatusEnum.NO_SHOW,
+    ]);
+
+    // Return only active reservations that occupy space
+    return reservations
+      .filter((r) => !INACTIVE_STATUSES.has(r.getStatus().getValue()))
+      .map((r) => ({
+        checkIn: r.getDateRange().getCheckIn(),
+        checkOut: r.getDateRange().getCheckOut(),
+      }));
+  }
+}

--- a/src/application/reservation/queries/get-unit-occupancy/get-unit-occupancy.query.ts
+++ b/src/application/reservation/queries/get-unit-occupancy/get-unit-occupancy.query.ts
@@ -1,0 +1,7 @@
+export class GetUnitOccupancyQuery {
+  constructor(
+    public readonly unitId: string,
+    public readonly startDate: Date,
+    public readonly endDate: Date,
+  ) {}
+}

--- a/src/application/reservation/reservation-application.module.ts
+++ b/src/application/reservation/reservation-application.module.ts
@@ -14,6 +14,7 @@ import { GetReservationsByTenantHandler } from '@/application/reservation/querie
 import { GetReservationsByUnitHandler } from '@/application/reservation/queries/get-reservations-by-unit/get-reservations-by-unit.query-handler';
 import { GetGuestReservationHandler } from '@/application/reservation/queries/get-guest-reservation/get-guest-reservation.query-handler';
 import { GetGuestReservationsHandler } from '@/application/reservation/queries/get-guest-reservations/get-guest-reservations.query-handler';
+import { GetUnitOccupancyHandler } from '@/application/reservation/queries/get-unit-occupancy/get-unit-occupancy.query-handler';
 
 const CommandHandlers = [
   CreateReservationHandler,
@@ -32,6 +33,7 @@ const QueryHandlers = [
   GetReservationsByUnitHandler,
   GetGuestReservationHandler,
   GetGuestReservationsHandler,
+  GetUnitOccupancyHandler,
 ];
 
 @Module({

--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
@@ -5,6 +5,12 @@ import { GetAllPublicUnitsResult } from './get-all-public-units.result';
 import { UNIT_REPOSITORY } from '@/domain/unit/repositories/unit.repository';
 import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
 import { mapUnitToPublicDto } from '@/application/reservation/queries/shared/unit.mapper';
+import {
+  RESERVATION_REPOSITORY,
+  type ReservationRepository,
+} from '@/domain/reservation/repositories/reservation.repository';
+import { AvailabilityChecker } from '@/domain/reservation/services/availability-checker.domain-service';
+import { DateRange } from '@/domain/reservation/value-objects/date-range.vo';
 
 @QueryHandler(GetAllPublicUnitsQuery)
 export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
@@ -14,15 +20,57 @@ export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
   constructor(
     @Inject(UNIT_REPOSITORY)
     private readonly unitRepository: UnitRepository,
+    @Inject(RESERVATION_REPOSITORY)
+    private readonly reservationRepository: ReservationRepository,
   ) {}
 
   async execute(
     query: GetAllPublicUnitsQuery,
   ): Promise<GetAllPublicUnitsResult> {
+    // Si hay fechas, necesitamos filtrar por disponibilidad
+    if (query.startDate && query.endDate) {
+      const dateRange = DateRange.create(query.startDate, query.endDate);
+      
+      // Obtenemos todas las unidades candidatas (sin paginar en DB para poder filtrar luego)
+      const { units } = await this.unitRepository.findAllPaginated(
+        1,
+        1000, // Un límite razonable para filtrado en memoria
+        query.minGuests,
+        query.propertyId,
+      );
+
+      const availableUnits: any[] = [];
+      for (const unit of units) {
+        const reservations = await this.reservationRepository.findByUnitAndDateRange(
+          unit.getId()!,
+          dateRange,
+        );
+
+        const isAvailable = AvailabilityChecker.isAvailable(
+          dateRange,
+          reservations,
+          unit.getInventoryCount(),
+        );
+
+        if (isAvailable) {
+          availableUnits.push(unit);
+        }
+      }
+
+      const total = availableUnits.length;
+      const skip = (query.page - 1) * query.limit;
+      const paginatedUnits = availableUnits.slice(skip, skip + query.limit);
+      const dtos = paginatedUnits.map(mapUnitToPublicDto);
+
+      return new GetAllPublicUnitsResult(dtos, total, query.page, query.limit);
+    }
+
+    // Si no hay fechas, usamos la paginación estándar de DB
     const { units, total } = await this.unitRepository.findAllPaginated(
       query.page,
       query.limit,
       query.minGuests,
+      query.propertyId,
     );
     const dtos = units.map(mapUnitToPublicDto);
 

--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query.ts
@@ -5,5 +5,8 @@ export class GetAllPublicUnitsQuery implements IQuery {
     public readonly page: number = 1,
     public readonly limit: number = 10,
     public readonly minGuests?: number,
+    public readonly propertyId?: string,
+    public readonly startDate?: Date,
+    public readonly endDate?: Date,
   ) {}
 }

--- a/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler.ts
+++ b/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler.ts
@@ -8,6 +8,12 @@ import type { TenantRepository } from '@/domain/tenant/repositories/tenant.repos
 import { UNIT_REPOSITORY } from '@/domain/unit/repositories/unit.repository';
 import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
 import { mapUnitToPublicDto } from '@/application/reservation/queries/shared/unit.mapper';
+import {
+  RESERVATION_REPOSITORY,
+  type ReservationRepository,
+} from '@/domain/reservation/repositories/reservation.repository';
+import { AvailabilityChecker } from '@/domain/reservation/services/availability-checker.domain-service';
+import { DateRange } from '@/domain/reservation/value-objects/date-range.vo';
 
 @QueryHandler(GetPublicUnitsByTenantQuery)
 export class GetPublicUnitsByTenantQueryHandler implements IQueryHandler<
@@ -19,6 +25,8 @@ export class GetPublicUnitsByTenantQueryHandler implements IQueryHandler<
     private readonly unitRepository: UnitRepository,
     @Inject(TENANT_REPOSITORY)
     private readonly tenantRepository: TenantRepository,
+    @Inject(RESERVATION_REPOSITORY)
+    private readonly reservationRepository: ReservationRepository,
   ) {}
 
   async execute(
@@ -27,6 +35,45 @@ export class GetPublicUnitsByTenantQueryHandler implements IQueryHandler<
     const tenantId = TenantId.createFromString(String(query.tenantId));
     const tenant = await this.tenantRepository.findById(tenantId);
     if (!tenant) throw new NotFoundException('Tenant not found');
+
+    // Si hay fechas, necesitamos filtrar por disponibilidad
+    if (query.startDate && query.endDate) {
+      const dateRange = DateRange.create(query.startDate, query.endDate);
+
+      // Obtenemos todas las unidades candidatas del tenant (sin paginar en DB para filtrar luego)
+      const { units } = await this.unitRepository.findByTenantIdPaginated(
+        tenantId,
+        1,
+        1000,
+        query.minGuests,
+      );
+
+      const availableUnits: any[] = [];
+      for (const unit of units) {
+        const reservations = await this.reservationRepository.findByUnitAndDateRange(
+          unit.getId()!,
+          dateRange,
+        );
+
+        const isAvailable = AvailabilityChecker.isAvailable(
+          dateRange,
+          reservations,
+          unit.getInventoryCount(),
+        );
+
+        if (isAvailable) {
+          availableUnits.push(unit);
+        }
+      }
+
+      const total = availableUnits.length;
+      const skip = (query.page - 1) * query.limit;
+      const paginatedUnits = availableUnits.slice(skip, skip + query.limit);
+      const dtos = paginatedUnits.map(mapUnitToPublicDto);
+
+      return new GetPublicUnitsByTenantResult(dtos, total, query.page, query.limit);
+    }
+
     const { units, total } = await this.unitRepository.findByTenantIdPaginated(
       tenantId,
       query.page,

--- a/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query.ts
+++ b/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query.ts
@@ -6,5 +6,7 @@ export class GetPublicUnitsByTenantQuery implements IQuery {
     public readonly page: number = 1,
     public readonly limit: number = 10,
     public readonly minGuests?: number,
+    public readonly startDate?: Date,
+    public readonly endDate?: Date,
   ) {}
 }

--- a/src/domain/unit/repositories/unit.repository.ts
+++ b/src/domain/unit/repositories/unit.repository.ts
@@ -21,10 +21,12 @@ export interface UnitRepository {
     page: number,
     limit: number,
     minGuests?: number,
+    propertyId?: string,
   ): Promise<{ units: Unit[]; total: number }>;
   findAllPaginated(
     page: number,
     limit: number,
     minGuests?: number,
+    propertyId?: string,
   ): Promise<{ units: Unit[]; total: number }>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
@@ -98,6 +98,7 @@ export class MongoUnitRepository implements UnitRepository {
     page: number,
     limit: number,
     minGuests?: number,
+    propertyId?: string,
   ): Promise<{ units: Unit[]; total: number }> {
     const filter: any = {
       tenantId: new Types.ObjectId(tenantId.toString()),
@@ -105,6 +106,9 @@ export class MongoUnitRepository implements UnitRepository {
     };
     if (minGuests !== undefined) {
       filter.maxGuests = { $gte: minGuests };
+    }
+    if (propertyId) {
+      filter.propertyId = new Types.ObjectId(propertyId);
     }
     const total = await this.unitModel.countDocuments(filter);
     const documents = await this.unitModel
@@ -122,10 +126,14 @@ export class MongoUnitRepository implements UnitRepository {
     page: number,
     limit: number,
     minGuests?: number,
+    propertyId?: string,
   ): Promise<{ units: Unit[]; total: number }> {
     const filter: any = { deletedAt: null };
     if (minGuests !== undefined) {
       filter.maxGuests = { $gte: minGuests };
+    }
+    if (propertyId) {
+      filter.propertyId = new Types.ObjectId(propertyId);
     }
     const total = await this.unitModel.countDocuments(filter);
     const documents = await this.unitModel

--- a/src/presentation/controllers/guest-reservation.controller.ts
+++ b/src/presentation/controllers/guest-reservation.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Public } from '@/infrastructure/auth/decorators/public.decorator';
+import { GuestPublic } from '@/infrastructure/guest-auth/decorators/guest-public.decorator';
 import { GuestJwtAuthGuard } from '@/infrastructure/guest-auth/guards/guest-jwt-auth.guard';
 import { CurrentGuest } from '@/infrastructure/guest-auth/decorators/current-guest.decorator';
 import { type GuestJwtPayload } from '@/application/guest-auth/services/guest-jwt.service';
@@ -26,6 +27,7 @@ import { GetGuestReservationQuery } from '@/application/reservation/queries/get-
 import { GuestReservationDetailResult } from '@/application/reservation/queries/get-guest-reservation/get-guest-reservation.result';
 import { GetGuestReservationsQuery } from '@/application/reservation/queries/get-guest-reservations/get-guest-reservations.query';
 import { GetGuestReservationsResult } from '@/application/reservation/queries/get-guest-reservations/get-guest-reservations.result';
+import { GetUnitOccupancyQuery } from '@/application/reservation/queries/get-unit-occupancy/get-unit-occupancy.query';
 import { ReservationStatusEnum } from '@/domain/reservation/value-objects/reservation-status.vo';
 
 @ApiTags('guest-reservations')
@@ -37,7 +39,7 @@ export class GuestReservationController {
   constructor(
     private readonly commandBus: CommandBus,
     private readonly queryBus: QueryBus,
-  ) {}
+  ) { }
 
   @Post()
   @ApiOperation({ summary: 'Create a reservation as a guest' })
@@ -113,6 +115,34 @@ export class GuestReservationController {
     );
   }
 
+  @Get('unit/:unitId/calendar')
+  @GuestPublic()
+  @Public()
+  @ApiOperation({ summary: 'Get occupied dates for a specific unit calendar' })
+  @ApiResponse({ status: 200, description: 'List of occupied date ranges' })
+  @ApiQuery({ name: 'startDate', required: false, description: 'Start date of the range (defaults to today)' })
+  @ApiQuery({ name: 'endDate', required: false, description: 'End date of the range (defaults to 1 year from now)' })
+  async getUnitCalendar(
+    @Param('unitId') unitId: string,
+    @Query('startDate') startDateStr?: string,
+    @Query('endDate') endDateStr?: string,
+  ): Promise<{ message: string; data: { checkIn: Date; checkOut: Date }[] }> {
+    const startDate = startDateStr ? new Date(startDateStr) : new Date();
+    const endDate = endDateStr
+      ? new Date(endDateStr)
+      : new Date(startDate.getTime() + 365 * 24 * 60 * 60 * 1000); // 1 año por defecto
+
+    const occupancy = await this.queryBus.execute<
+      GetUnitOccupancyQuery,
+      { checkIn: Date; checkOut: Date }[]
+    >(new GetUnitOccupancyQuery(unitId, startDate, endDate));
+
+    return {
+      message: 'Occupancy calendar retrieved successfully',
+      data: occupancy,
+    };
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get a guest reservation by ID' })
   @ApiResponse({ status: 200, description: 'Reservation detail for guest' })
@@ -157,4 +187,5 @@ export class GuestReservationController {
     const mapped = statusMap[normalized];
     return mapped ? [mapped] : undefined;
   }
+
 }

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -163,14 +163,23 @@ export class UnitController {
     type: Number,
     description: 'Filter units by minimum number of guests (maxGuests)',
   })
+  @ApiQuery({ name: 'propertyId', required: false, type: String, description: 'Filter by property ID' })
+  @ApiQuery({ name: 'startDate', required: false, type: String, description: 'Start date for availability check (ISO)' })
+  @ApiQuery({ name: 'endDate', required: false, type: String, description: 'End date for availability check (ISO)' })
   @ApiResponse({ status: 200, description: 'Units retrieved successfully' })
   async getAllPublic(
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
     @Query('minGuests') minGuests?: string,
+    @Query('propertyId') propertyId?: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
   ) {
     const minGuestsNum = minGuests ? parseInt(minGuests, 10) : undefined;
-    const query = new GetAllPublicUnitsQuery(page, limit, minGuestsNum);
+    const start = startDate ? new Date(startDate) : undefined;
+    const end = endDate ? new Date(endDate) : undefined;
+
+    const query = new GetAllPublicUnitsQuery(page, limit, minGuestsNum, propertyId, start, end);
 
     const result = await this.queryBus.execute<
       GetAllPublicUnitsQuery,
@@ -214,19 +223,29 @@ export class UnitController {
     type: Number,
     description: 'Filter units by minimum number of guests (maxGuests)',
   })
+  @ApiQuery({ name: 'propertyId', required: false, type: String, description: 'Filter by property ID' })
+  @ApiQuery({ name: 'startDate', required: false, type: String, description: 'Start date for availability check (ISO)' })
+  @ApiQuery({ name: 'endDate', required: false, type: String, description: 'End date for availability check (ISO)' })
   @ApiResponse({ status: 200, description: 'Units retrieved successfully' })
   async getPublicByTenant(
     @Param('tenantId') tenantId: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
     @Query('minGuests') minGuests?: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
   ) {
     const minGuestsNum = minGuests ? parseInt(minGuests, 10) : undefined;
+    const start = startDate ? new Date(startDate) : undefined;
+    const end = endDate ? new Date(endDate) : undefined;
+
     const query = new GetPublicUnitsByTenantQuery(
       tenantId,
       page,
       limit,
       minGuestsNum,
+      start,
+      end,
     );
 
     const result = await this.queryBus.execute<


### PR DESCRIPTION
This pull request introduces significant improvements to unit availability and occupancy features in the reservation system. It adds a new endpoint for retrieving a unit's occupancy calendar, enhances public unit listing queries to support date and property-based availability filtering, and updates the underlying repository and query interfaces to support these new capabilities. The changes also ensure that the API documentation and query handlers reflect the new filtering options.

**Unit Occupancy and Availability Enhancements:**

* Added a new query (`GetUnitOccupancyQuery`) and handler (`GetUnitOccupancyHandler`) to retrieve occupied date ranges for a specific unit, filtering out inactive reservations. This is exposed via a new public endpoint in `GuestReservationController`. [[1]](diffhunk://#diff-c267ebd7f0389f5d0e652739acc45cd0a0f384c54d8240dfa83e148bfa54499dR1-R45) [[2]](diffhunk://#diff-bc1750bbec02adb0c8e2fd63d2880e527a2edc5d668a17f97c9cbfc1601127b6R1-R7) [[3]](diffhunk://#diff-e82333b834d6175857f3a8006455246ec9f980705a7fdbca5d8fed44834dc612R30) [[4]](diffhunk://#diff-e82333b834d6175857f3a8006455246ec9f980705a7fdbca5d8fed44834dc612R118-R145)
* Implemented a new endpoint in `GuestReservationController` to allow guests to fetch a unit's occupancy calendar, with optional date range parameters and appropriate API documentation.

**Public Unit Listing Improvements:**

* Enhanced `GetAllPublicUnitsQuery` and `GetPublicUnitsByTenantQuery` (and their handlers) to accept optional `startDate`, `endDate`, and `propertyId` parameters, enabling filtering of units by availability within a date range and by property. [[1]](diffhunk://#diff-225b362a8cb83658eb6295c0337fa524b0a617391aa5b11ca57f66fd17ecad21R8-R10) [[2]](diffhunk://#diff-036ef6a1d79243557e5919682a9c82b2a333a424fe438478078d06906672fdfbR9-R10) [[3]](diffhunk://#diff-07ee2a3f4618a145d888c7d35c22716a1a6c22880367151ade0046f669ea7c4eR8-R13) [[4]](diffhunk://#diff-07ee2a3f4618a145d888c7d35c22716a1a6c22880367151ade0046f669ea7c4eR23-R73) [[5]](diffhunk://#diff-1cff0ad7207f8d37a477681bab7440b43f5bc02c1bf35411ee5fd7671487bd97R11-R16) [[6]](diffhunk://#diff-1cff0ad7207f8d37a477681bab7440b43f5bc02c1bf35411ee5fd7671487bd97R28-R29) [[7]](diffhunk://#diff-1cff0ad7207f8d37a477681bab7440b43f5bc02c1bf35411ee5fd7671487bd97R38-R76)
* Updated the handlers to fetch all candidate units and filter them in-memory for availability using the `AvailabilityChecker`, ensuring only available units are returned when date filters are provided. [[1]](diffhunk://#diff-07ee2a3f4618a145d888c7d35c22716a1a6c22880367151ade0046f669ea7c4eR23-R73) [[2]](diffhunk://#diff-1cff0ad7207f8d37a477681bab7440b43f5bc02c1bf35411ee5fd7671487bd97R38-R76)

**Repository and Interface Updates:**

* Modified the `UnitRepository` interface and its MongoDB implementation to support filtering by `propertyId` in both `findByTenantIdPaginated` and `findAllPaginated` methods. [[1]](diffhunk://#diff-f6a9cfd3d8ce8c6058316a38122485bb7b230ab51f9553ffdb2cbf7f8eafbb0fR24-R30) [[2]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R101) [[3]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R110-R112) [[4]](diffhunk://#diff-fae333c7d6e5a723c7518f7df833bc3832c7f62f8bc4aa5a6caf0f8abb3e7c06R129-R137)

**API Documentation and Controller Adjustments:**

* Updated `UnitController` endpoints to accept and document new query parameters (`propertyId`, `startDate`, `endDate`) for both general and tenant-specific public unit listings, and ensured these parameters are passed to the queries. [[1]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR166-R182) [[2]](diffhunk://#diff-5c1bc5c1e36992e696541045b9f54ec95f62bdca5782f4a8b88ae687ee5a8c2bR226-R248)

**Module Registration:**

* Registered the new `GetUnitOccupancyHandler` in the application's query handlers to enable the new query functionality. [[1]](diffhunk://#diff-eb79c5f58da8bcbe0dfde6f85cc444b77165e219871d5ca2fad9318355a6a158R17) [[2]](diffhunk://#diff-eb79c5f58da8bcbe0dfde6f85cc444b77165e219871d5ca2fad9318355a6a158R36)