### PR TITLE
LYMON-872 channex integration

### DIFF
--- a/src/infrastructure/channex/listeners/channex-room-type-sync.listener.ts
+++ b/src/infrastructure/channex/listeners/channex-room-type-sync.listener.ts
@@ -11,6 +11,7 @@ import {
 } from '@/domain/unit/repositories/unit.repository';
 import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
 import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import type { ChannexAvailabilityEntry } from '@/application/shared/services/channex.service';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 
@@ -24,6 +25,28 @@ export class ChannexRoomTypeSyncListener {
     @Inject(UNIT_REPOSITORY)
     private readonly unitRepository: UnitRepository,
   ) {}
+
+  private async pushInitialAvailability(
+    propertyChannexId: string,
+    roomTypeId: string,
+    inventoryCount: number,
+  ): Promise<void> {
+    const entries: ChannexAvailabilityEntry[] = [];
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    for (let i = 0; i < 365; i++) {
+      const d = new Date(today);
+      d.setUTCDate(today.getUTCDate() + i);
+      entries.push({ date: d.toISOString().slice(0, 10), availability: inventoryCount });
+    }
+    try {
+      await this.channexService.updateAvailability(propertyChannexId, roomTypeId, entries);
+      this.logger.log(`[CHANNEX] Initial availability set for room type ${roomTypeId}`);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`[CHANNEX] Failed to set initial availability for room type ${roomTypeId}: ${message}`);
+    }
+  }
 
   @OnEvent(CHANNEX_ROOM_TYPE_SYNC_EVENT)
   async handleRoomTypeSync(event: ChannexRoomTypeSyncEvent): Promise<void> {
@@ -45,6 +68,12 @@ export class ChannexRoomTypeSyncListener {
 
       this.logger.log(
         `[CHANNEX] Unit ${event.unitId} synced as room type ${roomTypeId}`,
+      );
+
+      await this.pushInitialAvailability(
+        event.propertyChannexId,
+        roomTypeId,
+        event.countOfRooms,
       );
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/infrastructure/channex/services/channex-http.service.ts
+++ b/src/infrastructure/channex/services/channex-http.service.ts
@@ -133,7 +133,7 @@ export class ChannexHttpService implements IChannexService {
     entries: ChannexAvailabilityEntry[],
   ): Promise<void> {
     const body = {
-      availability: entries.map((e) => ({
+      values: entries.map((e) => ({
         property_id: propertyChannexId,
         room_type_id: roomTypeId,
         date: e.date,
@@ -142,12 +142,12 @@ export class ChannexHttpService implements IChannexService {
     };
 
     this.logger.debug(
-      `[CHANNEX] PUT /availability body: ${JSON.stringify(body)}`,
+      `[CHANNEX] POST /availability body: ${JSON.stringify(body)}`,
     );
 
     try {
       await firstValueFrom(
-        this.httpService.put(`${CHANNEX_BASE_URL}/availability`, body, {
+        this.httpService.post(`${CHANNEX_BASE_URL}/availability`, body, {
           headers: { 'user-api-key': this.apiKey },
         }),
       );


### PR DESCRIPTION
This pull request introduces the automatic initialization of room availability in Channex when a new room type is synced. It also updates the way availability data is sent to the Channex API to match the expected payload and HTTP method.

**Channex Room Type Sync Improvements:**

* Added a new `pushInitialAvailability` method in `ChannexRoomTypeSyncListener` to automatically set 365 days of initial availability for each new room type synced, using the room count from the event. This helps ensure that new room types are immediately available in Channex. [[1]](diffhunk://#diff-ebd8ce63fde899cef2d0f82ae1a037dc9af14020f8ec56748ea33269203bbe17R29-R50) [[2]](diffhunk://#diff-ebd8ce63fde899cef2d0f82ae1a037dc9af14020f8ec56748ea33269203bbe17R72-R77)
* Imported the `ChannexAvailabilityEntry` type to support the new availability logic.

**Channex API Integration Fixes:**

* Changed the request body key from `availability` to `values` in the `updateAvailability` method of `ChannexHttpService`, aligning with the Channex API requirements.
* Updated the HTTP method from `PUT` to `POST` and adjusted the log message accordingly, ensuring compatibility with the Channex API endpoint for updating availability.…te availability method to use POST