### PR TITLE
Lymon 931 auto delete old photos from r2 storage when tenant updates unit images

### DIFF
--- a/src/application/experience/commands/update-experience/update-experience.handler.ts
+++ b/src/application/experience/commands/update-experience/update-experience.handler.ts
@@ -20,6 +20,10 @@ import {
   Inject,
   NotFoundException,
 } from '@nestjs/common';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
@@ -32,6 +36,8 @@ export class UpdateExperienceHandler implements ICommandHandler<
     @Inject(EXPERIENCE_REPOSITORY)
     private readonly experienceRepository: ExperienceRepository,
     private readonly eventEmitter: EventEmitter2,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly r2StorageService: R2StorageService,
   ) {}
 
   async execute(command: UpdateExperienceCommand): Promise<void> {
@@ -49,6 +55,11 @@ export class UpdateExperienceHandler implements ICommandHandler<
       );
     }
 
+    const oldMediaKeys =
+      command.changes.mediaKeys !== undefined
+        ? experience.getMediaKeys()
+        : [];
+
     try {
       experience.update(command.changes);
     } catch (error) {
@@ -58,6 +69,13 @@ export class UpdateExperienceHandler implements ICommandHandler<
     }
 
     await this.experienceRepository.save(experience);
+
+    if (command.changes.mediaKeys !== undefined) {
+      const orphaned = oldMediaKeys.filter(
+        (k) => !command.changes.mediaKeys!.includes(k),
+      );
+      await this.r2StorageService.deleteObjects(orphaned);
+    }
 
     this.eventEmitter.emit(
       AUDIT_LOG_EVENT,

--- a/src/application/experience/commands/update-experience/update-experience.handler.ts
+++ b/src/application/experience/commands/update-experience/update-experience.handler.ts
@@ -56,9 +56,9 @@ export class UpdateExperienceHandler implements ICommandHandler<
     }
 
     const oldMediaKeys =
