### PR TITLE
LYMON-925-view-guests-ratings-inside-the-guest-crm-profile

### DIFF
--- a/src/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.handler.ts
+++ b/src/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.handler.ts
@@ -1,0 +1,57 @@
+import { Inject } from '@nestjs/common';
+import { QueryHandler, IQueryHandler } from '@nestjs/cqrs';
+import { GetGuestRatingsQuery } from './get-guest-ratings.query';
+import {
+  GetGuestRatingsResult,
+  GuestRatingDto,
+} from './get-guest-ratings.result';
+import {
+  UNIT_RATING_REPOSITORY,
+  type UnitRatingRepository,
+} from '@/domain/unit-rating/repositories/unit-rating.repository';
+import {
+  UNIT_REPOSITORY,
+  type UnitRepository,
+} from '@/domain/unit/repositories/unit.repository';
+import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
+
+@QueryHandler(GetGuestRatingsQuery)
+export class GetGuestRatingsHandler
+  implements IQueryHandler<GetGuestRatingsQuery>
+{
+  constructor(
+    @Inject(UNIT_RATING_REPOSITORY)
+    private readonly unitRatingRepository: UnitRatingRepository,
+    @Inject(UNIT_REPOSITORY)
+    private readonly unitRepository: UnitRepository,
+  ) {}
+
+  async execute(query: GetGuestRatingsQuery): Promise<GetGuestRatingsResult> {
+    const guestId = GuestId.createFromString(query.guestId);
+
+    const [{ ratings, total }, averageRating] = await Promise.all([
+      this.unitRatingRepository.findByGuestIdPaginated(
+        guestId,
+        query.page,
+        query.limit,
+      ),
+      this.unitRatingRepository.calculateAverageForGuest(guestId),
+    ]);
+
+    const dtos = await Promise.all(
+      ratings.map(async (rating) => {
+        const unit = await this.unitRepository.findById(rating.getUnitId());
+        return new GuestRatingDto(
+          rating.getId()!.toString(),
+          rating.getUnitId().toString(),
+          unit?.getName() ?? 'Unknown',
+          rating.getRate(),
+          rating.getMessage(),
+          rating.getCreatedAt(),
+        );
+      }),
+    );
+
+    return new GetGuestRatingsResult(dtos, total, query.page, query.limit, averageRating);
+  }
+}

--- a/src/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.query.ts
+++ b/src/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.query.ts
@@ -1,0 +1,8 @@
+export class GetGuestRatingsQuery {
+  constructor(
+    public readonly tenantId: string,
+    public readonly guestId: string,
+    public readonly page: number,
+    public readonly limit: number,
+  ) {}
+}

--- a/src/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.result.ts
+++ b/src/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.result.ts
@@ -1,0 +1,24 @@
+export class GuestRatingDto {
+  constructor(
+    public readonly id: string,
+    public readonly unitId: string,
+    public readonly unitName: string,
+    public readonly rate: number,
+    public readonly message: string | null,
+    public readonly createdAt: Date,
+  ) {}
+}
+
+export class GetGuestRatingsResult {
+  constructor(
+    public readonly ratings: GuestRatingDto[],
+    public readonly total: number,
+    public readonly page: number,
+    public readonly limit: number,
+    public readonly averageRating: number | null,
+  ) {}
+
+  get totalPages(): number {
+    return Math.ceil(this.total / this.limit);
+  }
+}

--- a/src/application/unit-rating/unit-rating-application.module.ts
+++ b/src/application/unit-rating/unit-rating-application.module.ts
@@ -3,9 +3,10 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { CreateUnitRatingHandler } from '@/application/unit-rating/commands/create-unit-rating/create-unit-rating.handler';
 import { GetUnitRatingsHandler } from '@/application/unit-rating/queries/get-unit-ratings/get-unit-ratings.handler';
+import { GetGuestRatingsHandler } from '@/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.handler';
 
 const CommandHandlers = [CreateUnitRatingHandler];
