### PR TITLE
LYMON-893 feat(guests): add PATCH /guests/:guestId profile endpoint

### DIFF
--- a/src/application/guest/commands/update-guest-profile/update-guest-profile.command.ts
+++ b/src/application/guest/commands/update-guest-profile/update-guest-profile.command.ts
@@ -1,0 +1,21 @@
+export class UpdateGuestProfileCommand {
+  constructor(
+    public readonly tenantId: string,
+    public readonly guestId: string,
+    public readonly fullName?: string,
+    public readonly firstName?: string | null,
+    public readonly lastName?: string | null,
+    public readonly primaryEmail?: string,
+    public readonly emails?: string[],
+    public readonly phones?: Array<{
+      number: string;
+      type?: string;
+      isPrimary?: boolean;
+    }>,
+    public readonly identity?: {
+      documentType?: string;
+      documentNumber?: string;
+      countryCode?: string;
+    },
+  ) {}
+}

--- a/src/application/guest/commands/update-guest-profile/update-guest-profile.handler.ts
+++ b/src/application/guest/commands/update-guest-profile/update-guest-profile.handler.ts
@@ -1,0 +1,66 @@
+import { ConflictException, ForbiddenException, Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import {
+  GUEST_REPOSITORY,
+  type GuestRepository,
+} from '@/domain/guest/repositories/guest.repository';
+import { UpdateGuestProfileCommand } from './update-guest-profile.command';
+
+@CommandHandler(UpdateGuestProfileCommand)
+export class UpdateGuestProfileHandler
+  implements ICommandHandler<UpdateGuestProfileCommand>
+{
+  constructor(
+    @Inject(GUEST_REPOSITORY)
+    private readonly guestRepository: GuestRepository,
+  ) {}
+
+  async execute(command: UpdateGuestProfileCommand): Promise<void> {
+    const guestId = GuestId.createFromString(command.guestId);
+    const guest = await this.guestRepository.findById(guestId);
+
+    if (!guest) {
+      throw new NotFoundException(`Guest with ID ${command.guestId} not found`);
+    }
+
+    if (guest.getTenantId().toString() !== command.tenantId) {
+      throw new ForbiddenException('You do not have permission to modify this guest');
+    }
+
+    if (command.fullName !== undefined) {
+      guest.updateBasicInfo(
+        command.fullName,
+        command.firstName !== undefined ? command.firstName : guest.getFirstName(),
+        command.lastName !== undefined ? command.lastName : guest.getLastName(),
+      );
+    }
+
+    if (command.primaryEmail !== undefined) {
+      const tenantId = TenantId.createFromString(command.tenantId);
+      const existing = await this.guestRepository.findByPrimaryEmail(
+        tenantId,
+        command.primaryEmail,
+      );
+      if (existing && existing.getId()?.toString() !== command.guestId) {
+        throw new ConflictException('A guest with this primary email already exists');
+      }
+      guest.setPrimaryEmail(command.primaryEmail);
+    }
+
+    if (command.emails !== undefined) {
+      guest.setEmails(command.emails);
+    }
+
+    if (command.phones !== undefined) {
+      guest.setPhones(command.phones);
+    }
+
+    if (command.identity !== undefined) {
+      guest.setIdentity(command.identity);
+    }
+
+    await this.guestRepository.save(guest);
+  }
+}

--- a/src/application/guest/commands/update-guest-profile/update-guest-profile.handler.ts
+++ b/src/application/guest/commands/update-guest-profile/update-guest-profile.handler.ts
@@ -1,4 +1,9 @@
-import { ConflictException, ForbiddenException, Inject, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  Inject,
+  NotFoundException,
+} from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
@@ -9,9 +14,7 @@ import {
 import { UpdateGuestProfileCommand } from './update-guest-profile.command';
 
 @CommandHandler(UpdateGuestProfileCommand)
-export class UpdateGuestProfileHandler
-  implements ICommandHandler<UpdateGuestProfileCommand>
-{
+export class UpdateGuestProfileHandler implements ICommandHandler<UpdateGuestProfileCommand> {
   constructor(
     @Inject(GUEST_REPOSITORY)
     private readonly guestRepository: GuestRepository,
@@ -26,14 +29,18 @@ export class UpdateGuestProfileHandler
     }
 
     if (guest.getTenantId().toString() !== command.tenantId) {
-      throw new ForbiddenException('You do not have permission to modify this guest');
+      throw new ForbiddenException(
+        'You do not have permission to modify this guest',
+      );
     }
 
     if (command.fullName !== undefined) {
       guest.updateBasicInfo(
         command.fullName,
-        command.firstName !== undefined ? command.firstName : guest.getFirstName(),
-        command.lastName !== undefined ? command.lastName : guest.getLastName(),
+        command.firstName === undefined
+          ? guest.getFirstName()
+          : command.firstName,
+        command.lastName === undefined ? guest.getLastName() : command.lastName,
       );
     }
 
@@ -44,7 +51,9 @@ export class UpdateGuestProfileHandler
         command.primaryEmail,
       );
       if (existing && existing.getId()?.toString() !== command.guestId) {
-        throw new ConflictException('A guest with this primary email already exists');
+        throw new ConflictException(
+          'A guest with this primary email already exists',
+        );
       }
       guest.setPrimaryEmail(command.primaryEmail);
     }

--- a/src/application/guest/guest-application.module.ts
+++ b/src/application/guest/guest-application.module.ts
@@ -8,11 +8,13 @@ import { GetGuestBookingsHandler } from './queries/get-guest-bookings/get-guest-
 import { CreateGuestHandler } from '@/application/guest/commands/create-guest.handler';
 import { AssignGuestTagsHandler } from './commands/assign-guest-tags.handler';
 import { SaveGuestPreferencesHandler } from './commands/preferences/save-guest-preferences.handler';
+import { UpdateGuestProfileHandler } from './commands/update-guest-profile/update-guest-profile.handler';
 
 const CommandHandlers = [
   CreateGuestHandler,
   AssignGuestTagsHandler,
   SaveGuestPreferencesHandler,
+  UpdateGuestProfileHandler,
 ];
 const QueryHandlers = [
   SearchGuestsQuery,

--- a/src/presentation/controllers/guest.controller.ts
+++ b/src/presentation/controllers/guest.controller.ts
@@ -10,6 +10,7 @@ import type { GetGuestByIdResult } from '@/application/guest/queries/get-guest-b
 import { AssignGuestTagsCommand } from '@/application/guest/commands/assign-guest-tags.command';
 import { SaveGuestPreferencesCommand } from '@/application/guest/commands/preferences/save-guest-preferences.command';
 import { SaveGuestPreferencesResult } from '@/application/guest/commands/preferences/save-guest-preferences.result';
+import { UpdateGuestProfileCommand } from '@/application/guest/commands/update-guest-profile/update-guest-profile.command';
 import { Permission } from '@/domain/role/value-objects/permission.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
@@ -23,6 +24,7 @@ import { ChangePasswordDto } from '@/presentation/dtos/auth/change-password.dto'
 import { CreateGuestDto } from '@/presentation/dtos/guest/create-guest.dto';
 import { UpdateTagsDto } from '@/presentation/dtos/guest/update-tags.dto';
 import { SaveGuestPreferencesDto } from '@/presentation/dtos/guest/save-guest-preferences.dto';
+import { UpdateGuestProfileDto } from '@/presentation/dtos/guest/update-guest-profile.dto';
 import {
   Body,
   Controller,
@@ -183,6 +185,35 @@ export class GuestController {
       message: 'Guest profile retrieved successfully',
       data: result.item,
     };
+  }
+
+  @Patch(':guestId')
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.CRM_MANAGE)
+  @ApiOperation({ summary: 'Update profile fields of a specific guest' })
+  @ApiResponse({ status: 200, description: 'Guest profile updated successfully' })
+  @ApiResponse({ status: 404, description: 'Guest not found' })
+  @ApiResponse({ status: 409, description: 'A guest with this primary email already exists' })
+  async updateProfile(
+    @CurrentUser() user: JwtPayload,
+    @Param('guestId') guestId: string,
+    @Body() dto: UpdateGuestProfileDto,
+  ) {
+    await this.commandBus.execute(
+      new UpdateGuestProfileCommand(
+        user.tenantId,
+        guestId,
+        dto.fullName,
+        dto.firstName,
+        dto.lastName,
+        dto.primaryEmail,
+        dto.emails,
+        dto.phones,
+        dto.identity,
+      ),
+    );
+
+    return { message: 'Guest profile updated successfully' };
   }
 
   @Patch(':guestId/tags')

--- a/src/presentation/dtos/guest/update-guest-profile.dto.ts
+++ b/src/presentation/dtos/guest/update-guest-profile.dto.ts
@@ -1,0 +1,87 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+class UpdateGuestIdentityDto {
+  @ApiPropertyOptional({ example: 'passport' })
+  @IsOptional()
+  @IsString()
+  documentType?: string;
+
+  @ApiPropertyOptional({ example: 'AB123456' })
+  @IsOptional()
+  @IsString()
+  documentNumber?: string;
+
+  @ApiPropertyOptional({ example: 'US' })
+  @IsOptional()
+  @IsString()
+  countryCode?: string;
+}
+
+class UpdateGuestPhoneDto {
+  @ApiPropertyOptional({ example: '+12025550123' })
+  @IsString()
+  @IsNotEmpty()
+  number: string;
+
+  @ApiPropertyOptional({ example: 'mobile' })
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  @ApiPropertyOptional({ example: true })
+  @IsOptional()
+  @IsBoolean()
+  isPrimary?: boolean;
+}
+
+export class UpdateGuestProfileDto {
+  @ApiPropertyOptional({ example: 'John Doe' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  fullName?: string;
+
+  @ApiPropertyOptional({ example: 'John' })
+  @IsOptional()
+  @IsString()
+  firstName?: string | null;
+
+  @ApiPropertyOptional({ example: 'Doe' })
+  @IsOptional()
+  @IsString()
+  lastName?: string | null;
+
+  @ApiPropertyOptional({ example: 'john.doe@example.com' })
+  @IsOptional()
+  @IsEmail()
+  primaryEmail?: string;
+
+  @ApiPropertyOptional({ type: [String], example: ['john.alt@example.com'] })
+  @IsOptional()
+  @IsArray()
+  @IsEmail({}, { each: true })
+  emails?: string[];
+
+  @ApiPropertyOptional({ type: [UpdateGuestPhoneDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpdateGuestPhoneDto)
+  phones?: UpdateGuestPhoneDto[];
+
+  @ApiPropertyOptional({ type: UpdateGuestIdentityDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdateGuestIdentityDto)
+  identity?: UpdateGuestIdentityDto;
+}


### PR DESCRIPTION
This pull request introduces the ability to update a guest's profile in the application. It includes a new command, handler, DTO, and controller endpoint to support updating various guest profile fields such as name, emails, phones, and identity documents. The changes also ensure proper validation, permission checks, and conflict handling (e.g., duplicate primary emails).

The most important changes are:

**Update Guest Profile Feature:**

* Added `UpdateGuestProfileCommand` to encapsulate all fields that can be updated in a guest's profile, including name, emails, phones, and identity information.
* Implemented `UpdateGuestProfileHandler` to process the update command, handle permission checks, prevent duplicate primary emails, and persist changes to the guest repository.
* Introduced `UpdateGuestProfileDto` with validation and API documentation to ensure correct data is received when updating a guest profile.

**Controller and Module Integration:**

* Added a new `PATCH /guests/:guestId` endpoint in `GuestController` to allow updating a guest's profile, with appropriate guards, permission checks, and API responses.
* Registered the new handler and imported necessary DTOs and commands in the guest module and controller for full integration. [[1]](diffhunk://#diff-f3a693e2a132e67a22c330fe796fae357dbd224e91f4a994a7217d1ad28216adR11-R17) [[2]](diffhunk://#diff-68a43fca50d65ec09a565ce3cf3a5a4fa7023ce5d2d05db5c5043f4e86f48044R13) [[3]](diffhunk://#diff-68a43fca50d65ec09a565ce3cf3a5a4fa7023ce5d2d05db5c5043f4e86f48044R27)Supports partial updates of name, emails, phones, and identity. Email uniqueness validated on primaryEmail change.