### PR TITLE
LYMON-873: Add staff-specific shift query with access control

### DIFF
--- a/src/application/shift/queries/get-shifts/get-shifts.handler.ts
+++ b/src/application/shift/queries/get-shifts/get-shifts.handler.ts
@@ -1,4 +1,4 @@
-import { Inject } from '@nestjs/common';
+import { ForbiddenException, Inject } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import {
   SHIFT_REPOSITORY,
@@ -22,9 +22,7 @@ export class GetShiftsHandler implements IQueryHandler<
 
   async execute(query: GetShiftsQuery): Promise<GetShiftsResult> {
     const tenantId = TenantId.createFromString(query.tenantId);
-    const visibleStaffMemberId = query.canViewAllStaff
-      ? undefined
-      : UserId.createFromString(query.actorUserId);
+    const visibleStaffMemberId = this.resolveVisibleStaffMemberId(query);
 
     const shifts = await this.shiftRepository.findByFilters(
       tenantId,
@@ -60,5 +58,21 @@ export class GetShiftsHandler implements IQueryHandler<
         updatedAt: shift.getUpdatedAt().toISOString(),
       })),
     };
+  }
+
+  private resolveVisibleStaffMemberId(
+    query: GetShiftsQuery,
+  ): UserId | undefined {
+    if (!query.staffMemberId) {
+      return query.canViewAllStaff
+        ? undefined
+        : UserId.createFromString(query.actorUserId);
+    }
+
+    if (!query.canViewAllStaff && query.staffMemberId !== query.actorUserId) {
+      throw new ForbiddenException('You can only view your own shifts');
+    }
+
+    return UserId.createFromString(query.staffMemberId);
   }
 }

--- a/src/application/shift/queries/get-shifts/get-shifts.query.ts
+++ b/src/application/shift/queries/get-shifts/get-shifts.query.ts
@@ -10,5 +10,6 @@ export class GetShiftsQuery {
     public readonly filters: GetShiftsFilters,
     public readonly actorUserId: string,
     public readonly canViewAllStaff: boolean,
+    public readonly staffMemberId?: string,
   ) {}
 }

--- a/src/presentation/controllers/shifts.controller.ts
+++ b/src/presentation/controllers/shifts.controller.ts
@@ -57,12 +57,6 @@ export class ShiftsController {
     @CurrentUser() user: JwtPayload,
     @Query() dto: GetShiftsDto,
   ): Promise<{ data: GetShiftsResult }> {
-    const canViewAllStaff =
-      user.isOwner ||
-      user.roleAssignments.some((assignment) =>
-        assignment.permissions.includes(Permission.TENANT_USERS_MANAGE),
-      );
-
     const result = await this.queryBus.execute<GetShiftsQuery, GetShiftsResult>(
       new GetShiftsQuery(
         user.tenantId,
@@ -72,7 +66,40 @@ export class ShiftsController {
           propertyId: dto.propertyId,
         },
         user.userId,
-        canViewAllStaff,
+        this.canViewAllStaff(user),
+      ),
+    );
+
+    return { data: result };
+  }
+
+  @Get('staff/:staffMemberId')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: 'List work shifts for a specific staff member',
+    description:
+      'For employee flow, non-manager users can only request their own staff member id.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Staff member shifts returned successfully',
+  })
+  async getShiftsByStaffMember(
+    @CurrentUser() user: JwtPayload,
+    @Param('staffMemberId') staffMemberId: string,
+    @Query() dto: GetShiftsDto,
+  ): Promise<{ data: GetShiftsResult }> {
+    const result = await this.queryBus.execute<GetShiftsQuery, GetShiftsResult>(
+      new GetShiftsQuery(
+        user.tenantId,
+        {
+          dateFrom: dto.dateFrom ? new Date(dto.dateFrom) : undefined,
+          dateTo: dto.dateTo ? new Date(dto.dateTo) : undefined,
+          propertyId: dto.propertyId,
+        },
+        user.userId,
+        this.canViewAllStaff(user),
+        staffMemberId,
       ),
     );
 
@@ -228,5 +255,14 @@ export class ShiftsController {
       message: 'Staff unassigned successfully',
       data: result,
     };
+  }
+
+  private canViewAllStaff(user: JwtPayload): boolean {
+    return (
+      user.isOwner ||
+      user.roleAssignments.some((assignment) =>
+        assignment.permissions.includes(Permission.TENANT_USERS_MANAGE),
+      )
+    );
   }
 }

