### PR TITLE
feat:Ensure unique active user email per tenant and sync indexes on init

### DIFF
--- a/src/infrastructure/persistence/repositories/mongo-user.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-user.repository.ts
@@ -9,20 +9,24 @@ import { InjectModel } from '@nestjs/mongoose';
 import { UserDocument } from '@/infrastructure/persistence/schemas/user.schema';
 import { Model, Types } from 'mongoose';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, OnModuleInit } from '@nestjs/common';
 import { MongoServerError } from 'mongodb';
 
-export class MongoUserRepository implements UserRepository {
+export class MongoUserRepository implements UserRepository, OnModuleInit {
   constructor(
     @InjectModel(UserDocument.name)
     private readonly userModel: Model<UserDocument>,
   ) {}
 
-  async save(user: User): Promise<void> {
-    try {
-      const id = user.getId()?.toString();
-      const document = this.buildDocument(user);
+  async onModuleInit(): Promise<void> {
+    await this.userModel.syncIndexes();
+  }
 
+  async save(user: User): Promise<void> {
+    const id = user.getId()?.toString();
+    const document = this.buildDocument(user);
+
+    try {
       if (id) {
         await this.updateUser(id, document, user);
       } else {
@@ -31,7 +35,7 @@ export class MongoUserRepository implements UserRepository {
     } catch (error) {
       if (error instanceof MongoServerError && error.code === 11000) {
         throw new ConflictException(
-          'This email is already registered. If this should be allowed across tenants, verify Mongo indexes and keep only the unique composite index { email, tenantId }.',
+          'This email is already registered for an active user in this tenant.',
         );
       }
 
@@ -57,15 +61,23 @@ export class MongoUserRepository implements UserRepository {
       { key: 'passwordChangedAt', value: user.getPasswordChangedAt() },
       { key: 'fullName', value: user.getFullName() },
       { key: 'document', value: user.getDocument() },
-    ];
+    ] as const;
 
     for (const field of optionalFields) {
-      if (field.value !== undefined) {
-        document[field.key as keyof Partial<UserDocument>] = field.value as any;
-      }
+      this.assignOptionalField(document, field.key, field.value);
     }
 
     return document;
+  }
+
+  private assignOptionalField<K extends keyof Partial<UserDocument>>(
+    document: Partial<UserDocument>,
+    key: K,
+    value: Partial<UserDocument>[K] | undefined,
+  ): void {
+    if (value !== undefined) {
+      document[key] = value;
+    }
   }
 
   private async updateUser(

--- a/src/infrastructure/persistence/schemas/user.schema.ts
+++ b/src/infrastructure/persistence/schemas/user.schema.ts
@@ -53,5 +53,12 @@ export class UserDocument extends Document {
 
 export const UserSchema = SchemaFactory.createForClass(UserDocument);
 
-UserSchema.index({ email: 1, tenantId: 1, deletedAt: 1 }, { unique: true });
+UserSchema.index(
+  { email: 1, tenantId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { deletedAt: null },
+    name: 'users_unique_active_email_tenant',
+  },
+);
 UserSchema.index({ tenantId: 1, deletedAt: 1 });


### PR DESCRIPTION
This pull request improves the handling of unique user emails across tenants in the MongoDB persistence layer, ensuring only active (non-deleted) users are considered for uniqueness and enhancing code maintainability and clarity. The main changes focus on updating the unique index for users, refining error messages, and improving the repository implementation.

**MongoDB User Email Uniqueness & Indexing:**

* Updated the `UserSchema` unique index to enforce uniqueness of `{ email, tenantId }` only for active users (`deletedAt: null`), using a partial index with a clear name (`users_unique_active_email_tenant`). This prevents conflicts when a user is soft-deleted.
* The repository now calls `syncIndexes()` on module initialization to ensure MongoDB indexes are up-to-date and consistent with the schema definition.

**Error Handling and Messaging:**

* Improved the conflict error message when a duplicate email is detected, clarifying that the email is already registered for an active user in the tenant.

**Code Quality Improvements:**

* Refactored assignment of optional fields in `MongoUserRepository` by introducing a type-safe helper method `assignOptionalField`, improving readability and maintainability.