### PR TITLE
Lymon 918 remove tenant id from the request body in the post endpoint of unit ratings

### DIFF
--- a/src/application/unit-rating/commands/create-unit-rating/create-unit-rating.command.ts
+++ b/src/application/unit-rating/commands/create-unit-rating/create-unit-rating.command.ts
@@ -2,7 +2,6 @@ export class CreateUnitRatingCommand {
   constructor(
     public readonly actorId: string,
     public readonly actorEmail: string,
-    public readonly tenantId: string,
     public readonly reservationId: string,
     public readonly rate: number,
     public readonly message: string | null,

--- a/src/application/unit-rating/commands/create-unit-rating/create-unit-rating.handler.ts
+++ b/src/application/unit-rating/commands/create-unit-rating/create-unit-rating.handler.ts
@@ -20,7 +20,6 @@ import {
   type GuestRepository,
 } from '@/domain/guest/repositories/guest.repository';
 import { UnitRating } from '@/domain/unit-rating/entities/unit-rating.entity';
-import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { ReservationId } from '@/domain/reservation/value-objects/reservation-id.vo';
 import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
 import { ReservationStatusEnum } from '@/domain/reservation/value-objects/reservation-status.vo';
@@ -53,7 +52,6 @@ export class CreateUnitRatingHandler
   async execute(
     command: CreateUnitRatingCommand,
   ): Promise<CreateUnitRatingResult> {
-    const tenantId = TenantId.createFromString(command.tenantId);
     const reservationId = ReservationId.create(command.reservationId);
 
     const reservation = await this.reservationRepository.findById(reservationId);
@@ -61,9 +59,7 @@ export class CreateUnitRatingHandler
       throw new NotFoundException('Reservation not found');
     }
 
-    if (!reservation.getTenantId().equals(tenantId)) {
-      throw new NotFoundException('Reservation not found');
-    }
+    const tenantId = reservation.getTenantId();
 
     if (
       reservation.getStatus().getValue() !== ReservationStatusEnum.CHECKED_OUT
@@ -125,7 +121,7 @@ export class CreateUnitRatingHandler
     this.eventEmitter.emit(
       AUDIT_LOG_EVENT,
       new AuditLoggedEvent(
-        command.tenantId,
+        tenantId.toString(),
         command.actorId,
         command.actorEmail,
         AuditAction.UNIT_RATING_CREATED,

--- a/src/presentation/controllers/unit-rating.controller.ts
+++ b/src/presentation/controllers/unit-rating.controller.ts
@@ -50,7 +50,6 @@ export class UnitRatingController {
       new CreateUnitRatingCommand(
         guest.guestAccountId,
         guest.email,
-        dto.tenantId,
         dto.reservationId,
         dto.rate,
         dto.message ?? null,

--- a/src/presentation/dtos/unit-rating/create-unit-rating.dto.ts
+++ b/src/presentation/dtos/unit-rating/create-unit-rating.dto.ts
@@ -12,11 +12,6 @@ import {
 import { Type } from 'class-transformer';
 
 export class CreateUnitRatingDto {
-  @ApiProperty({ example: '64f1a2b3c4d5e6f7a8b9c0d1', description: 'Tenant ID' })
-  @IsMongoId()
-  @IsNotEmpty()
-  tenantId: string;
-
   @ApiProperty({ example: '64f1a2b3c4d5e6f7a8b9c0d2', description: 'Reservation ID' })
   @IsMongoId()
   @IsNotEmpty()

--- a/test/application/unit-rating/commands/create-unit-rating.handler.spec.ts
+++ b/test/application/unit-rating/commands/create-unit-rating.handler.spec.ts
@@ -57,7 +57,6 @@ describe('CreateUnitRatingHandler', () => {
   const defaultCommand = new CreateUnitRatingCommand(
     GUEST_ACCOUNT_ID,
     'guest@example.com',
-    TENANT_ID,
     RESERVATION_ID,
     4,
     'Great stay!',
@@ -112,17 +111,6 @@ describe('CreateUnitRatingHandler', () => {
   describe('Error cases', () => {
     it('throws NotFoundException when reservation not found', async () => {
       reservationRepository.findById.mockResolvedValue(null);
-
-      await expect(handler.execute(defaultCommand)).rejects.toThrow(NotFoundException);
-    });
-
-    it('throws NotFoundException when reservation belongs to different tenant', async () => {
-      const reservation = makeReservation({
-        tenantId: 'other-tenant-000000000001',
-        guestId: GUEST_ID,
-        status: ReservationStatusEnum.CHECKED_OUT,
-      });
-      reservationRepository.findById.mockResolvedValue(reservation);
 
       await expect(handler.execute(defaultCommand)).rejects.toThrow(NotFoundException);
     });


### PR DESCRIPTION
Guests shouldn't need to supply tenantId — it's an internal concept they don't know. Reservation already carries it, so derive it there instead of requiring it in the request body.