### PR TITLE
Lymon 876 get experience by

### DIFF
--- a/src/application/experience/experience-application.module.ts
+++ b/src/application/experience/experience-application.module.ts
@@ -6,6 +6,7 @@ import { UpdateExperienceHandler } from '@/application/experience/commands/updat
 import { DeleteExperienceHandler } from '@/application/experience/commands/delete-experience.handler';
 import { GetExperiencesByTenantQueryHandler } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler';
 import { GetAvailableExperiencesQueryHandler } from '@/application/experience/queries/GetAvailableExperiences/get-available-experiences.query-handler';
+import { GetExperienceByIdQueryHandler } from '@/application/experience/queries/GetExperienceById/get-experience-by-id.query-handler';
 
 const CommandHandlers = [
   CreateExperienceHandler,
@@ -15,6 +16,7 @@ const CommandHandlers = [
 const QueryHandlers = [
   GetExperiencesByTenantQueryHandler,
   GetAvailableExperiencesQueryHandler,
+  GetExperienceByIdQueryHandler,
 ];
 
 @Module({

--- a/src/application/experience/experience-application.module.ts
+++ b/src/application/experience/experience-application.module.ts
@@ -7,6 +7,7 @@ import { DeleteExperienceHandler } from '@/application/experience/commands/delet
 import { GetExperiencesByTenantQueryHandler } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler';
 import { GetAvailableExperiencesQueryHandler } from '@/application/experience/queries/GetAvailableExperiences/get-available-experiences.query-handler';
 import { GetExperienceByIdQueryHandler } from '@/application/experience/queries/GetExperienceById/get-experience-by-id.query-handler';
+import { GetAvailableExperienceByIdQueryHandler } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query-handler';
 
 const CommandHandlers = [
   CreateExperienceHandler,
@@ -17,6 +18,7 @@ const QueryHandlers = [
   GetExperiencesByTenantQueryHandler,
   GetAvailableExperiencesQueryHandler,
   GetExperienceByIdQueryHandler,
+  GetAvailableExperienceByIdQueryHandler,
 ];
 
 @Module({

--- a/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query-handler.ts
+++ b/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query-handler.ts
@@ -1,0 +1,41 @@
+import { Inject, NotFoundException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetAvailableExperienceByIdQuery } from './get-available-experience-by-id.query';
+import { GetAvailableExperienceByIdResult } from './get-available-experience-by-id.result';
+import {
+  EXPERIENCE_REPOSITORY,
+  type ExperienceRepository,
+} from '@/domain/experience/repositories/experience.repository';
+import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
+import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
+import { mapExperienceToPublicDto } from '@/application/experience/queries/shared/experience.mapper';
+
+@QueryHandler(GetAvailableExperienceByIdQuery)
+export class GetAvailableExperienceByIdQueryHandler
+  implements
+    IQueryHandler<GetAvailableExperienceByIdQuery, GetAvailableExperienceByIdResult>
+{
+  constructor(
+    @Inject(EXPERIENCE_REPOSITORY)
+    private readonly experienceRepository: ExperienceRepository,
+  ) {}
+
+  async execute(
+    query: GetAvailableExperienceByIdQuery,
+  ): Promise<GetAvailableExperienceByIdResult> {
+    const experience = await this.experienceRepository.findById(
+      ExperienceId.create(query.experienceId),
+    );
+
+    if (!experience || experience.getStatus().toString() !== ExperienceStatus.active().toString()) {
+      throw new NotFoundException(
+        `Experience with id "${query.experienceId}" not found`,
+      );
+    }
+
+    return new GetAvailableExperienceByIdResult(
+      mapExperienceToPublicDto(experience),
+    );
+  }
+}
+

--- a/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query.ts
+++ b/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query.ts
@@ -1,0 +1,4 @@
+export class GetAvailableExperienceByIdQuery {
+  constructor(public readonly experienceId: string) {}
+}
+

--- a/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.result.ts
+++ b/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.result.ts
@@ -1,0 +1,6 @@
+import { PublicExperienceDto } from '@/application/experience/queries/shared/experience-read.dto';
+
+export class GetAvailableExperienceByIdResult {
+  constructor(public readonly experience: PublicExperienceDto) {}
+}
+

--- a/src/application/experience/queries/GetExperienceById/get-experience-by-id.query-handler.ts
+++ b/src/application/experience/queries/GetExperienceById/get-experience-by-id.query-handler.ts
@@ -1,0 +1,35 @@
+import { Inject, NotFoundException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetExperienceByIdQuery } from './get-experience-by-id.query';
+import { GetExperienceByIdResult } from './get-experience-by-id.result';
+import {
+  EXPERIENCE_REPOSITORY,
+  type ExperienceRepository,
+} from '@/domain/experience/repositories/experience.repository';
+import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
+import { mapExperienceToPublicDto } from '@/application/experience/queries/shared/experience.mapper';
+
+@QueryHandler(GetExperienceByIdQuery)
+export class GetExperienceByIdQueryHandler
+  implements IQueryHandler<GetExperienceByIdQuery, GetExperienceByIdResult>
+{
+  constructor(
+    @Inject(EXPERIENCE_REPOSITORY)
+    private readonly experienceRepository: ExperienceRepository,
+  ) {}
+
+  async execute(query: GetExperienceByIdQuery): Promise<GetExperienceByIdResult> {
+    const experience = await this.experienceRepository.findById(
+      ExperienceId.create(query.experienceId),
+    );
+
+    if (!experience || experience.getTenantId().toString() !== query.tenantId) {
+      throw new NotFoundException(
+        `Experience with id "${query.experienceId}" not found`,
+      );
+    }
+
+    return new GetExperienceByIdResult(mapExperienceToPublicDto(experience));
+  }
+}
+

--- a/src/application/experience/queries/GetExperienceById/get-experience-by-id.query.ts
+++ b/src/application/experience/queries/GetExperienceById/get-experience-by-id.query.ts
@@ -1,0 +1,7 @@
+export class GetExperienceByIdQuery {
+  constructor(
+    public readonly experienceId: string,
+    public readonly tenantId: string,
+  ) {}
+}
+

--- a/src/application/experience/queries/GetExperienceById/get-experience-by-id.result.ts
+++ b/src/application/experience/queries/GetExperienceById/get-experience-by-id.result.ts
@@ -1,0 +1,6 @@
+import { PublicExperienceDto } from '@/application/experience/queries/shared/experience-read.dto';
+
+export class GetExperienceByIdResult {
+  constructor(public readonly experience: PublicExperienceDto) {}
+}
+

--- a/src/presentation/controllers/experience.controller.ts
+++ b/src/presentation/controllers/experience.controller.ts
@@ -9,6 +9,8 @@ import { pickDefined } from '@/presentation/common/utils/pick-defined.util';
 import { DeleteExperienceCommand } from '@/application/experience/commands/delete-experience.command';
 import { GetExperiencesByTenantQuery } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query';
 import { GetExperiencesByTenantResult } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.result';
+import { GetExperienceByIdQuery } from '@/application/experience/queries/GetExperienceById/get-experience-by-id.query';
+import { GetExperienceByIdResult } from '@/application/experience/queries/GetExperienceById/get-experience-by-id.result';
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { Permission } from '@/domain/role/value-objects/permission.vo';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
@@ -99,6 +101,24 @@ export class ExperienceController {
           totalPages: result.totalPages,
         },
       },
+    };
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_VIEW)
+  @ApiOperation({ summary: 'Get experience by ID' })
+  @ApiResponse({ status: 200, description: 'Experience retrieved successfully' })
+  @ApiResponse({ status: 404, description: 'Experience not found' })
+  async getById(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
+    const result = await this.queryBus.execute<
+      GetExperienceByIdQuery,
+      GetExperienceByIdResult
+    >(new GetExperienceByIdQuery(id, user.tenantId));
+
+    return {
+      message: 'Experience retrieved successfully',
+      data: result.experience,
     };
   }
 

--- a/src/presentation/controllers/guest-experience.controller.ts
+++ b/src/presentation/controllers/guest-experience.controller.ts
@@ -1,25 +1,33 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 import {
-  ApiBearerAuth,
   ApiOperation,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { Public } from '@/infrastructure/auth/decorators/public.decorator';
+import { GuestPublic } from '@/infrastructure/guest-auth/decorators/guest-public.decorator';
 import { GuestJwtAuthGuard } from '@/infrastructure/guest-auth/guards/guest-jwt-auth.guard';
 import { GetAvailableExperiencesQuery } from '@/application/experience/queries/GetAvailableExperiences/get-available-experiences.query';
 import { GetAvailableExperiencesResult } from '@/application/experience/queries/GetAvailableExperiences/get-available-experiences.result';
 import { GetAvailableExperiencesQueryDto } from '@/presentation/dtos/experience/get-available-experiences-query.dto';
+import { GetAvailableExperienceByIdQuery } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query';
+import { GetAvailableExperienceByIdResult } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.result';
+import {
+  PublicExperienceBlackoutRangeDto,
+  PublicExperienceDto,
+  PublicExperienceLocationDto,
+  PublicExperienceRecurrenceDto,
+} from '@/application/experience/queries/shared/experience-read.dto';
 
 @ApiTags('guest-experiences')
-@ApiBearerAuth('GuestJWT-auth')
 @Public()
 @UseGuards(GuestJwtAuthGuard)
 @Controller('guest/experiences')
 export class GuestExperienceController {
   constructor(private readonly queryBus: QueryBus) {}
 
+  @GuestPublic()
   @Get()
   @ApiOperation({ summary: 'List available experiences for guests' })
   @ApiResponse({
@@ -28,8 +36,8 @@ export class GuestExperienceController {
   })
   async findAvailable(
     @Query() query: GetAvailableExperiencesQueryDto,
-  ): Promise<GetAvailableExperiencesResult> {
-    return this.queryBus.execute<
+  ): Promise<PublicExperienceCatalogListResult> {
+    const result = await this.queryBus.execute<
       GetAvailableExperiencesQuery,
       GetAvailableExperiencesResult
     >(
@@ -41,5 +49,105 @@ export class GuestExperienceController {
         query.category,
       ),
     );
+
+    return {
+      experiences: result.experiences.map((experience) =>
+        this.toCatalogExperienceDto(experience),
+      ),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+      totalPages: result.totalPages,
+    };
   }
+
+  @GuestPublic()
+  @Get(':id')
+  @ApiOperation({ summary: 'Get public available experience by ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Available experience retrieved successfully',
+  })
+  @ApiResponse({ status: 404, description: 'Experience not found' })
+  async findById(@Param('id') id: string) {
+    const result = await this.queryBus.execute<
+      GetAvailableExperienceByIdQuery,
+      GetAvailableExperienceByIdResult
+    >(new GetAvailableExperienceByIdQuery(id));
+
+    return {
+      data: this.toCatalogExperienceDto(result.experience),
+    };
+  }
+
+  private toCatalogExperienceDto(
+    experience: PublicExperienceDto,
+  ): PublicExperienceCatalogDto {
+    return {
+      id: experience.id,
+      scope: experience.scope,
+      propertyId: experience.propertyId,
+      name: experience.name,
+      description: experience.description,
+      category: experience.category,
+      priceCop: experience.priceCop,
+      durationHours: experience.durationHours,
+      capacity: experience.capacity,
+      coverImageUrl: experience.coverImageUrl,
+      location: new PublicExperienceLocationDto(
+        experience.location.label,
+        experience.location.address,
+        experience.location.lat,
+        experience.location.lng,
+      ),
+      availabilityType: experience.availabilityType,
+      startAt: experience.startAt,
+      endAt: experience.endAt,
+      recurrence: experience.recurrence
+        ? new PublicExperienceRecurrenceDto(
+            experience.recurrence.daysOfWeek,
+            experience.recurrence.startTime,
+            experience.recurrence.endTime,
+          )
+        : null,
+      blackoutRanges: experience.blackoutRanges.map(
+        (range) => new PublicExperienceBlackoutRangeDto(range.startAt, range.endAt),
+      ),
+      allowStandalonePurchase: experience.allowStandalonePurchase,
+      allowReservationPurchase: experience.allowReservationPurchase,
+      minNoticeHours: experience.minNoticeHours,
+      purchaseCutoffHours: experience.purchaseCutoffHours,
+    };
+  }
+}
+
+interface PublicExperienceCatalogDto {
+  id: string;
+  scope: string;
+  propertyId: string | null;
+  name: string;
+  description: string;
+  category: string;
+  priceCop: number;
+  durationHours: number;
+  capacity: number;
+  coverImageUrl: string;
+  location: PublicExperienceLocationDto;
+  availabilityType: string;
+  startAt: Date | null;
+  endAt: Date | null;
+  recurrence: PublicExperienceRecurrenceDto | null;
+  blackoutRanges: PublicExperienceBlackoutRangeDto[];
+  allowStandalonePurchase: boolean;
+  allowReservationPurchase: boolean;
+  minNoticeHours: number;
+  purchaseCutoffHours: number;
+}
+
+interface PublicExperienceCatalogListResult {
+  experiences: PublicExperienceCatalogDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
 }

--- a/test/application/experience/get-available-experience-by-id.spec.ts
+++ b/test/application/experience/get-available-experience-by-id.spec.ts
@@ -1,0 +1,91 @@
+import { NotFoundException } from '@nestjs/common';
+import { GetAvailableExperienceByIdQuery } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query';
+import { GetAvailableExperienceByIdQueryHandler } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query-handler';
+import { GetAvailableExperienceByIdResult } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.result';
+import { Experience } from '@/domain/experience/entities/experience.entity';
+import type { ExperienceRepository } from '@/domain/experience/repositories/experience.repository';
+import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
+import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
+import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
+import { ExperienceScope } from '@/domain/experience/value-objects/experience-scope.vo';
+import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { createExperienceRepositoryMock } from '@test/shared/mocks/repositories/experience-repository.mock';
+
+const EXPERIENCE_ID = 'experience-123';
+
+function makeExperience(status: 'ACTIVE' | 'ARCHIVED' = 'ACTIVE') {
+  return Experience.reconstitute({
+    id: ExperienceId.create(EXPERIENCE_ID),
+    tenantId: TenantId.createFromString('65f1a1a2b3c4d5e6f7a8b9c0'),
+    scope: ExperienceScope.create('PROPERTY'),
+    propertyId: PropertyId.create('65f1a1a2b3c4d5e6f7a8b9c1'),
+    unitIds: [UnitId.create('65f1a1a2b3c4d5e6f7a8b9c8')],
+    name: 'Airport transfer',
+    description: 'Private transfer service',
+    category: ExperienceCategory.create('TRANSPORTATION'),
+    priceCop: 120000,
+    durationHours: 2,
+    capacity: 8,
+    coverImageUrl: 'https://image.example.com/cover.jpg',
+    location: {
+      label: 'Main lobby',
+      address: 'Cra 10 #20-30, Bogota',
+      lat: 4.6097,
+      lng: -74.0817,
+    },
+    availabilityType: ExperienceAvailabilityType.create('DATE_RANGE'),
+    startAt: new Date('2099-01-10T10:00:00.000Z'),
+    endAt: new Date('2099-01-20T10:00:00.000Z'),
+    recurrence: undefined,
+    blackoutRanges: [],
+    allowStandalonePurchase: true,
+    allowReservationPurchase: true,
+    minNoticeHours: 2,
+    purchaseCutoffHours: 24,
+    status: ExperienceStatus.create(status),
+    createdAt: new Date('2099-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2099-01-01T00:00:00.000Z'),
+    deletedAt: null,
+  });
+}
+
+describe('GetAvailableExperienceByIdQueryHandler', () => {
+  let handler: GetAvailableExperienceByIdQueryHandler;
+  let experienceRepository: jest.Mocked<ExperienceRepository>;
+
+  beforeEach(() => {
+    experienceRepository = createExperienceRepositoryMock();
+    handler = new GetAvailableExperienceByIdQueryHandler(experienceRepository);
+  });
+
+  it('returns active experience by id', async () => {
+    experienceRepository.findById.mockResolvedValue(makeExperience('ACTIVE'));
+
+    const result = await handler.execute(
+      new GetAvailableExperienceByIdQuery(EXPERIENCE_ID),
+    );
+
+    expect(result).toBeInstanceOf(GetAvailableExperienceByIdResult);
+    expect(result.experience.id).toBe(EXPERIENCE_ID);
+  });
+
+  it('throws not found when experience does not exist', async () => {
+    experienceRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new GetAvailableExperienceByIdQuery(EXPERIENCE_ID)),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws not found when experience is not active', async () => {
+    experienceRepository.findById.mockResolvedValue(makeExperience('ARCHIVED'));
+
+    await expect(
+      handler.execute(new GetAvailableExperienceByIdQuery(EXPERIENCE_ID)),
+    ).rejects.toThrow(NotFoundException);
+  });
+});
+

--- a/test/application/experience/get-experiences-by-tenant.spec.ts
+++ b/test/application/experience/get-experiences-by-tenant.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Experience } from '@/domain/experience/entities/experience.entity';
 import type { ExperienceRepository } from '@/domain/experience/repositories/experience.repository';
@@ -15,14 +16,19 @@ import { ExperienceController } from '@/presentation/controllers/experience.cont
 import { GetExperiencesByTenantQuery } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query';
 import { GetExperiencesByTenantQueryHandler } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler';
 import { GetExperiencesByTenantResult } from '@/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.result';
+import { GetExperienceByIdQuery } from '@/application/experience/queries/GetExperienceById/get-experience-by-id.query';
+import { GetExperienceByIdQueryHandler } from '@/application/experience/queries/GetExperienceById/get-experience-by-id.query-handler';
+import { GetExperienceByIdResult } from '@/application/experience/queries/GetExperienceById/get-experience-by-id.result';
 
 const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c0';
 const EXPERIENCE_ID = 'experience-123';
 
-function makeExperience(overrides?: Partial<{ id: string }>) {
+function makeExperience(
+  overrides?: Partial<{ id: string; tenantId: string }>,
+) {
   return Experience.reconstitute({
     id: ExperienceId.create(overrides?.id ?? EXPERIENCE_ID),
-    tenantId: TenantId.createFromString(TENANT_ID),
+    tenantId: TenantId.createFromString(overrides?.tenantId ?? TENANT_ID),
     scope: ExperienceScope.create('PROPERTY'),
     propertyId: PropertyId.create('65f1a1a2b3c4d5e6f7a8b9c1'),
     unitIds: [UnitId.create('65f1a1a2b3c4d5e6f7a8b9c8')],
@@ -57,6 +63,7 @@ function makeExperience(overrides?: Partial<{ id: string }>) {
 
 describe('GetExperiencesByTenant', () => {
   let handler: GetExperiencesByTenantQueryHandler;
+  let getByIdHandler: GetExperienceByIdQueryHandler;
   let experienceRepository: jest.Mocked<ExperienceRepository>;
   let controller: ExperienceController;
   let queryBus: QueryBus;
@@ -65,6 +72,7 @@ describe('GetExperiencesByTenant', () => {
     experienceRepository = createExperienceRepositoryMock();
 
     handler = new GetExperiencesByTenantQueryHandler(experienceRepository);
+    getByIdHandler = new GetExperienceByIdQueryHandler(experienceRepository);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ExperienceController],
@@ -127,5 +135,55 @@ describe('GetExperiencesByTenant', () => {
       expect.any(GetExperiencesByTenantQuery),
     );
     expect(response.data.experiences[0].id).toBe(EXPERIENCE_ID);
+  });
+
+  it('getById handler returns mapped experience for same tenant', async () => {
+    experienceRepository.findById.mockResolvedValue(makeExperience());
+
+    const result = await getByIdHandler.execute(
+      new GetExperienceByIdQuery(EXPERIENCE_ID, TENANT_ID),
+    );
+
+    expect(result).toBeInstanceOf(GetExperienceByIdResult);
+    expect(result.experience.id).toBe(EXPERIENCE_ID);
+  });
+
+  it('getById handler throws NotFound when experience does not exist', async () => {
+    experienceRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      getByIdHandler.execute(new GetExperienceByIdQuery(EXPERIENCE_ID, TENANT_ID)),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('getById handler throws NotFound when experience belongs to other tenant', async () => {
+    experienceRepository.findById.mockResolvedValue(
+      makeExperience({ tenantId: 'other-tenant-id' }),
+    );
+
+    await expect(
+      getByIdHandler.execute(new GetExperienceByIdQuery(EXPERIENCE_ID, TENANT_ID)),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('controller getById executes query bus with experience and tenant id', async () => {
+    const mockResult = new GetExperienceByIdResult(
+      {
+        id: EXPERIENCE_ID,
+      } as any,
+    );
+    (queryBus.execute as jest.Mock).mockResolvedValue(mockResult);
+
+    const response = await controller.getById(
+      {
+        tenantId: TENANT_ID,
+      } as any,
+      EXPERIENCE_ID,
+    );
+
+    expect(queryBus.execute).toHaveBeenCalledWith(
+      expect.any(GetExperienceByIdQuery),
+    );
+    expect(response.data.id).toBe(EXPERIENCE_ID);
   });
 });

--- a/test/presentation/controllers/guest-experience.controller.spec.ts
+++ b/test/presentation/controllers/guest-experience.controller.spec.ts
@@ -1,0 +1,73 @@
+import { QueryBus } from '@nestjs/cqrs';
+import { GuestExperienceController } from '@/presentation/controllers/guest-experience.controller';
+import { GetAvailableExperiencesQuery } from '@/application/experience/queries/GetAvailableExperiences/get-available-experiences.query';
+import { GetAvailableExperienceByIdQuery } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query';
+import { GetAvailableExperiencesResult } from '@/application/experience/queries/GetAvailableExperiences/get-available-experiences.result';
+import { GetAvailableExperienceByIdResult } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.result';
+
+describe('GuestExperienceController', () => {
+  let controller: GuestExperienceController;
+  let queryBus: { execute: jest.Mock };
+
+  const experience = {
+    id: 'exp-1',
+    tenantId: 'tenant-1',
+    scope: 'PROPERTY',
+    propertyId: 'prop-1',
+    unitIds: ['unit-1'],
+    name: 'Kayak tour',
+    description: 'Tour',
+    category: 'ADVENTURE',
+    priceCop: 100000,
+    durationHours: 3,
+    capacity: 10,
+    coverImageUrl: 'https://img',
+    location: { label: 'Dock', address: 'Address', lat: 1, lng: 2 },
+    availabilityType: 'DATE_RANGE',
+    startAt: null,
+    endAt: null,
+    recurrence: null,
+    blackoutRanges: [],
+    allowStandalonePurchase: true,
+    allowReservationPurchase: true,
+    minNoticeHours: 2,
+    purchaseCutoffHours: 24,
+    status: 'ACTIVE',
+  } as any;
+
+  beforeEach(() => {
+    queryBus = { execute: jest.fn() };
+    controller = new GuestExperienceController(queryBus as unknown as QueryBus);
+  });
+
+  it('list endpoint dispatches query and omits tenantId/unitIds/status', async () => {
+    queryBus.execute.mockResolvedValue(
+      new GetAvailableExperiencesResult([experience], 1, 1, 10),
+    );
+
+    const result = await controller.findAvailable({});
+
+    expect(queryBus.execute).toHaveBeenCalledWith(
+      expect.any(GetAvailableExperiencesQuery),
+    );
+    expect(result.experiences[0]).not.toHaveProperty('tenantId');
+    expect(result.experiences[0]).not.toHaveProperty('unitIds');
+    expect(result.experiences[0]).not.toHaveProperty('status');
+  });
+
+  it('by id endpoint dispatches query and omits tenantId/unitIds/status', async () => {
+    queryBus.execute.mockResolvedValue(
+      new GetAvailableExperienceByIdResult(experience),
+    );
+
+    const result = await controller.findById('exp-1');
+
+    expect(queryBus.execute).toHaveBeenCalledWith(
+      expect.any(GetAvailableExperienceByIdQuery),
+    );
+    expect(result.data).not.toHaveProperty('tenantId');
+    expect(result.data).not.toHaveProperty('unitIds');
+    expect(result.data).not.toHaveProperty('status');
+  });
+});
+


### PR DESCRIPTION
This pull request introduces two new queries for retrieving experience details by ID, both for authenticated users (tenants) and for guests, and integrates them into the application and presentation layers. It also adds comprehensive tests for these new handlers. These changes enhance the API by allowing clients to fetch individual experience details, with appropriate access control and filtering for active status and tenant ownership.

**New Experience Query Features:**

* Added `GetExperienceByIdQuery` and `GetAvailableExperienceByIdQuery` handlers, queries, and result DTOs to allow fetching experience details by ID for tenants and guests, respectively. The tenant version checks ownership, while the guest version restricts results to active experiences. [[1]](diffhunk://#diff-ed8305be163ee494737583a00f728b95767e8b323bb57180f27aa6c897b8a7ecR1-R35) [[2]](diffhunk://#diff-0a583121cbf82ea1c1268bbb9a985a65f245aaffb57b45d937a818386af29ba5R1-R7) [[3]](diffhunk://#diff-4cfdf95d7cefb343e280dbd4580ca95a1cba81119765f245fe4801007a47f85eR1-R6) [[4]](diffhunk://#diff-8207a393e58dd3ba8b15a6d31f982e139cef77d10de0c46357310224e750f14eR1-R41) [[5]](diffhunk://#diff-a54c23dcb327800d3db618ec5158a1bf39c66095a535924818a6832e499dfa57R1-R4) [[6]](diffhunk://#diff-57532ef94ad13047e68459e73e3f41d2664dde18ea0dba9455b260f9b4c3af86R1-R6)

* Registered the new query handlers in the `experience-application.module.ts` so they are available for dependency injection and CQRS dispatching. [[1]](diffhunk://#diff-f5a38127984c38de391a67bb8a44bda83c8baf65c31be96c99e34e3c018555e3R9-R10) [[2]](diffhunk://#diff-f5a38127984c38de391a67bb8a44bda83c8baf65c31be96c99e34e3c018555e3R20-R21)

**API Controller Enhancements:**

* Added a new endpoint to `ExperienceController` (`GET /experiences/:id`) for tenants to fetch experience details by ID, enforcing permission and tenant ownership. [[1]](diffhunk://#diff-276256878cabeac42468106bda5a3f140e896ba2ea461c5a639665d0e5ec2e03R12-R13) [[2]](diffhunk://#diff-276256878cabeac42468106bda5a3f140e896ba2ea461c5a639665d0e5ec2e03R107-R124)

* Added a new endpoint to `GuestExperienceController` (`GET /guest/experiences/:id`) for guests to fetch public experience details by ID, returning only active experiences. Also refactored the guest list endpoint to return a mapped DTO structure. [[1]](diffhunk://#diff-b1ab48ca547fa81539f9b90b1fe314562f1b5456d89ebc679da79941b60711a3L1-R30) [[2]](diffhunk://#diff-b1ab48ca547fa81539f9b90b1fe314562f1b5456d89ebc679da79941b60711a3L31-R40) [[3]](diffhunk://#diff-b1ab48ca547fa81539f9b90b1fe314562f1b5456d89ebc679da79941b60711a3R52-R152)

**Testing:**

* Added tests for `GetAvailableExperienceByIdQueryHandler` to ensure correct behavior when fetching, missing, or inactive experiences.

* Updated and extended tests for tenant experience queries to cover the new `GetExperienceByIdQueryHandler`. [[1]](diffhunk://#diff-7f3ea275ee4ff62bfd5e744a47c4a6ff7024d433f6bb33233d6baeb501ee169aR2) [[2]](diffhunk://#diff-7f3ea275ee4ff62bfd5e744a47c4a6ff7024d433f6bb33233d6baeb501ee169aR19-R31) [[3]](diffhunk://#diff-7f3ea275ee4ff62bfd5e744a47c4a6ff7024d433f6bb33233d6baeb501ee169aR66) [[4]](diffhunk://#diff-7f3ea275ee4ff62bfd5e744a47c4a6ff7024d433f6bb33233d6baeb501ee169aR75)