-      command.changes.mediaKeys !== undefined
-        ? experience.getMediaKeys()
-        : [];
+      command.changes.mediaKeys === undefined
+        ? []
+        : experience.getMediaKeys();
 
     try {
       experience.update(command.changes);

--- a/src/application/experience/experience-application.module.ts
+++ b/src/application/experience/experience-application.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
+import { StorageModule } from '@/infrastructure/storage/storage.module';
 import { CreateExperienceHandler } from '@/application/experience/commands/create-experience.handler';
 import { UpdateExperienceHandler } from '@/application/experience/commands/update-experience/update-experience.handler';
 import { DeleteExperienceHandler } from '@/application/experience/commands/delete-experience.handler';
@@ -22,7 +23,7 @@ const QueryHandlers = [
 ];
 
 @Module({
-  imports: [CqrsModule, PersistenceModule],
+  imports: [CqrsModule, PersistenceModule, StorageModule],
   providers: [...CommandHandlers, ...QueryHandlers],
   exports: [...CommandHandlers, ...QueryHandlers],
 })

--- a/src/application/unit/commands/update-unit.handler.ts
+++ b/src/application/unit/commands/update-unit.handler.ts
@@ -29,6 +29,10 @@ import {
   AUDIT_LOG_EVENT,
 } from '@/infrastructure/audit/events/audit-logged.event';
 import { InventoryCountValidator } from '@/domain/reservation/services/inventory-count-validator.domain-service';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @CommandHandler(UpdateUnitCommand)
 export class UpdateUnitHandler implements ICommandHandler<UpdateUnitCommand> {
@@ -38,6 +42,8 @@ export class UpdateUnitHandler implements ICommandHandler<UpdateUnitCommand> {
     @Inject(RESERVATION_REPOSITORY)
     private readonly reservationRepository: ReservationRepository,
     private readonly eventEmitter: EventEmitter2,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly r2StorageService: R2StorageService,
   ) {}
 
   async execute(command: UpdateUnitCommand): Promise<UpdateUnitResult> {
@@ -101,6 +107,9 @@ export class UpdateUnitHandler implements ICommandHandler<UpdateUnitCommand> {
       unit.updateAmenities(command.amenities);
     }
 
+    const oldMediaKeys =
+      command.mediaKeys !== undefined ? unit.getMediaKeys() : [];
+
     if (command.mediaKeys !== undefined) {
       unit.updateMediaKeys(command.mediaKeys);
     }
@@ -120,6 +129,13 @@ export class UpdateUnitHandler implements ICommandHandler<UpdateUnitCommand> {
     }
 
     await this.unitRepository.save(unit);
+
+    if (command.mediaKeys !== undefined) {
+      const orphaned = oldMediaKeys.filter(
+        (k) => !command.mediaKeys!.includes(k),
+      );
+      await this.r2StorageService.deleteObjects(orphaned);
+    }
 
     if (command.actorId && command.actorEmail) {
       this.eventEmitter.emit(

--- a/src/application/unit/commands/update-unit.handler.ts
+++ b/src/application/unit/commands/update-unit.handler.ts
@@ -67,66 +67,7 @@ export class UpdateUnitHandler implements ICommandHandler<UpdateUnitCommand> {
       );
     }
 
-    if (command.name !== undefined || command.description !== undefined) {
-      unit.updateDetails(
-        command.name ?? unit.getName(),
-        command.description ?? unit.getDescription(),
-      );
-    }
-
-    if (
-      command.maxGuests !== undefined ||
-      command.standardGuests !== undefined
-    ) {
-      unit.updateCapacity(
-        command.maxGuests ?? unit.getMaxGuests(),
-        command.standardGuests ?? unit.getStandardGuests(),
-      );
-    }
-
-    if (command.bedrooms !== undefined) {
-      const bedrooms = command.bedrooms.map((bedroom) => ({
-        roomName: bedroom.roomName,
-        beds: bedroom.beds.map((bed) => ({
-          type: bed.type as BedTypeEnum,
-          count: bed.count,
-        })),
-      }));
-      unit.updateBedrooms(bedrooms);
-    }
-
-    if (command.bathroomsCount !== undefined) {
-      unit.updateBathroomsCount(command.bathroomsCount);
-    }
-
-    if (command.isShared !== undefined) {
-      unit.updateShared(command.isShared);
-    }
-
-    if (command.amenities !== undefined) {
-      unit.updateAmenities(command.amenities);
-    }
-
-    const oldMediaKeys =
-      command.mediaKeys !== undefined ? unit.getMediaKeys() : [];
-
-    if (command.mediaKeys !== undefined) {
-      unit.updateMediaKeys(command.mediaKeys);
-    }
-
-    if (command.pricePerNight !== undefined) {
-      unit.updatePrice(command.pricePerNight);
-    }
-
-    if (command.externalIds !== undefined) {
-      unit.updateExternalIds(
-        ExternalIds.create(
-          command.externalIds.airbnbId,
-          command.externalIds.bookingId,
-          command.externalIds.vrboId,
-        ),
-      );
-    }
+    const oldMediaKeys = this.applyFieldUpdates(unit, command);
 
     await this.unitRepository.save(unit);
 
@@ -163,6 +104,55 @@ export class UpdateUnitHandler implements ICommandHandler<UpdateUnitCommand> {
     }
 
     return new UpdateUnitResult(command.unitId);
+  }
+
+  private applyFieldUpdates(unit: Unit, command: UpdateUnitCommand): string[] {
+    if (command.name !== undefined || command.description !== undefined) {
+      unit.updateDetails(
+        command.name ?? unit.getName(),
+        command.description ?? unit.getDescription(),
+      );
+    }
+
+    if (command.maxGuests !== undefined || command.standardGuests !== undefined) {
+      unit.updateCapacity(
+        command.maxGuests ?? unit.getMaxGuests(),
+        command.standardGuests ?? unit.getStandardGuests(),
+      );
+    }
+
+    if (command.bedrooms !== undefined) {
+      unit.updateBedrooms(
+        command.bedrooms.map((bedroom) => ({
+          roomName: bedroom.roomName,
+          beds: bedroom.beds.map((bed) => ({
+            type: bed.type as BedTypeEnum,
+            count: bed.count,
+          })),
+        })),
+      );
+    }
+
+    if (command.bathroomsCount !== undefined) unit.updateBathroomsCount(command.bathroomsCount);
+    if (command.isShared !== undefined) unit.updateShared(command.isShared);
+    if (command.amenities !== undefined) unit.updateAmenities(command.amenities);
+
+    const oldMediaKeys = command.mediaKeys === undefined ? [] : unit.getMediaKeys();
+    if (command.mediaKeys !== undefined) unit.updateMediaKeys(command.mediaKeys);
+
+    if (command.pricePerNight !== undefined) unit.updatePrice(command.pricePerNight);
+
+    if (command.externalIds !== undefined) {
+      unit.updateExternalIds(
+        ExternalIds.create(
+          command.externalIds.airbnbId,
+          command.externalIds.bookingId,
+          command.externalIds.vrboId,
+        ),
+      );
+    }
+
+    return oldMediaKeys;
   }
 
   private async validateAndApplyInventoryCount(

--- a/src/application/unit/unit-application.module.ts
+++ b/src/application/unit/unit-application.module.ts
@@ -9,6 +9,7 @@ import { GetPublicUnitByIdQueryHandler } from '@/application/unit/queries/GetPub
 import { GetAllPublicUnitsQueryHandler } from '@/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler';
 import { GetUnitWithExternalIdsByIdQueryHandler } from '@/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
+import { StorageModule } from '@/infrastructure/storage/storage.module';
 
 const CommandHandlers = [
   CreateUnitHandler,
@@ -24,7 +25,7 @@ const QueryHandlers = [
 ];
 
 @Module({
-  imports: [CqrsModule, PersistenceModule],
+  imports: [CqrsModule, PersistenceModule, StorageModule],
   providers: [...CommandHandlers, ...QueryHandlers],
   exports: [...CommandHandlers, ...QueryHandlers],
 })

--- a/src/infrastructure/storage/r2-storage.service.ts
+++ b/src/infrastructure/storage/r2-storage.service.ts
@@ -47,12 +47,17 @@ export class R2StorageService {
 
   async deleteObjects(keys: string[]): Promise<void> {
     if (keys.length === 0) return;
-    await this.client.send(
-      new DeleteObjectsCommand({
-        Bucket: this.bucket,
-        Delete: { Objects: keys.map((k) => ({ Key: k })) },
-      }),
-    );
+    try {
+      await this.client.send(
+        new DeleteObjectsCommand({
+          Bucket: this.bucket,
+          Delete: { Objects: keys.map((k) => ({ Key: k })) },
+        }),
+      );
+    } catch (err) {
+      // ponytail: orphan cleanup is best-effort; never fail the committed update. Add a retry queue if orphan buildup becomes real.
+      console.error('R2 orphan cleanup failed', { keys, err });
+    }
   }
 
   getPublicUrl(key: string): string {

--- a/src/infrastructure/storage/r2-storage.service.ts
+++ b/src/infrastructure/storage/r2-storage.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectsCommand,
+} from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 export const R2_STORAGE_SERVICE = 'R2_STORAGE_SERVICE';
@@ -39,6 +43,16 @@ export class R2StorageService {
     });
 
     return getSignedUrl(this.client, command, { expiresIn: expiresInSeconds });
+  }
+
+  async deleteObjects(keys: string[]): Promise<void> {
+    if (keys.length === 0) return;
+    await this.client.send(
+      new DeleteObjectsCommand({
+        Bucket: this.bucket,
+        Delete: { Objects: keys.map((k) => ({ Key: k })) },
+      }),
+    );
   }
 
   getPublicUrl(key: string): string {

--- a/test/application/experience/update-experience.handler.spec.ts
+++ b/test/application/experience/update-experience.handler.spec.ts
@@ -26,6 +26,7 @@ import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
 import { createExperienceRepositoryMock } from '@test/shared/mocks/repositories/experience-repository.mock';
 import { createEventEmitterMock } from '@test/shared/mocks/services/event-emitter.mock';
+import { createR2StorageServiceMock } from '@test/shared/mocks/services/r2-storage.mock';
 
 const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c0';
 const OTHER_TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9ff';
@@ -35,7 +36,10 @@ const DEFAULT_ACTOR: ExperienceActor = {
   email: 'host@example.com',
 };
 
-function makeExperience(overrides?: { tenantId?: string }): Experience {
+function makeExperience(overrides?: {
+  tenantId?: string;
+  mediaKeys?: string[];
+}): Experience {
   return Experience.reconstitute({
     id: ExperienceId.create(EXPERIENCE_ID),
     tenantId: TenantId.createFromString(overrides?.tenantId ?? TENANT_ID),
@@ -66,6 +70,7 @@ function makeExperience(overrides?: { tenantId?: string }): Experience {
     minNoticeHours: 2,
     purchaseCutoffHours: 24,
     status: ExperienceStatus.create('ACTIVE'),
+    mediaKeys: overrides?.mediaKeys ?? [],
     createdAt: new Date('2099-01-01T00:00:00.000Z'),
     updatedAt: new Date('2099-01-01T00:00:00.000Z'),
     deletedAt: null,
@@ -90,13 +95,18 @@ describe('UpdateExperienceHandler', () => {
   let handler: UpdateExperienceHandler;
   let experienceRepository: jest.Mocked<ExperienceRepository>;
   let eventEmitter: ReturnType<typeof createEventEmitterMock>;
+  let r2StorageService: ReturnType<typeof createR2StorageServiceMock>;
 
   beforeEach(() => {
     experienceRepository = createExperienceRepositoryMock();
     eventEmitter = createEventEmitterMock();
+    r2StorageService = createR2StorageServiceMock();
+    r2StorageService.deleteObjects.mockResolvedValue(undefined);
+
     handler = new UpdateExperienceHandler(
       experienceRepository,
       eventEmitter as any,
+      r2StorageService as any,
     );
   });
 
@@ -167,5 +177,43 @@ describe('UpdateExperienceHandler', () => {
 
     expect(experienceRepository.save).toHaveBeenCalledTimes(1);
     expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes orphaned R2 keys after save when mediaKeys is updated', async () => {
+    const oldKeys = ['tenant/exp-1.jpg', 'tenant/exp-2.jpg'];
+    const newKeys = ['tenant/exp-2.jpg', 'tenant/exp-3.jpg'];
+    experienceRepository.findById.mockResolvedValue(
+      makeExperience({ mediaKeys: oldKeys }),
+    );
+    experienceRepository.save.mockResolvedValue(EXPERIENCE_ID);
+
+    await handler.execute(
+      makeCommand({ changes: { mediaKeys: newKeys } }),
+    );
+
+    expect(r2StorageService.deleteObjects).toHaveBeenCalledWith(['tenant/exp-1.jpg']);
+  });
+
+  it('does not call deleteObjects when mediaKeys is not in the command', async () => {
+    experienceRepository.findById.mockResolvedValue(
+      makeExperience({ mediaKeys: ['tenant/exp-1.jpg'] }),
+    );
+    experienceRepository.save.mockResolvedValue(EXPERIENCE_ID);
+
+    await handler.execute(makeCommand({ changes: { name: 'Updated' } }));
+
+    expect(r2StorageService.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it('calls deleteObjects with empty array when no keys were removed', async () => {
+    const keys = ['tenant/exp-1.jpg'];
+    experienceRepository.findById.mockResolvedValue(
+      makeExperience({ mediaKeys: keys }),
+    );
+    experienceRepository.save.mockResolvedValue(EXPERIENCE_ID);
+
+    await handler.execute(makeCommand({ changes: { mediaKeys: keys } }));
+
+    expect(r2StorageService.deleteObjects).toHaveBeenCalledWith([]);
   });
 });

--- a/test/application/unit/update-unit.handler.spec.ts
+++ b/test/application/unit/update-unit.handler.spec.ts
@@ -17,6 +17,7 @@ import { BedTypeEnum } from '@/domain/unit/value-objects/bed-type.vo';
 import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
 import { createReservationRepositoryMock } from '@test/shared/mocks/repositories/reservation-repository.mock';
 import { createEventEmitterMock } from '@test/shared/mocks/services/event-emitter.mock';
+import { createR2StorageServiceMock } from '@test/shared/mocks/services/r2-storage.mock';
 import { makeReservation } from '@test/shared/fixtures/reservation.fixture';
 
 const UNIT_ID = '65f1a1a2b3c4d5e6f7a8b9c4';
@@ -24,7 +25,11 @@ const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c2';
 const PROPERTY_ID = '65f1a1a2b3c4d5e6f7a8b9c3';
 
 function makeUnit(
-  overrides?: Partial<{ tenantId: string; inventoryCount: number }>,
+  overrides?: Partial<{
+    tenantId: string;
+    inventoryCount: number;
+    mediaKeys: string[];
+  }>,
 ): Unit {
   return Unit.reconstitute({
     id: UnitId.create(UNIT_ID),
@@ -52,6 +57,7 @@ function makeUnit(
       pricePerNight: 200,
     },
     amenities: ['wifi'],
+    mediaKeys: overrides?.mediaKeys ?? [],
     externalIds: ExternalIds.create('airbnb-1', undefined, undefined),
     timestamps: {
       createdAt: new Date('2030-01-01T00:00:00.000Z'),
@@ -95,16 +101,20 @@ describe('UpdateUnitHandler', () => {
   let unitRepository: jest.Mocked<UnitRepository>;
   let reservationRepository: jest.Mocked<ReservationRepository>;
   let eventEmitter: ReturnType<typeof createEventEmitterMock>;
+  let r2StorageService: ReturnType<typeof createR2StorageServiceMock>;
 
   beforeEach(() => {
     unitRepository = createUnitRepositoryMock();
     reservationRepository = createReservationRepositoryMock();
     eventEmitter = createEventEmitterMock();
+    r2StorageService = createR2StorageServiceMock();
+    r2StorageService.deleteObjects.mockResolvedValue(undefined);
 
     handler = new UpdateUnitHandler(
       unitRepository,
       reservationRepository,
       eventEmitter as any,
+      r2StorageService as any,
     );
   });
 
@@ -207,5 +217,55 @@ describe('UpdateUnitHandler', () => {
       expect.any(String),
       expect.objectContaining({ entityType: 'UNIT' }),
     );
+  });
+
+  it('deletes orphaned R2 keys after save when mediaKeys is updated', async () => {
+    const oldKeys = ['tenant/photo-1.jpg', 'tenant/photo-2.jpg'];
+    const newKeys = ['tenant/photo-2.jpg', 'tenant/photo-3.jpg'];
+    unitRepository.findById.mockResolvedValue(makeUnit({ mediaKeys: oldKeys }));
+    unitRepository.save.mockResolvedValue(UNIT_ID);
+
+    await handler.execute(
+      new UpdateUnitCommand(
+        TENANT_ID, UNIT_ID,
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined,
+        newKeys,
+        undefined, undefined,
+        'user-1', 'owner@example.com',
+      ),
+    );
+
+    expect(r2StorageService.deleteObjects).toHaveBeenCalledWith(['tenant/photo-1.jpg']);
+  });
+
+  it('does not call deleteObjects when mediaKeys is not in the command', async () => {
+    unitRepository.findById.mockResolvedValue(
+      makeUnit({ mediaKeys: ['tenant/photo-1.jpg'] }),
+    );
+    unitRepository.save.mockResolvedValue(UNIT_ID);
+
+    await handler.execute(makeCommand({ name: 'Updated' }));
+
+    expect(r2StorageService.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it('calls deleteObjects with empty array when no keys were removed', async () => {
+    const keys = ['tenant/photo-1.jpg'];
+    unitRepository.findById.mockResolvedValue(makeUnit({ mediaKeys: keys }));
+    unitRepository.save.mockResolvedValue(UNIT_ID);
+
+    await handler.execute(
+      new UpdateUnitCommand(
+        TENANT_ID, UNIT_ID,
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined,
+        keys,
+        undefined, undefined,
+        'user-1', 'owner@example.com',
+      ),
+    );
+
+    expect(r2StorageService.deleteObjects).toHaveBeenCalledWith([]);
   });
 });

--- a/test/shared/mocks/services/r2-storage.mock.ts
+++ b/test/shared/mocks/services/r2-storage.mock.ts
@@ -1,10 +1,9 @@
 import { R2StorageService } from '@/infrastructure/storage/r2-storage.service';
 
-export function createR2StorageServiceMock(): jest.Mocked<
-  Pick<R2StorageService, 'generatePresignedPutUrl' | 'getPublicUrl'>
-> {
+export function createR2StorageServiceMock(): jest.Mocked<R2StorageService> {
   return {
     generatePresignedPutUrl: jest.fn(),
     getPublicUrl: jest.fn(),
-  };
+    deleteObjects: jest.fn(),
+  } as unknown as jest.Mocked<R2StorageService>;
 }


### PR DESCRIPTION
Summary

  - Added deleteObjects(keys) to R2StorageService using DeleteObjectsCommand (bulk S3-compatible delete)
  - UpdateUnitHandler and UpdateExperienceHandler now capture old mediaKeys before save, diff against the new array, and
  delete orphaned R2 objects after the DB write succeeds
  - Both application modules wired with StorageModule to inject R2StorageService

  How it works

  The client always sends the complete new mediaKeys[] array on update. The backend diffs old vs new — keys that
  disappeared are deleted from R2. Deletion happens after the DB write, so a failed DB save never triggers R2 deletion.

  Test plan

  - [ ] UpdateUnitHandler: deletes orphaned keys, no-op when no keys removed, skips when mediaKeys not in command
  - [ ] UpdateExperienceHandler: same coverage
  - [ ] Manual: PATCH unit with a subset of current mediaKeys → confirm removed keys return 404 from R2 public URL