### PR TITLE
LYMON-1012 fix(shift): update validation to prevent identical start a…

### DIFF
--- a/src/domain/shift/entities/shift.entity.ts
+++ b/src/domain/shift/entities/shift.entity.ts
@@ -54,8 +54,8 @@ export class Shift {
   ) {}
 
   static create(params: CreateShiftParams): Shift {
-    if (params.endMinutes <= params.startMinutes) {
-      throw new Error('Shift end time must be after start time');
+    if (params.endMinutes === params.startMinutes) {
+      throw new Error('Shift start and end time cannot be the same');
     }
 
     if (
@@ -284,8 +284,8 @@ export class Shift {
     startMinutes: number,
     endMinutes: number,
   ): void {
-    if (endMinutes <= startMinutes) {
-      throw new Error('Shift end time must be after start time');
+    if (endMinutes === startMinutes) {
+      throw new Error('Shift start and end time cannot be the same');
     }
   }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the validation logic for shift start and end times in the `Shift` entity. The main change is to only disallow shifts where the start and end times are exactly the same, rather than when the end time is less than or equal to the start time. The error message has also been updated for clarity.

Validation logic update:

* Updated both the `create` method and the internal validation method in `shift.entity.ts` to throw an error only when `startMinutes` and `endMinutes` are exactly the same, instead of when the end is less than or equal to the start. The error message now specifies that shift start and end time cannot be the same. [[1]](diffhunk://#diff-d6702b27630bd6193c118cb68312d77e6837d8826bcd653da6ff2e2b5ccefe74L57-R58) [[2]](diffhunk://#diff-d6702b27630bd6193c118cb68312d77e6837d8826bcd653da6ff2e2b5ccefe74L287-R288)