### PR TITLE
refactor:Add createdAt field to StaffDto and related layers

### DIFF
--- a/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.handler.ts
+++ b/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.handler.ts
@@ -62,6 +62,7 @@ export class GetStaffByTenantHandler implements IQueryHandler<
       .map((u) => ({
         id: u.getId()?.toString() ?? '',
         email: u.getEmail().toString(),
+        createdAt: u.getCreatedAt().toISOString(),
         fullName: u.getFullName(),
         document: u.getDocument(),
         isOwner: u.isOwner(),

--- a/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.result.ts
+++ b/src/application/user/queries/get-staff-by-tenant/get-staff-by-tenant.result.ts
@@ -19,6 +19,7 @@ export type StaffScopeDto =
 export interface StaffDto {
   id: string;
   email: string;
+  createdAt: string;
   fullName?: string;
   document?: string;
   isOwner: boolean;

--- a/src/domain/user/entities/user.entity.ts
+++ b/src/domain/user/entities/user.entity.ts
@@ -193,6 +193,10 @@ export class User {
     return this.document;
   }
 
+  getCreatedAt(): Date {
+    return this.createdAt;
+  }
+
   getPasswordHash(): string {
     return this.passwordHash;
   }

--- a/src/presentation/controllers/user.controller.ts
+++ b/src/presentation/controllers/user.controller.ts
@@ -133,6 +133,11 @@ export class UserController {
                 format: 'email',
                 example: 'staff@example.com',
               },
+              createdAt: {
+                type: 'string',
+                format: 'date-time',
+                example: '2026-05-14T14:30:00.000Z',
+              },
               isOwner: { type: 'boolean', example: false },
               emailVerified: { type: 'boolean', example: true },
               roleAssignments: {


### PR DESCRIPTION
This pull request adds the user's creation date (`createdAt`) to the staff-related query results and API documentation. The main changes include updating the data transfer object, query handler, user entity, and API schema to support and expose the new `createdAt` field.

**API and Data Model Enhancements:**

* Added a `createdAt` field (ISO string) to the `StaffDto` type to represent when the user was created.
* Updated the `GetStaffByTenantHandler` to include the `createdAt` field in its mapped results, converting the date to an ISO string.
* Added a `getCreatedAt()` method to the `User` entity to provide access to the user's creation date.

**API Documentation Updates:**

* Documented the new `createdAt` field in the OpenAPI schema for staff objects in the `UserController`.