### PR TITLE
LYMON-881 feat(unit-rating): add tenantId to GetUnitRatingsQuery and …

### DIFF
--- a/src/application/unit-rating/queries/get-unit-ratings/get-unit-ratings.handler.ts
+++ b/src/application/unit-rating/queries/get-unit-ratings/get-unit-ratings.handler.ts
@@ -33,6 +33,9 @@ export class GetUnitRatingsHandler
     if (!unit) {
       throw new NotFoundException('Unit not found');
     }
+    if (query.tenantId && unit.getTenantId().toString() !== query.tenantId) {
+      throw new NotFoundException('Unit not found');
+    }
 
     const { ratings, total } =
       await this.unitRatingRepository.findByUnitIdPaginated(

--- a/src/application/unit-rating/queries/get-unit-ratings/get-unit-ratings.query.ts
+++ b/src/application/unit-rating/queries/get-unit-ratings/get-unit-ratings.query.ts
@@ -1,5 +1,6 @@
 export class GetUnitRatingsQuery {
   constructor(
+    public readonly tenantId: string,
     public readonly unitId: string,
     public readonly page: number,
     public readonly limit: number,

--- a/src/presentation/controllers/unit-rating.controller.ts
+++ b/src/presentation/controllers/unit-rating.controller.ts
@@ -89,6 +89,7 @@ export class UnitRatingController {
 
     return this.queryBus.execute<GetUnitRatingsQuery, GetUnitRatingsResult>(
       new GetUnitRatingsQuery(
+        '',
         unitId,
         Math.max(1, Number.parseInt(page ?? '1', 10) || 1),
         Math.max(1, Number.parseInt(limit ?? '20', 10) || 20),

--- a/test/application/cart/add-experience-to-cart.handler.spec.ts
+++ b/test/application/cart/add-experience-to-cart.handler.spec.ts
@@ -73,7 +73,7 @@ describe('AddExperienceToCartHandler', () => {
   it('creates a new cart and adds experience when no open cart exists', async () => {
     const experience = makeExperience();
     experienceRepository.findById.mockResolvedValue(experience);
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(null);
+    cartRepository.findOpenByGuest.mockResolvedValue(null);
     cartRepository.save.mockResolvedValue('new-cart-id');
 
     await handler.execute(makeCommand());
@@ -88,7 +88,7 @@ describe('AddExperienceToCartHandler', () => {
     const experience = makeExperience();
     experienceRepository.findById.mockResolvedValue(experience);
     const existingCart = makeCart();
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(existingCart);
+    cartRepository.findOpenByGuest.mockResolvedValue(existingCart);
     cartRepository.save.mockResolvedValue(existingCart.getId()!.toString());
 
     await handler.execute(makeCommand());

--- a/test/application/cart/checkout-cart.handler.spec.ts
+++ b/test/application/cart/checkout-cart.handler.spec.ts
@@ -58,13 +58,13 @@ describe('CheckoutCartHandler', () => {
   });
 
   it('throws NotFoundException when no open cart exists', async () => {
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(null);
+    cartRepository.findOpenByGuest.mockResolvedValue(null);
 
     await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
   });
 
   it('throws DomainException when cart is empty', async () => {
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(makeCart());
+    cartRepository.findOpenByGuest.mockResolvedValue(makeCart());
     const guest = makeGuest({ id: GUEST_ID });
     guestRepository.findByGuestAccountId.mockResolvedValue(guest);
 
@@ -74,7 +74,7 @@ describe('CheckoutCartHandler', () => {
   it('checks out cart with only experience items', async () => {
     const cartItem = makeCartItem({ quantity: 2 });
     const cart = makeCart({ experienceItems: [cartItem] });
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(cart);
+    cartRepository.findOpenByGuest.mockResolvedValue(cart);
 
     const guest = makeGuest({ id: GUEST_ID });
     guestRepository.findByGuestAccountId.mockResolvedValue(guest);
@@ -94,6 +94,7 @@ describe('CheckoutCartHandler', () => {
 
   it('pays reservation and creates purchases on full checkout', async () => {
     const reservationItem = CartReservationItem.create({
+      tenantId: TENANT_ID,
       reservationId: RESERVATION_ID,
       totalPriceCopSnapshot: 400000,
     });
@@ -102,7 +103,7 @@ describe('CheckoutCartHandler', () => {
       experienceItems: [cartItem],
       reservationItem,
     });
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(cart);
+    cartRepository.findOpenByGuest.mockResolvedValue(cart);
 
     const guest = makeGuest({ id: GUEST_ID });
     guestRepository.findByGuestAccountId.mockResolvedValue(guest);
@@ -131,7 +132,7 @@ describe('CheckoutCartHandler', () => {
     const experience = makeExperience();
     const cartItem = makeCartItem({ quantity: 10 });
     const cart = makeCart({ experienceItems: [cartItem] });
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(cart);
+    cartRepository.findOpenByGuest.mockResolvedValue(cart);
 
     const guest = makeGuest({ id: GUEST_ID });
     guestRepository.findByGuestAccountId.mockResolvedValue(guest);
@@ -146,11 +147,12 @@ describe('CheckoutCartHandler', () => {
 
   it('throws DomainException when reservation in cart is not PENDING', async () => {
     const reservationItem = CartReservationItem.create({
+      tenantId: TENANT_ID,
       reservationId: RESERVATION_ID,
       totalPriceCopSnapshot: 400000,
     });
     const cart = makeCart({ reservationItem, experienceItems: [] });
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(cart);
+    cartRepository.findOpenByGuest.mockResolvedValue(cart);
 
     const guest = makeGuest({ id: GUEST_ID });
     guestRepository.findByGuestAccountId.mockResolvedValue(guest);
@@ -167,11 +169,12 @@ describe('CheckoutCartHandler', () => {
 
   it('throws DomainException when overlapping reservation exists at same property', async () => {
     const reservationItem = CartReservationItem.create({
+      tenantId: TENANT_ID,
       reservationId: RESERVATION_ID,
       totalPriceCopSnapshot: 400000,
     });
     const cart = makeCart({ reservationItem, experienceItems: [] });
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(cart);
+    cartRepository.findOpenByGuest.mockResolvedValue(cart);
 
     const guest = makeGuest({ id: GUEST_ID });
     guestRepository.findByGuestAccountId.mockResolvedValue(guest);

--- a/test/application/cart/set-cart-reservation.handler.spec.ts
+++ b/test/application/cart/set-cart-reservation.handler.spec.ts
@@ -52,7 +52,7 @@ describe('SetCartReservationHandler', () => {
     reservationRepository.findByGuestId.mockResolvedValue([]);
 
     const cart = makeCart();
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(cart);
+    cartRepository.findOpenByGuest.mockResolvedValue(cart);
     cartRepository.save.mockResolvedValue(cart.getId()!.toString());
 
     await handler.execute(command);
@@ -74,7 +74,7 @@ describe('SetCartReservationHandler', () => {
     reservationRepository.findById.mockResolvedValue(reservation);
     reservationRepository.findByGuestId.mockResolvedValue([]);
 
-    cartRepository.findOpenByGuestAndTenant.mockResolvedValue(null);
+    cartRepository.findOpenByGuest.mockResolvedValue(null);
     cartRepository.save.mockResolvedValue('new-cart-id');
 
     await handler.execute(command);

--- a/test/application/unit/update-unit.handler.spec.ts
+++ b/test/application/unit/update-unit.handler.spec.ts
@@ -84,6 +84,7 @@ function makeCommand(
     undefined,
     undefined,
     undefined,
+    undefined,
     'user-1',
     'owner@example.com',
   );
@@ -115,6 +116,7 @@ describe('UpdateUnitHandler', () => {
         new UpdateUnitCommand(
           TENANT_ID,
           UNIT_ID,
+          undefined,
           undefined,
           undefined,
           undefined,

--- a/test/shared/fixtures/cart.fixture.ts
+++ b/test/shared/fixtures/cart.fixture.ts
@@ -4,7 +4,6 @@ import { CartItem } from '@/domain/cart/value-objects/cart-item.vo';
 import { CartReservationItem } from '@/domain/cart/value-objects/cart-reservation-item.vo';
 import { CartStatus, CartStatusEnum } from '@/domain/cart/value-objects/cart-status.vo';
 import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
-import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
 
 export const CART_FIXTURE_DEFAULTS = {
@@ -19,7 +18,6 @@ export const CART_FIXTURE_DEFAULTS = {
 export function makeCart(
   overrides?: Partial<{
     id: string;
-    tenantId: string;
     guestAccountId: string;
     status: CartStatusEnum;
     experienceItems: CartItem[];
@@ -31,7 +29,6 @@ export function makeCart(
   const merged = { ...CART_FIXTURE_DEFAULTS, ...overrides };
   return Cart.reconstitute({
     id: CartId.createFromString(merged.id),
-    tenantId: TenantId.createFromString(merged.tenantId),
     guestAccountId: GuestAccountId.createFromString(merged.guestAccountId),
     experienceItems: merged.experienceItems ?? [],
     reservationItem: merged.reservationItem ?? null,
@@ -43,6 +40,7 @@ export function makeCart(
 
 export function makeCartItem(
   overrides?: Partial<{
+    tenantId: string;
     experienceId: string;
     experienceName: string;
     selectedDate: Date | null;
@@ -52,6 +50,7 @@ export function makeCartItem(
   }>,
 ): CartItem {
   return CartItem.create({
+    tenantId: overrides?.tenantId ?? CART_FIXTURE_DEFAULTS.tenantId,
     experienceId: ExperienceId.create(
       overrides?.experienceId ?? '65f1a1a2b3c4d5e6f7a8bb10',
     ),

--- a/test/shared/mocks/repositories/cart-repository.mock.ts
+++ b/test/shared/mocks/repositories/cart-repository.mock.ts
@@ -4,6 +4,6 @@ export function createCartRepositoryMock(): jest.Mocked<CartRepository> {
   return {
     save: jest.fn(),
     findById: jest.fn(),
-    findOpenByGuestAndTenant: jest.fn(),
+    findOpenByGuest: jest.fn(),
   };
 }


### PR DESCRIPTION
This pull request primarily updates the handling of tenant IDs in cart and unit rating queries, and refactors test code to align with repository method changes. The most significant changes include enforcing tenant checks in unit rating queries, removing the use of `findOpenByGuestAndTenant` in favor of `findOpenByGuest` in cart repository mocks and tests, and minor adjustments to test fixtures.

**Unit Rating Query Improvements:**

* Added a `tenantId` parameter to `GetUnitRatingsQuery` and updated `GetUnitRatingsHandler` to throw a `NotFoundException` if the unit's tenant ID does not match the query's tenant ID. [[1]](diffhunk://#diff-1547771402c497c7641243b0cd6ad9a19a8309b7a8584d4222a9b0b5512ea551R3) [[2]](diffhunk://#diff-0f9b1972241c3aa5427e4f8928d6d531088aa56e03742b79ad24ff64fb7f6203R36-R38)
* Updated the controller to pass an empty string for `tenantId` when constructing `GetUnitRatingsQuery`.

**Cart Repository and Test Refactoring:**

* Replaced all instances of `findOpenByGuestAndTenant` with `findOpenByGuest` in cart-related test files and the cart repository mock, simplifying the repository interface and test setup. [[1]](diffhunk://#diff-51a52ef5511e1dd3349482fcf10ce818a4f054f36ccef6d744879d63c4a5de9cL76-R76) [[2]](diffhunk://#diff-51a52ef5511e1dd3349482fcf10ce818a4f054f36ccef6d744879d63c4a5de9cL91-R91) [[3]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595L61-R67) [[4]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595L77-R77) [[5]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595L105-R106) [[6]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595L134-R135) [[7]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595R150-R155) [[8]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595R172-R177) [[9]](diffhunk://#diff-729ba4d130568dc5567c929b2641919c5fe222a905c2818f7a412ee88c3e5211L55-R55) [[10]](diffhunk://#diff-729ba4d130568dc5567c929b2641919c5fe222a905c2818f7a412ee88c3e5211L77-R77) [[11]](diffhunk://#diff-fad392a92ac21f43b5a0bf6a800b6ffc5020b9931ae883c7205c4aee54b6df8fL7-R7)

**Test Fixture Adjustments:**

* Removed `tenantId` from the `makeCart` test fixture and added it to `makeCartItem` instead, reflecting changes in how tenant IDs are handled in cart items. [[1]](diffhunk://#diff-0bc1a2138cf35abc06992877b10d9df4c031fb846a8e6e4b487771aeff3d4aebL7) [[2]](diffhunk://#diff-0bc1a2138cf35abc06992877b10d9df4c031fb846a8e6e4b487771aeff3d4aebL22) [[3]](diffhunk://#diff-0bc1a2138cf35abc06992877b10d9df4c031fb846a8e6e4b487771aeff3d4aebL34) [[4]](diffhunk://#diff-0bc1a2138cf35abc06992877b10d9df4c031fb846a8e6e4b487771aeff3d4aebR43) [[5]](diffhunk://#diff-0bc1a2138cf35abc06992877b10d9df4c031fb846a8e6e4b487771aeff3d4aebR53)

**Other Test Updates:**

* Added an extra `undefined` argument to the `makeCommand` helper and related test cases in `update-unit.handler.spec.ts` to match updated function signatures. [[1]](diffhunk://#diff-60fa3b807f3e9be0d52b30d2dc4888e9696b7ddcd659a2061c89a19524bf3c11R87) [[2]](diffhunk://#diff-60fa3b807f3e9be0d52b30d2dc4888e9696b7ddcd659a2061c89a19524bf3c11R130)
* Added `tenantId` to `CartReservationItem.create()` in several checkout cart handler tests for completeness. [[1]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595R97) [[2]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595R150-R155) [[3]](diffhunk://#diff-7a13f1dbfbe84b5117f4893964070e7d840b3454fb42615c5668a348c1dca595R172-R177)…update handler logic

