### PR TITLE
LYMON-892 fix(units): add missing rating arg to UnitWithExternalIdsDto

### DIFF
--- a/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler.ts
+++ b/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler.ts
@@ -65,6 +65,7 @@ export class GetUnitWithExternalIdsByIdQueryHandler
       unit.getPricePerNight(),
       unit.getTenantId().toString(),
       unit.getPropertyId().toString(),
+      unit.getRating(),
       externalIdsDto,
     );
 

--- a/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result.ts
+++ b/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result.ts
@@ -25,6 +25,7 @@ export class UnitWithExternalIdsDto extends PublicUnitDto {
     pricePerNight: number,
     tenantId: string,
     propertyId: string,
+    rating: number | null,
     public readonly externalIds: ExternalIdsDto,
   ) {
     super(
@@ -40,6 +41,7 @@ export class UnitWithExternalIdsDto extends PublicUnitDto {
       pricePerNight,
       tenantId,
       propertyId,
+      rating,
     );
   }
 }


### PR DESCRIPTION
Ratings had a problem inside the new endpoint implemented for unit controllers