### PR TITLE
LYMON-890 feat(units): add GET /units/unit/:unitId endpoint with exte…

### DIFF
--- a/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler.ts
+++ b/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler.ts
@@ -1,0 +1,73 @@
+import { Inject, NotFoundException } from '@nestjs/common';
+import { QueryHandler, IQueryHandler } from '@nestjs/cqrs';
+import { GetUnitWithExternalIdsByIdQuery } from './get-unit-with-external-ids-by-id.query';
+import {
+  ExternalIdsDto,
+  GetUnitWithExternalIdsByIdResult,
+  UnitWithExternalIdsDto,
+} from './get-unit-with-external-ids-by-id.result';
+import { UNIT_REPOSITORY } from '@/domain/unit/repositories/unit.repository';
+import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import {
+  PublicBedDto,
+  PublicBedroomDto,
+} from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.result';
+
+@QueryHandler(GetUnitWithExternalIdsByIdQuery)
+export class GetUnitWithExternalIdsByIdQueryHandler
+  implements
+    IQueryHandler<
+      GetUnitWithExternalIdsByIdQuery,
+      GetUnitWithExternalIdsByIdResult
+    >
+{
+  constructor(
+    @Inject(UNIT_REPOSITORY)
+    private readonly unitRepository: UnitRepository,
+  ) {}
+
+  async execute(
+    query: GetUnitWithExternalIdsByIdQuery,
+  ): Promise<GetUnitWithExternalIdsByIdResult> {
+    const unitId = UnitId.create(query.unitId);
+    const unit = await this.unitRepository.findById(unitId);
+
+    if (!unit || unit.getTenantId().toString() !== query.tenantId) {
+      throw new NotFoundException('Unit not found');
+    }
+
+    const bedrooms = unit.getBedrooms().map(
+      (bedroom) =>
+        new PublicBedroomDto(
+          bedroom.roomName,
+          bedroom.beds.map((bed) => new PublicBedDto(bed.type, bed.count)),
+        ),
+    );
+
+    const externalIds = unit.getExternalIds();
+    const externalIdsDto = new ExternalIdsDto(
+      externalIds?.getAirbnbId(),
+      externalIds?.getBookingId(),
+      externalIds?.getVrboId(),
+    );
+
+    const dto = new UnitWithExternalIdsDto(
+      unit.getId()?.toString() ?? '',
+      unit.getName(),
+      unit.getDescription(),
+      unit.getMaxGuests(),
+      unit.getStandardGuests(),
+      bedrooms,
+      unit.getBathroomsCount(),
+      unit.getIsShared(),
+      unit.getAmenities(),
+      unit.getPricePerNight(),
+      unit.getTenantId().toString(),
+      unit.getPropertyId().toString(),
+      externalIdsDto,
+    );
+
+    return new GetUnitWithExternalIdsByIdResult(dto);
+  }
+}

--- a/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query.ts
+++ b/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query.ts
@@ -1,0 +1,6 @@
+export class GetUnitWithExternalIdsByIdQuery {
+  constructor(
+    public readonly unitId: string,
+    public readonly tenantId: string,
+  ) {}
+}

--- a/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result.ts
+++ b/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result.ts
@@ -1,0 +1,49 @@
+import {
+  PublicBedroomDto,
+  PublicUnitDto,
+} from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.result';
+
+export class ExternalIdsDto {
+  constructor(
+    public readonly airbnbId?: string,
+    public readonly bookingId?: string,
+    public readonly vrboId?: string,
+  ) {}
+}
+
+export class UnitWithExternalIdsDto extends PublicUnitDto {
+  constructor(
+    id: string,
+    name: string,
+    description: string,
+    maxGuests: number,
+    standardGuests: number,
+    bedrooms: PublicBedroomDto[],
+    bathroomsCount: number,
+    isShared: boolean,
+    amenities: string[],
+    pricePerNight: number,
+    tenantId: string,
+    propertyId: string,
+    public readonly externalIds: ExternalIdsDto,
+  ) {
+    super(
+      id,
+      name,
+      description,
+      maxGuests,
+      standardGuests,
+      bedrooms,
+      bathroomsCount,
+      isShared,
+      amenities,
+      pricePerNight,
+      tenantId,
+      propertyId,
+    );
+  }
+}
+
+export class GetUnitWithExternalIdsByIdResult {
+  constructor(public readonly unit: UnitWithExternalIdsDto) {}
+}

