### PR TITLE
Refactor: GetShifts response to map items to StaffShiftListItemDto

### DIFF
--- a/src/presentation/controllers/shifts.controller.ts
+++ b/src/presentation/controllers/shifts.controller.ts
@@ -6,7 +6,10 @@ import { UpdateShiftCommandResult } from '@/application/shift/commands/update-sh
 import { DeleteShiftCommand } from '@/application/shift/commands/delete-shift/delete-shift.command';
 import { DeleteShiftCommandResult } from '@/application/shift/commands/delete-shift/delete-shift.result';
 import { GetShiftsQuery } from '@/application/shift/queries/get-shifts/get-shifts.query';
-import { type GetShiftsResult } from '@/application/shift/queries/get-shifts/get-shifts.result';
+import {
+  type GetShiftsResult,
+  type ShiftListItemDto,
+} from '@/application/shift/queries/get-shifts/get-shifts.result';
 import { Permission } from '@/domain/role/value-objects/permission.vo';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
 import { RequirePermission } from '@/infrastructure/auth/decorators/require-permission.decorator';
@@ -88,7 +91,7 @@ export class ShiftsController {
     @CurrentUser() user: JwtPayload,
     @Param('staffMemberId') staffMemberId: string,
     @Query() dto: GetShiftsDto,
-  ): Promise<{ data: GetShiftsResult }> {
+  ): Promise<{ data: { items: StaffShiftListItemDto[] } }> {
     const result = await this.queryBus.execute<GetShiftsQuery, GetShiftsResult>(
       new GetShiftsQuery(
         user.tenantId,
@@ -103,7 +106,11 @@ export class ShiftsController {
       ),
     );
 
-    return { data: result };
+    return {
+      data: {
+        items: result.items.map((shift) => this.toStaffShiftListItemDto(shift)),
+      },
+    };
   }
 
   @Post()
@@ -265,4 +272,28 @@ export class ShiftsController {
       )
     );
   }
+
+  private toStaffShiftListItemDto(
+    shift: ShiftListItemDto,
+  ): StaffShiftListItemDto {
+    return {
+      id: shift.id,
+      tenantId: shift.tenantId,
+      propertyId: shift.propertyId,
+      name: shift.name,
+      startDate: shift.startDate,
+      endDate: shift.endDate,
+      startHour: shift.startHour,
+      endHour: shift.endHour,
+      startMinutes: shift.startMinutes,
+      endMinutes: shift.endMinutes,
+      notes: shift.notes,
+      createdBy: shift.createdBy,
+      createdByEmail: shift.createdByEmail,
+      createdAt: shift.createdAt,
+      updatedAt: shift.updatedAt,
+    };
+  }
 }
+
+type StaffShiftListItemDto = Omit<ShiftListItemDto, 'staffMemberIds'>;


### PR DESCRIPTION
This pull request updates the `ShiftsController` to change the shape of the data returned by the endpoint that retrieves shifts for a staff member. Instead of returning the raw shift data, it now transforms each shift into a new DTO (`StaffShiftListItemDto`) that omits the `staffMemberIds` field. This improves the clarity and security of the API response by only exposing relevant fields.

**API Response Restructuring:**

* The return type of the `getShiftsForStaffMember` endpoint is changed to return an object with a `data.items` array containing `StaffShiftListItemDto` objects, instead of the previous `GetShiftsResult` structure. [[1]](diffhunk://#diff-a23a43cccdd49954f0e60cd5163a8f2f8433953e07f1301765513ba385305bb0L91-R94) [[2]](diffhunk://#diff-a23a43cccdd49954f0e60cd5163a8f2f8433953e07f1301765513ba385305bb0L106-R113)

**Data Transformation:**

* Introduced a private method `toStaffShiftListItemDto` in `ShiftsController` to map `ShiftListItemDto` objects to `StaffShiftListItemDto`, explicitly omitting the `staffMemberIds` property.

**Type Definitions:**

* Added a new type alias `StaffShiftListItemDto` as an `Omit<ShiftListItemDto, 'staffMemberIds'>` to define the structure of the transformed shift items.

**Imports:**

* Updated imports to include `ShiftListItemDto` from the appropriate module for use in the new DTO and transformation logic.