--- a/test/application/shift/get-shifts.handler.spec.ts
+++ b/test/application/shift/get-shifts.handler.spec.ts
@@ -1,0 +1,85 @@
+import { ForbiddenException } from '@nestjs/common';
+import { GetShiftsHandler } from '@/application/shift/queries/get-shifts/get-shifts.handler';
+import { GetShiftsQuery } from '@/application/shift/queries/get-shifts/get-shifts.query';
+import { ShiftRepository } from '@/domain/shift/repositories/shift.repository';
+import { PropertyRepository } from '@/domain/property/repositories/property.repository';
+import { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+
+describe('GetShiftsHandler', () => {
+  const tenantId = '65f1a1a2b3c4d5e6f7a8b9c0';
+  const actorUserId = '65f1a1a2b3c4d5e6f7a8b9c1';
+  const otherUserId = '65f1a1a2b3c4d5e6f7a8b9c2';
+
+  let shiftRepository: jest.Mocked<ShiftRepository>;
+  let propertyRepository: jest.Mocked<PropertyRepository>;
+  let unitRepository: jest.Mocked<UnitRepository>;
+  let handler: GetShiftsHandler;
+
+  beforeEach(() => {
+    shiftRepository = {
+      save: jest.fn(),
+      delete: jest.fn(),
+      findById: jest.fn(),
+      findByFilters: jest.fn(),
+      findOverlappingByStaffInRange: jest.fn(),
+      findOverlappingByStaff: jest.fn(),
+    };
+
+    propertyRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findByTenantId: jest.fn().mockResolvedValue([]),
+      countByTenantId: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<PropertyRepository>;
+
+    unitRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findByPropertyId: jest.fn(),
+      findByTenantId: jest.fn().mockResolvedValue([]),
+      countByTenantId: jest.fn(),
+      delete: jest.fn(),
+      findByTenantIdPaginated: jest.fn(),
+      findAllPaginated: jest.fn(),
+    } as unknown as jest.Mocked<UnitRepository>;
+
+    shiftRepository.findByFilters.mockResolvedValue([]);
+    handler = new GetShiftsHandler(
+      shiftRepository,
+      propertyRepository,
+      unitRepository,
+    );
+  });
+
+  it('throws when staff user asks shifts for another user', async () => {
+    const query = new GetShiftsQuery(
+      tenantId,
+      {},
+      actorUserId,
+      false,
+      otherUserId,
+    );
+
+    await expect(handler.execute(query)).rejects.toThrow(ForbiddenException);
+    expect(shiftRepository.findByFilters).not.toHaveBeenCalled();
+  });
+
+  it('filters by requested staff member when manager asks by id', async () => {
+    const query = new GetShiftsQuery(tenantId, {}, actorUserId, true, otherUserId);
+
+    await handler.execute(query);
+
+    const [, , visibleStaffMemberId] = shiftRepository.findByFilters.mock.calls[0];
+    expect(visibleStaffMemberId?.toString()).toBe(otherUserId);
+  });
+
+  it('keeps existing behavior for staff without explicit staffMemberId', async () => {
+    const query = new GetShiftsQuery(tenantId, {}, actorUserId, false);
+
+    await handler.execute(query);
+
+    const [, , visibleStaffMemberId] = shiftRepository.findByFilters.mock.calls[0];
+    expect(visibleStaffMemberId?.toString()).toBe(actorUserId);
+  });
+});


### PR DESCRIPTION
This pull request introduces improvements to the shift querying functionality, specifically enabling secure retrieval of shifts for a specific staff member and enforcing access control. It also adds comprehensive tests to ensure correct behavior and error handling. The main themes are enhanced authorization checks, controller API expansion, and improved test coverage.

**Authorization and Query Logic Enhancements:**

* Added a private `resolveVisibleStaffMemberId` method in `GetShiftsHandler` to centralize and enforce authorization logic, throwing a `ForbiddenException` if a non-manager user attempts to access another staff member's shifts. [[1]](diffhunk://#diff-07cf1c1c699c3248c70fd865c959e9bf8bcc582874d80a0567765c26a1b63ddeL25-R25) [[2]](diffhunk://#diff-07cf1c1c699c3248c70fd865c959e9bf8bcc582874d80a0567765c26a1b63ddeR62-R77)
* Updated the `GetShiftsQuery` to accept an optional `staffMemberId`, allowing queries for specific staff members.

**Controller/API Changes:**

* Added a new endpoint `GET /shifts/staff/:staffMemberId` in `ShiftsController` to retrieve shifts for a specific staff member, with proper authorization checks to ensure non-manager users can only request their own shifts. [[1]](diffhunk://#diff-a23a43cccdd49954f0e60cd5163a8f2f8433953e07f1301765513ba385305bb0L60-R91) [[2]](diffhunk://#diff-a23a43cccdd49954f0e60cd5163a8f2f8433953e07f1301765513ba385305bb0L75-R102)
* Refactored controller logic to use a new `canViewAllStaff` helper method, improving code clarity and reuse for permission checks.

**Testing Improvements:**

* Introduced unit tests for `GetShiftsHandler` to verify:
  - Unauthorized access is blocked with a `ForbiddenException`
  - Managers can fetch shifts for any staff member
  - Existing behavior for staff users without an explicit `staffMemberId` is unchanged