--- a/src/application/unit/unit-application.module.ts
+++ b/src/application/unit/unit-application.module.ts
@@ -7,6 +7,7 @@ import { GetUnitsByPropertyQueryHandler } from '@/application/unit/queries/GetUn
 import { GetPublicUnitsByTenantQueryHandler } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler';
 import { GetPublicUnitByIdQueryHandler } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query-handler';
 import { GetAllPublicUnitsQueryHandler } from '@/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler';
+import { GetUnitWithExternalIdsByIdQueryHandler } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 
 const CommandHandlers = [
@@ -19,6 +20,7 @@ const QueryHandlers = [
   GetPublicUnitsByTenantQueryHandler,
   GetPublicUnitByIdQueryHandler,
   GetAllPublicUnitsQueryHandler,
+  GetUnitWithExternalIdsByIdQueryHandler,
 ];
 
 @Module({

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -11,6 +11,8 @@ import { GetAllPublicUnitsQuery } from '@/application/unit/queries/GetAllPublicU
 import { GetAllPublicUnitsResult } from '@/application/unit/queries/GetAllPublicUnits/get-all-public-units.result';
 import { GetPublicUnitByIdQuery } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query';
 import { GetPublicUnitByIdResult } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.result';
+import { GetUnitWithExternalIdsByIdQuery } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query';
+import { GetUnitWithExternalIdsByIdResult } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result';
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
 import { Public } from '@/infrastructure/auth/decorators/public.decorator';
@@ -264,6 +266,31 @@ export class UnitController {
           limit: result.limit,
           totalPages: result.totalPages,
         },
+      },
+    };
+  }
+
+  @Get('unit/:unitId')
+  @ApiOperation({
+    summary: 'Get a specific unit by ID including external IDs (tenant only)',
+  })
+  @ApiResponse({ status: 200, description: 'Unit retrieved successfully' })
+  @ApiResponse({ status: 404, description: 'Unit not found' })
+  async getByIdWithExternalIds(
+    @CurrentUser() user: JwtPayload,
+    @Param('unitId') unitId: string,
+  ) {
+    const query = new GetUnitWithExternalIdsByIdQuery(unitId, user.tenantId);
+
+    const result = await this.queryBus.execute<
+      GetUnitWithExternalIdsByIdQuery,
+      GetUnitWithExternalIdsByIdResult
+    >(query);
+
+    return {
+      message: 'Unit retrieved successfully',
+      data: {
+        unit: result.unit,
       },
     };
   }

--- a/test/application/unit/get-public-unit-by-id.spec.ts
+++ b/test/application/unit/get-public-unit-by-id.spec.ts
@@ -5,50 +5,11 @@ import { GetPublicUnitByIdQueryHandler } from '@/application/unit/queries/GetPub
 import { GetPublicUnitByIdQuery } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query';
 import { GetPublicUnitByIdResult } from '@/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.result';
 import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
-import { Unit } from '@/domain/unit/entities/unit.entity';
-import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
-import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
-import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
-import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
 import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
+import { makeUnit, UNIT_FIXTURE_DEFAULTS } from '@test/shared/fixtures/unit.fixture';
 import { UnitController } from '@/presentation/controllers/unit.controller';
 