-const QueryHandlers = [GetUnitRatingsHandler];
+const QueryHandlers = [GetUnitRatingsHandler, GetGuestRatingsHandler];
 
 @Module({
   imports: [CqrsModule, PersistenceModule],

--- a/src/domain/unit-rating/repositories/unit-rating.repository.ts
+++ b/src/domain/unit-rating/repositories/unit-rating.repository.ts
@@ -2,6 +2,7 @@ import { UnitRating } from '@/domain/unit-rating/entities/unit-rating.entity';
 import { UnitRatingId } from '@/domain/unit-rating/value-objects/unit-rating-id.vo';
 import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
 import { ReservationId } from '@/domain/reservation/value-objects/reservation-id.vo';
+import { GuestId } from '@/domain/guest/value-objects/guest-id.vo';
 
 export const UNIT_RATING_REPOSITORY = 'UNIT_RATING_REPOSITORY';
 
@@ -17,4 +18,10 @@ export interface UnitRatingRepository {
     filterRate?: number,
   ): Promise<{ ratings: UnitRating[]; total: number }>;
   calculateAverageForUnit(unitId: UnitId): Promise<number | null>;
+  findByGuestIdPaginated(
+    guestId: GuestId,
+    page: number,
+    limit: number,
+  ): Promise<{ ratings: UnitRating[]; total: number }>;
+  calculateAverageForGuest(guestId: GuestId): Promise<number | null>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-unit-rating.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-unit-rating.repository.ts
@@ -104,6 +104,40 @@ export class MongoUnitRatingRepository implements UnitRatingRepository {
     return Math.round(result[0].avg * 10) / 10;
   }
 
+  async findByGuestIdPaginated(
+    guestId: GuestId,
+    page: number,
+    limit: number,
+  ): Promise<{ ratings: UnitRating[]; total: number }> {
+    const filter = {
+      guestId: new Types.ObjectId(guestId.toString()),
+      deletedAt: null,
+    };
+    const [total, docs] = await Promise.all([
+      this.unitRatingModel.countDocuments(filter),
+      this.unitRatingModel
+        .find(filter)
+        .sort({ createdAt: -1 })
+        .skip((page - 1) * limit)
+        .limit(limit),
+    ]);
+    return { ratings: docs.map((d) => this.toDomain(d)), total };
+  }
+
+  async calculateAverageForGuest(guestId: GuestId): Promise<number | null> {
+    const result = await this.unitRatingModel.aggregate([
+      {
+        $match: {
+          guestId: new Types.ObjectId(guestId.toString()),
+          deletedAt: null,
+        },
+      },
+      { $group: { _id: null, avg: { $avg: '$rate' } } },
+    ]);
+    if (!result.length) return null;
+    return Math.round(result[0].avg * 10) / 10;
+  }
+
   private toDomain(doc: UnitRatingDocument): UnitRating {
     return UnitRating.reconstitute({
       id: UnitRatingId.create(doc._id.toString()),

--- a/src/presentation/controllers/crm.controller.ts
+++ b/src/presentation/controllers/crm.controller.ts
@@ -57,6 +57,8 @@ import { SaveGuestPreferencesDto } from '@/presentation/dtos/guest/save-guest-pr
 import { CreateCatalogItemDto } from '@/presentation/dtos/catalog/create-catalog-item.dto';
 import { UpdateCatalogItemDto } from '@/presentation/dtos/catalog/update-catalog-item.dto';
 import { ToggleCatalogItemDto } from '@/presentation/dtos/catalog/toggle-catalog-item.dto';
+import { GetGuestRatingsQuery } from '@/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.query';
+import { GetGuestRatingsResult } from '@/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.result';
 
 @ApiTags('crm')
 @ApiBearerAuth('JWT-auth')
@@ -394,6 +396,42 @@ export class CrmController {
       message: 'Guest communication history retrieved successfully',
       data: {
         items: result.items,
+        pagination: {
+          total: result.total,
+          page: result.page,
+          limit: result.limit,
+          totalPages: result.totalPages,
+        },
+      },
+    };
+  }
+
+  @Get('guests/:guestId/ratings')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.CRM_VIEW)
+  @ApiOperation({ summary: 'Get all ratings given by a guest' })
+  @ApiResponse({
+    status: 200,
+    description: 'Guest ratings retrieved successfully',
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  async getGuestRatings(
+    @Param('guestId') guestId: string,
+    @CurrentUser() user: JwtPayload,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    const result = await this.queryBus.execute<
+      GetGuestRatingsQuery,
+      GetGuestRatingsResult
+    >(new GetGuestRatingsQuery(user.tenantId, guestId, page, limit));
+
+    return {
+      message: 'Guest ratings retrieved successfully',
+      data: {
+        items: result.ratings,
+        averageRating: result.averageRating,
         pagination: {
           total: result.total,
           page: result.page,

--- a/test/application/unit-rating/queries/get-guest-ratings.handler.spec.ts
+++ b/test/application/unit-rating/queries/get-guest-ratings.handler.spec.ts
@@ -48,7 +48,7 @@ describe('GetGuestRatingsHandler', () => {
       ratings: [rating],
       total: 1,
     });
-    unitRatingRepository.calculateAverageForGuest.mockResolvedValue(4.0);
+    unitRatingRepository.calculateAverageForGuest.mockResolvedValue(4);
     unitRepository.findById.mockResolvedValue(makeUnitFixture('Casa del Mar'));
 
     const result = await handler.execute(
@@ -60,7 +60,7 @@ describe('GetGuestRatingsHandler', () => {
     expect(result.ratings[0].unitName).toBe('Casa del Mar');
     expect(result.ratings[0].rate).toBe(4);
     expect(result.ratings[0].message).toBe('Great unit!');
-    expect(result.averageRating).toBe(4.0);
+    expect(result.averageRating).toBe(4);
     expect(result.totalPages).toBe(1);
   });
 
@@ -87,7 +87,7 @@ describe('GetGuestRatingsHandler', () => {
       ratings: [rating],
       total: 1,
     });
-    unitRatingRepository.calculateAverageForGuest.mockResolvedValue(4.0);
+    unitRatingRepository.calculateAverageForGuest.mockResolvedValue(4);
     unitRepository.findById.mockResolvedValue(null);
 
     const result = await handler.execute(

--- a/test/application/unit-rating/queries/get-guest-ratings.handler.spec.ts
+++ b/test/application/unit-rating/queries/get-guest-ratings.handler.spec.ts
@@ -1,0 +1,113 @@
+import { GetGuestRatingsHandler } from '@/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.handler';
+import { GetGuestRatingsQuery } from '@/application/unit-rating/queries/get-guest-ratings/get-guest-ratings.query';
+import { UnitRatingRepository } from '@/domain/unit-rating/repositories/unit-rating.repository';
+import { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import { createUnitRatingRepositoryMock } from '@test/shared/mocks/repositories/unit-rating-repository.mock';
+import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
+import { makeUnitRating, UNIT_RATING_FIXTURE_DEFAULTS } from '@test/shared/fixtures/unit-rating.fixture';
+import { Unit } from '@/domain/unit/entities/unit.entity';
+import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { ExternalIds } from '@/domain/unit/value-objects/external-ids.vo';
+
+const GUEST_ID = UNIT_RATING_FIXTURE_DEFAULTS.guestId;
+const TENANT_ID = UNIT_RATING_FIXTURE_DEFAULTS.tenantId;
+const UNIT_ID = UNIT_RATING_FIXTURE_DEFAULTS.unitId;
+
+function makeUnitFixture(name = 'Casa del Mar'): Unit {
+  return Unit.reconstitute({
+    id: UnitId.create(UNIT_ID),
+    tenantId: TenantId.createFromString(TENANT_ID),
+    propertyId: PropertyId.create('65f1a1a2b3c4d5e6f7a8b9c9'),
+    basicInfo: { name, description: 'Desc' },
+    inventoryConfig: { inventoryCount: 1 },
+    capacityConfig: { maxGuests: 2, standardGuests: 2 },
+    physicalFeatures: { bedrooms: [], bathroomsCount: 1, isShared: false },
+    pricingConfig: { pricePerNight: 80 },
+    amenities: [],
+    externalIds: ExternalIds.create(),
+    timestamps: { createdAt: new Date(), updatedAt: new Date() },
+  });
+}
+
+describe('GetGuestRatingsHandler', () => {
+  let handler: GetGuestRatingsHandler;
+  let unitRatingRepository: jest.Mocked<UnitRatingRepository>;
+  let unitRepository: jest.Mocked<UnitRepository>;
+
+  beforeEach(() => {
+    unitRatingRepository = createUnitRatingRepositoryMock();
+    unitRepository = createUnitRepositoryMock();
+    handler = new GetGuestRatingsHandler(unitRatingRepository, unitRepository);
+  });
+
+  it('returns paginated ratings with unit names and average', async () => {
+    const rating = makeUnitRating();
+    unitRatingRepository.findByGuestIdPaginated.mockResolvedValue({
+      ratings: [rating],
+      total: 1,
+    });
+    unitRatingRepository.calculateAverageForGuest.mockResolvedValue(4.0);
+    unitRepository.findById.mockResolvedValue(makeUnitFixture('Casa del Mar'));
+
+    const result = await handler.execute(
+      new GetGuestRatingsQuery(TENANT_ID, GUEST_ID, 1, 20),
+    );
+
+    expect(result.total).toBe(1);
+    expect(result.ratings).toHaveLength(1);
+    expect(result.ratings[0].unitName).toBe('Casa del Mar');
+    expect(result.ratings[0].rate).toBe(4);
+    expect(result.ratings[0].message).toBe('Great unit!');
+    expect(result.averageRating).toBe(4.0);
+    expect(result.totalPages).toBe(1);
+  });
+
+  it('returns empty list and null average when guest has no ratings', async () => {
+    unitRatingRepository.findByGuestIdPaginated.mockResolvedValue({
+      ratings: [],
+      total: 0,
+    });
+    unitRatingRepository.calculateAverageForGuest.mockResolvedValue(null);
+
+    const result = await handler.execute(
+      new GetGuestRatingsQuery(TENANT_ID, GUEST_ID, 1, 20),
+    );
+
+    expect(result.ratings).toHaveLength(0);
+    expect(result.total).toBe(0);
+    expect(result.averageRating).toBeNull();
+    expect(result.totalPages).toBe(0);
+  });
+
+  it('falls back to "Unknown" unit name when unit is not found', async () => {
+    const rating = makeUnitRating();
+    unitRatingRepository.findByGuestIdPaginated.mockResolvedValue({
+      ratings: [rating],
+      total: 1,
+    });
+    unitRatingRepository.calculateAverageForGuest.mockResolvedValue(4.0);
+    unitRepository.findById.mockResolvedValue(null);
+
+    const result = await handler.execute(
+      new GetGuestRatingsQuery(TENANT_ID, GUEST_ID, 1, 20),
+    );
+
+    expect(result.ratings[0].unitName).toBe('Unknown');
+  });
+
+  it('computes correct totalPages for multi-page result', async () => {
+    unitRatingRepository.findByGuestIdPaginated.mockResolvedValue({
+      ratings: [],
+      total: 45,
+    });
+    unitRatingRepository.calculateAverageForGuest.mockResolvedValue(3.5);
+
+    const result = await handler.execute(
+      new GetGuestRatingsQuery(TENANT_ID, GUEST_ID, 1, 20),
+    );
+
+    expect(result.totalPages).toBe(3);
+  });
+});

--- a/test/shared/mocks/repositories/unit-rating-repository.mock.ts
+++ b/test/shared/mocks/repositories/unit-rating-repository.mock.ts
@@ -7,5 +7,7 @@ export function createUnitRatingRepositoryMock(): jest.Mocked<UnitRatingReposito
     findByReservationId: jest.fn(),
     findByUnitIdPaginated: jest.fn(),
     calculateAverageForUnit: jest.fn(),
+    findByGuestIdPaginated: jest.fn(),
+    calculateAverageForGuest: jest.fn(),
   };
 }


### PR DESCRIPTION
## Summary
  
  - Adds `GET /crm/guests/:guestId/ratings` endpoint (requires `CRM_VIEW`) to power the "Reseñas dadas" widget in the CRM guest profile
  - Returns paginated ratings the guest has given: unit name, star rating, comment, `createdAt`, plus overall `averageRating`
  - Extends `UnitRatingRepository` with `findByGuestIdPaginated` + `calculateAverageForGuest`; implements both in `MongoUnitRatingRepository`
  - Adds `GetGuestRatingsQuery` / `GetGuestRatingsHandler` / `GetGuestRatingsResult` following existing CQRS pattern

  ## Test plan

  - [ ] `npx jest --testPathPatterns="get-guest-ratings"` — 4 unit tests pass
  - [ ] `GET /crm/guests/:guestId/ratings` returns `{ data: { items, averageRating, pagination } }`
  - [ ] Guest with no ratings returns `items: []`, `averageRating: null`
  - [ ] `page` / `limit` query params paginate correctly