-const UNIT_ID = '65f1a1a2b3c4d5e6f7a8b9c8';
-const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c0';
-const PROPERTY_ID = '65f1a1a2b3c4d5e6f7a8b9c1';
-
-function makeUnit(overrides?: Partial<{ id: string }>): Unit {
-  return Unit.reconstitute({
-    id: UnitId.create(overrides?.id ?? UNIT_ID),
-    tenantId: TenantId.createFromString(TENANT_ID),
-    propertyId: PropertyId.create(PROPERTY_ID),
-    basicInfo: {
-      name: 'Unit Name',
-      description: 'Unit Description',
-    },
-    inventoryConfig: {
-      inventoryCount: 1,
-    },
-    capacityConfig: {
-      maxGuests: 4,
-      standardGuests: 2,
-    },
-    physicalFeatures: {
-      bedrooms: [],
-      bathroomsCount: 1,
-      isShared: false,
-    },
-    pricingConfig: {
-      pricePerNight: 100,
-    },
-    amenities: ['wifi'],
-    externalIds: ExternalIds.create('ext-airbnb', 'ext-booking', 'ext-vrbo'),
-    timestamps: {
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-  });
-}
+const UNIT_ID = UNIT_FIXTURE_DEFAULTS.id;
 
 describe('GetPublicUnitById', () => {
   let handler: GetPublicUnitByIdQueryHandler;
@@ -108,7 +69,6 @@ describe('GetPublicUnitById', () => {
       const result = await handler.execute(query);
 
       expect(result.unit).not.toHaveProperty('externalIds');
-
       expect(result.unit.name).toBe(unit.getName());
     });
   });

--- a/test/application/unit/get-unit-with-external-ids-by-id.spec.ts
+++ b/test/application/unit/get-unit-with-external-ids-by-id.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { GetUnitWithExternalIdsByIdQueryHandler } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler';
+import { GetUnitWithExternalIdsByIdQuery } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query';
+import { GetUnitWithExternalIdsByIdResult } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result';
+import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import { Unit } from '@/domain/unit/entities/unit.entity';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
+import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
+import { UnitController } from '@/presentation/controllers/unit.controller';
+
+const UNIT_ID = '65f1a1a2b3c4d5e6f7a8b9c8';
+const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c0';
+const OTHER_TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9ff';
+const PROPERTY_ID = '65f1a1a2b3c4d5e6f7a8b9c1';
+
+function makeUnit(tenantId = TENANT_ID): Unit {
+  return Unit.reconstitute({
+    id: UnitId.create(UNIT_ID),
+    tenantId: TenantId.createFromString(tenantId),
+    propertyId: PropertyId.create(PROPERTY_ID),
+    basicInfo: {
+      name: 'Unit Name',
+      description: 'Unit Description',
+    },
+    inventoryConfig: {
+      inventoryCount: 1,
+    },
+    capacityConfig: {
+      maxGuests: 4,
+      standardGuests: 2,
+    },
+    physicalFeatures: {
+      bedrooms: [],
+      bathroomsCount: 1,
+      isShared: false,
+    },
+    pricingConfig: {
+      pricePerNight: 100,
+    },
+    amenities: ['wifi'],
+    externalIds: ExternalIds.create('ext-airbnb', 'ext-booking', 'ext-vrbo'),
+    timestamps: {
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+}
+
+describe('GetUnitWithExternalIdsById', () => {
+  let handler: GetUnitWithExternalIdsByIdQueryHandler;
+  let unitRepository: jest.Mocked<UnitRepository>;
+  let controller: UnitController;
+  let queryBus: QueryBus;
+
+  beforeEach(async () => {
+    unitRepository = createUnitRepositoryMock();
+    handler = new GetUnitWithExternalIdsByIdQueryHandler(unitRepository);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UnitController],
+      providers: [
+        {
+          provide: QueryBus,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: CommandBus,
+          useValue: { execute: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UnitController>(UnitController);
+    queryBus = module.get<QueryBus>(QueryBus);
+  });
+
+  describe('TC-01: Consultar una Unit válida del tenant autenticado', () => {
+    it('Handler should return the unit as UnitWithExternalIdsDto', async () => {
+      const unit = makeUnit();
+      unitRepository.findById.mockResolvedValue(unit);
+
+      const query = new GetUnitWithExternalIdsByIdQuery(UNIT_ID, TENANT_ID);
+      const result = await handler.execute(query);
+
+      expect(result).toBeInstanceOf(GetUnitWithExternalIdsByIdResult);
+      expect(result.unit.id).toBe(UNIT_ID);
+      expect(result.unit.name).toBe(unit.getName());
+    });
+
+    it('Handler should throw NotFoundException if unit does not exist', async () => {
+      unitRepository.findById.mockResolvedValue(null);
+
+      const query = new GetUnitWithExternalIdsByIdQuery('invalid-id', TENANT_ID);
+      await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+    });
+
+    it('Handler should throw NotFoundException if unit belongs to a different tenant', async () => {
+      const unit = makeUnit(OTHER_TENANT_ID);
+      unitRepository.findById.mockResolvedValue(unit);
+
+      const query = new GetUnitWithExternalIdsByIdQuery(UNIT_ID, TENANT_ID);
+      await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('TC-02: Verificar inclusión de externalIds en la respuesta', () => {
+    it('The resulting DTO must contain externalIds with airbnbId, bookingId and vrboId', async () => {
+      const unit = makeUnit();
+      unitRepository.findById.mockResolvedValue(unit);
+
+      const query = new GetUnitWithExternalIdsByIdQuery(UNIT_ID, TENANT_ID);
+      const result = await handler.execute(query);
+
+      expect(result.unit).toHaveProperty('externalIds');
+      expect(result.unit.externalIds.airbnbId).toBe('ext-airbnb');
+      expect(result.unit.externalIds.bookingId).toBe('ext-booking');
+      expect(result.unit.externalIds.vrboId).toBe('ext-vrbo');
+    });
+  });
+
+  describe('TC-03: Acceso protegido por autenticación de tenant', () => {
+    it('The controller method should NOT have the @Public() decorator', () => {
+      const target = controller.getByIdWithExternalIds;
+      const isPublic = Reflect.getMetadata('isPublic', target);
+      expect(isPublic).toBeUndefined();
+    });
+
+    it('The controller should call the query bus with tenantId from the authenticated user', async () => {
+      const mockResult = new GetUnitWithExternalIdsByIdResult({
+        id: UNIT_ID,
+        name: 'Unit Name',
+        externalIds: { airbnbId: 'ext-airbnb' },
+      } as any);
+      (queryBus.execute as jest.Mock).mockResolvedValue(mockResult);
+
+      const fakeUser = { tenantId: TENANT_ID, userId: 'user-1', email: 'a@b.com' } as any;
+      const response = await controller.getByIdWithExternalIds(fakeUser, UNIT_ID);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          unitId: UNIT_ID,
+          tenantId: TENANT_ID,
+        }),
+      );
+      expect(response.data.unit.id).toBe(UNIT_ID);
+    });
+  });
+});

--- a/test/application/unit/get-unit-with-external-ids-by-id.spec.ts
+++ b/test/application/unit/get-unit-with-external-ids-by-id.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { GetUnitWithExternalIdsByIdQueryHandler } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler';
+import { GetUnitWithExternalIdsByIdQuery } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query';
+import { GetUnitWithExternalIdsByIdResult } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result';
+import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
+import {
+  makeUnit,
+  UNIT_FIXTURE_DEFAULTS,
+} from '@test/shared/fixtures/unit.fixture';
+import { UnitController } from '@/presentation/controllers/unit.controller';
+
+const UNIT_ID = UNIT_FIXTURE_DEFAULTS.id;
+const TENANT_ID = UNIT_FIXTURE_DEFAULTS.tenantId;
+const OTHER_TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9ff';
+
+describe('GetUnitWithExternalIdsById', () => {
+  let handler: GetUnitWithExternalIdsByIdQueryHandler;
+  let unitRepository: jest.Mocked<UnitRepository>;
+  let controller: UnitController;
+  let queryBus: QueryBus;
+
+  beforeEach(async () => {
+    unitRepository = createUnitRepositoryMock();
+    handler = new GetUnitWithExternalIdsByIdQueryHandler(unitRepository);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UnitController],
+      providers: [
+        {
+          provide: QueryBus,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: CommandBus,
+          useValue: { execute: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UnitController>(UnitController);
+    queryBus = module.get<QueryBus>(QueryBus);
+  });
+
+  describe('TC-01: Consultar una Unit válida del tenant autenticado', () => {
+    it('Handler should return the unit as UnitWithExternalIdsDto', async () => {
+      const unit = makeUnit();
+      unitRepository.findById.mockResolvedValue(unit);
+
+      const query = new GetUnitWithExternalIdsByIdQuery(UNIT_ID, TENANT_ID);
+      const result = await handler.execute(query);
+
+      expect(result).toBeInstanceOf(GetUnitWithExternalIdsByIdResult);
+      expect(result.unit.id).toBe(UNIT_ID);
+      expect(result.unit.name).toBe(unit.getName());
+    });
+
+    it('Handler should throw NotFoundException if unit does not exist', async () => {
+      unitRepository.findById.mockResolvedValue(null);
+
+      const query = new GetUnitWithExternalIdsByIdQuery('invalid-id', TENANT_ID);
+      await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+    });
+
+    it('Handler should throw NotFoundException if unit belongs to a different tenant', async () => {
+      const unit = makeUnit({ tenantId: OTHER_TENANT_ID });
+      unitRepository.findById.mockResolvedValue(unit);
+
+      const query = new GetUnitWithExternalIdsByIdQuery(UNIT_ID, TENANT_ID);
+      await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('TC-02: Verificar inclusión de externalIds en la respuesta', () => {
+    it('The resulting DTO must contain externalIds with airbnbId, bookingId and vrboId', async () => {
+      const unit = makeUnit();
+      unitRepository.findById.mockResolvedValue(unit);
+
+      const query = new GetUnitWithExternalIdsByIdQuery(UNIT_ID, TENANT_ID);
+      const result = await handler.execute(query);
+
+      expect(result.unit).toHaveProperty('externalIds');
+      expect(result.unit.externalIds.airbnbId).toBe(UNIT_FIXTURE_DEFAULTS.externalIds.airbnbId);
+      expect(result.unit.externalIds.bookingId).toBe(UNIT_FIXTURE_DEFAULTS.externalIds.bookingId);
+      expect(result.unit.externalIds.vrboId).toBe(UNIT_FIXTURE_DEFAULTS.externalIds.vrboId);
+    });
+  });
+
+  describe('TC-03: Acceso protegido por autenticación de tenant', () => {
+    it('The controller method should NOT have the @Public() decorator', () => {
+      const target = controller.getByIdWithExternalIds;
+      const isPublic = Reflect.getMetadata('isPublic', target);
+      expect(isPublic).toBeUndefined();
+    });
+
+    it('The controller should call the query bus with tenantId from the authenticated user', async () => {
+      const mockResult = new GetUnitWithExternalIdsByIdResult({
+        id: UNIT_ID,
+        name: 'Unit Name',
+        externalIds: { airbnbId: 'ext-airbnb' },
+      } as any);
+      (queryBus.execute as jest.Mock).mockResolvedValue(mockResult);
+
+      const fakeUser = { tenantId: TENANT_ID, userId: 'user-1', email: 'a@b.com' } as any;
+      const response = await controller.getByIdWithExternalIds(fakeUser, UNIT_ID);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          unitId: UNIT_ID,
+          tenantId: TENANT_ID,
+        }),
+      );
+      expect(response.data.unit.id).toBe(UNIT_ID);
+    });
+  });
+});

--- a/test/application/unit/get-unit-with-external-ids-by-id.spec.ts
+++ b/test/application/unit/get-unit-with-external-ids-by-id.spec.ts
@@ -1,0 +1,141 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { GetUnitWithExternalIdsByIdQueryHandler } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler';
+import { GetUnitWithExternalIdsByIdQuery } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query';
+import { GetUnitWithExternalIdsByIdResult } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result';
+import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import { Unit } from '@/domain/unit/entities/unit.entity';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
+import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
+import { UnitController } from '@/presentation/controllers/unit.controller';
+
+const UNIT_ID = '65f1a1a2b3c4d5e6f7a8b9c8';
+const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c0';
+const OTHER_TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9ff';
+const PROPERTY_ID = '65f1a1a2b3c4d5e6f7a8b9c1';
+
+function makeUnit(tenantId = TENANT_ID): Unit {
+  return Unit.reconstitute({
+    id: UnitId.create(UNIT_ID),
+    tenantId: TenantId.createFromString(tenantId),
+    propertyId: PropertyId.create(PROPERTY_ID),
+    basicInfo: {
+      name: 'Unit Name',
+      description: 'Unit Description',
+    },
+    inventoryConfig: {
+      inventoryCount: 1,
+    },
+    capacityConfig: {
+      maxGuests: 4,
+      standardGuests: 2,
+    },
+    physicalFeatures: {
+      bedrooms: [],
+      bathroomsCount: 1,
+      isShared: false,
+    },
+    pricingConfig: {
+      pricePerNight: 100,
+    },
+    amenities: ['wifi'],
+    externalIds: ExternalIds.create('ext-airbnb', 'ext-booking', 'ext-vrbo'),
+    timestamps: {
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+}
+
+describe('GetUnitWithExternalIdsById', () => {
+  let handler: GetUnitWithExternalIdsByIdQueryHandler;
+  let unitRepository: jest.Mocked<UnitRepository>;
+  let controller: UnitController;
+  let queryBus: QueryBus;
+
+  beforeEach(async () => {
+    unitRepository = createUnitRepositoryMock();
+    handler = new GetUnitWithExternalIdsByIdQueryHandler(unitRepository);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UnitController],
+      providers: [
+        {
+          provide: QueryBus,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: CommandBus,
+          useValue: { execute: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<UnitController>(UnitController);
+    queryBus = module.get<QueryBus>(QueryBus);
+  });
+
+  describe('TC-01: Consultar una Unit válida del tenant autenticado', () => {
+    it('Handler should return the unit as UnitWithExternalIdsDto including externalIds', async () => {
+      const unit = makeUnit();
+      unitRepository.findById.mockResolvedValue(unit);
+
+      const query = new GetUnitWithExternalIdsByIdQuery(UNIT_ID, TENANT_ID);
+      const result = await handler.execute(query);
+
+      expect(result).toBeInstanceOf(GetUnitWithExternalIdsByIdResult);
+      expect(result.unit.id).toBe(UNIT_ID);
+      expect(result.unit.name).toBe(unit.getName());
+      expect(result.unit.externalIds.airbnbId).toBe('ext-airbnb');
+      expect(result.unit.externalIds.bookingId).toBe('ext-booking');
+      expect(result.unit.externalIds.vrboId).toBe('ext-vrbo');
+    });
+
+    it('Handler should throw NotFoundException if unit does not exist', async () => {
+      unitRepository.findById.mockResolvedValue(null);
+
+      const query = new GetUnitWithExternalIdsByIdQuery('invalid-id', TENANT_ID);
+      await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+    });
+
+    it('Handler should throw NotFoundException if unit belongs to a different tenant', async () => {
+      const unit = makeUnit(OTHER_TENANT_ID);
+      unitRepository.findById.mockResolvedValue(unit);
+
+      const query = new GetUnitWithExternalIdsByIdQuery(UNIT_ID, TENANT_ID);
+      await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('TC-02: Acceso protegido por autenticación de tenant', () => {
+    it('The controller method should NOT have the @Public() decorator', () => {
+      const target = controller.getByIdWithExternalIds;
+      const isPublic = Reflect.getMetadata('isPublic', target);
+      expect(isPublic).toBeUndefined();
+    });
+
+    it('The controller should call the query bus with tenantId from the authenticated user', async () => {
+      const mockResult = new GetUnitWithExternalIdsByIdResult({
+        id: UNIT_ID,
+        name: 'Unit Name',
+        externalIds: { airbnbId: 'ext-airbnb' },
+      } as any);
+      (queryBus.execute as jest.Mock).mockResolvedValue(mockResult);
+
+      const fakeUser = { tenantId: TENANT_ID, userId: 'user-1', email: 'a@b.com' } as any;
+      const response = await controller.getByIdWithExternalIds(fakeUser, UNIT_ID);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          unitId: UNIT_ID,
+          tenantId: TENANT_ID,
+        }),
+      );
+      expect(response.data.unit.id).toBe(UNIT_ID);
+    });
+  });
+});

--- a/test/shared/fixtures/unit.fixture.ts
+++ b/test/shared/fixtures/unit.fixture.ts
@@ -1,0 +1,68 @@
+import { Unit } from '@/domain/unit/entities/unit.entity';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
+import { TENANT_FIXTURE_DEFAULTS } from '@test/shared/fixtures/tenant.fixture';
+import { PROPERTY_FIXTURE_DEFAULTS } from '@test/shared/fixtures/property.fixture';
+
+export const UNIT_FIXTURE_DEFAULTS = {
+  id: '65f1a1a2b3c4d5e6f7a8b9c8',
+  tenantId: TENANT_FIXTURE_DEFAULTS.id,
+  propertyId: PROPERTY_FIXTURE_DEFAULTS.id,
+  name: 'Unit Name',
+  description: 'Unit Description',
+  inventoryCount: 1,
+  maxGuests: 4,
+  standardGuests: 2,
+  bedrooms: [],
+  bathroomsCount: 1,
+  isShared: false,
+  pricePerNight: 100,
+  amenities: ['wifi'],
+  externalIds: {
+    airbnbId: 'ext-airbnb',
+    bookingId: 'ext-booking',
+    vrboId: 'ext-vrbo',
+  },
+};
+
+export function makeUnit(
+  overrides?: Partial<{ id: string; tenantId: string }>,
+): Unit {
+  const merged = { ...UNIT_FIXTURE_DEFAULTS, ...overrides };
+  return Unit.reconstitute({
+    id: UnitId.create(merged.id),
+    tenantId: TenantId.createFromString(merged.tenantId),
+    propertyId: PropertyId.create(merged.propertyId),
+    basicInfo: {
+      name: merged.name,
+      description: merged.description,
+    },
+    inventoryConfig: {
+      inventoryCount: merged.inventoryCount,
+    },
+    capacityConfig: {
+      maxGuests: merged.maxGuests,
+      standardGuests: merged.standardGuests,
+    },
+    physicalFeatures: {
+      bedrooms: merged.bedrooms,
+      bathroomsCount: merged.bathroomsCount,
+      isShared: merged.isShared,
+    },
+    pricingConfig: {
+      pricePerNight: merged.pricePerNight,
+    },
+    amenities: merged.amenities,
+    externalIds: ExternalIds.create(
+      merged.externalIds.airbnbId,
+      merged.externalIds.bookingId,
+      merged.externalIds.vrboId,
+    ),
+    timestamps: {
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+}


### PR DESCRIPTION
  ## Summary

  - Add `GET /units/unit/:unitId` — tenant-authenticated endpoint that returns
    unit data including `externalIds` (airbnbId, bookingId, vrboId)
  - Tenant ownership enforced in the handler: returns 404 if the unit doesn't
    belong to the requesting tenant
  - Mirrors the shape of the existing public endpoint, extending it with the
    `externalIds` field needed for channel manager integrations

  ## Changes

  - `GetUnitWithExternalIdsByIdQuery` + handler + `UnitWithExternalIdsDto`
    (extends `PublicUnitDto` with `externalIds`)
  - Handler registered in `UnitApplicationModule`
  - 6 unit tests: happy path, wrong-tenant isolation, externalIds presence,
    auth decorator check

  ## Test plan

  - [ ] `GET /units/unit/:unitId` with valid tenant JWT returns unit + externalIds
  - [ ] Returns 404 when unitId belongs to a different tenant
  - [ ] Returns 404 for non-existent unitId
  - [ ] Request without JWT is rejected by the global auth guard
  - [ ] Public endpoint `GET /units/public/unit/:unitId` still works without auth