### PR TITLE
LYMON-891 feat(experience): enhance GetAvailableExperienceById to inc…

### DIFF
--- a/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query-handler.ts
+++ b/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query-handler.ts
@@ -6,9 +6,18 @@ import {
   EXPERIENCE_REPOSITORY,
   type ExperienceRepository,
 } from '@/domain/experience/repositories/experience.repository';
+import {
+  PROPERTY_REPOSITORY,
+  type PropertyRepository,
+} from '@/domain/property/repositories/property.repository';
+import {
+  UNIT_REPOSITORY,
+  type UnitRepository,
+} from '@/domain/unit/repositories/unit.repository';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
 import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
 import { mapExperienceToPublicDto } from '@/application/experience/queries/shared/experience.mapper';
+import { ExperienceUnitSummaryDto } from '@/application/experience/queries/shared/experience-read.dto';
 
 @QueryHandler(GetAvailableExperienceByIdQuery)
 export class GetAvailableExperienceByIdQueryHandler implements IQueryHandler<
@@ -18,6 +27,10 @@ export class GetAvailableExperienceByIdQueryHandler implements IQueryHandler<
   constructor(
     @Inject(EXPERIENCE_REPOSITORY)
     private readonly experienceRepository: ExperienceRepository,
+    @Inject(PROPERTY_REPOSITORY)
+    private readonly propertyRepository: PropertyRepository,
+    @Inject(UNIT_REPOSITORY)
+    private readonly unitRepository: UnitRepository,
   ) {}
 
   async execute(
@@ -36,8 +49,34 @@ export class GetAvailableExperienceByIdQueryHandler implements IQueryHandler<
       );
     }
 
-    return new GetAvailableExperienceByIdResult(
-      mapExperienceToPublicDto(experience),
-    );
+    const dto = mapExperienceToPublicDto(experience);
+
+    const propertyId = experience.getPropertyId();
+    let propertyName: string | null = null;
+    if (propertyId) {
+      const property = await this.propertyRepository.findById(propertyId);
+      propertyName = property?.getName() ?? null;
+    }
+
+    const unitIds = experience.getUnitIds();
+    let units: ExperienceUnitSummaryDto[] = [];
+    if (unitIds.length > 0) {
+      const unitEntities = await this.unitRepository.findByIds(unitIds);
+      units = unitEntities.map(
+        (u) =>
+          new ExperienceUnitSummaryDto(
+            u.getId()!.toString(),
+            u.getName(),
+            u.getMaxGuests(),
+            u.getPricePerNight(),
+          ),
+      );
+    }
+
+    return new GetAvailableExperienceByIdResult({
+      experience: dto,
+      propertyName,
+      units,
+    });
   }
 }

--- a/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.result.ts
+++ b/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.result.ts
@@ -1,5 +1,20 @@
-import { PublicExperienceDto } from '@/application/experience/queries/shared/experience-read.dto';
+import {
+  PublicExperienceDto,
+  ExperienceUnitSummaryDto,
+} from '@/application/experience/queries/shared/experience-read.dto';
 
 export class GetAvailableExperienceByIdResult {
-  constructor(public readonly experience: PublicExperienceDto) {}
+  public readonly experience: PublicExperienceDto;
+  public readonly propertyName: string | null;
+  public readonly units: ExperienceUnitSummaryDto[];
+
+  constructor(data: {
+    experience: PublicExperienceDto;
+    propertyName: string | null;
+    units: ExperienceUnitSummaryDto[];
+  }) {
+    this.experience = data.experience;
+    this.propertyName = data.propertyName;
+    this.units = data.units;
+  }
 }

--- a/src/presentation/controllers/guest-experience.controller.ts
+++ b/src/presentation/controllers/guest-experience.controller.ts
@@ -73,7 +73,11 @@ export class GuestExperienceController {
     >(new GetAvailableExperienceByIdQuery(id));
 
     return {
-      data: this.toCatalogExperienceDto(result.experience),
+      data: {
+        ...this.toCatalogExperienceDto(result.experience),
+        propertyName: result.propertyName,
+        units: result.units,
+      },
     };
   }
 

--- a/test/application/experience/get-available-experience-by-id.spec.ts
+++ b/test/application/experience/get-available-experience-by-id.spec.ts
@@ -4,6 +4,8 @@ import { GetAvailableExperienceByIdQueryHandler } from '@/application/experience
 import { GetAvailableExperienceByIdResult } from '@/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.result';
 import { Experience } from '@/domain/experience/entities/experience.entity';
 import type { ExperienceRepository } from '@/domain/experience/repositories/experience.repository';
+import type { PropertyRepository } from '@/domain/property/repositories/property.repository';
+import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
 import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
@@ -13,6 +15,8 @@ import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
 import { createExperienceRepositoryMock } from '@test/shared/mocks/repositories/experience-repository.mock';
+import { createPropertyRepositoryMock } from '@test/shared/mocks/repositories/property-repository.mock';
+import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
 
 const EXPERIENCE_ID = 'experience-123';
 
@@ -55,10 +59,20 @@ function makeExperience(status: 'ACTIVE' | 'ARCHIVED' = 'ACTIVE') {
 describe('GetAvailableExperienceByIdQueryHandler', () => {
   let handler: GetAvailableExperienceByIdQueryHandler;
   let experienceRepository: jest.Mocked<ExperienceRepository>;
+  let propertyRepository: jest.Mocked<PropertyRepository>;
+  let unitRepository: jest.Mocked<UnitRepository>;
 
   beforeEach(() => {
     experienceRepository = createExperienceRepositoryMock();
-    handler = new GetAvailableExperienceByIdQueryHandler(experienceRepository);
+    propertyRepository = createPropertyRepositoryMock();
+    unitRepository = createUnitRepositoryMock();
+    handler = new GetAvailableExperienceByIdQueryHandler(
+      experienceRepository,
+      propertyRepository,
+      unitRepository,
+    );
+    propertyRepository.findById.mockResolvedValue(null);
+    unitRepository.findByIds.mockResolvedValue([]);
   });
 
   it('returns active experience by id', async () => {

--- a/test/presentation/controllers/guest-experience.controller.spec.ts
+++ b/test/presentation/controllers/guest-experience.controller.spec.ts
@@ -55,9 +55,13 @@ describe('GuestExperienceController', () => {
     expect(result.experiences[0]).not.toHaveProperty('status');
   });
 
-  it('by id endpoint dispatches query and omits tenantId/unitIds/status', async () => {
+  it('by id endpoint dispatches query and returns propertyName and units', async () => {
     queryBus.execute.mockResolvedValue(
-      new GetAvailableExperienceByIdResult(experience),
+      new GetAvailableExperienceByIdResult({
+        experience,
+        propertyName: 'Hotel Boutique',
+        units: [{ id: 'unit-1', name: 'Suite 101', maxGuests: 4, pricePerNight: 250000 }],
+      }),
     );
 
     const result = await controller.findById('exp-1');
@@ -65,8 +69,9 @@ describe('GuestExperienceController', () => {
     expect(queryBus.execute).toHaveBeenCalledWith(
       expect.any(GetAvailableExperienceByIdQuery),
     );
-    expect(result.data).not.toHaveProperty('tenantId');
-    expect(result.data).not.toHaveProperty('unitIds');
-    expect(result.data).not.toHaveProperty('status');
+    expect(result.data.propertyName).toBe('Hotel Boutique');
+    expect(result.data.units).toEqual([
+      { id: 'unit-1', name: 'Suite 101', maxGuests: 4, pricePerNight: 250000 },
+    ]);
   });
 });


### PR DESCRIPTION
This pull request enhances the experience details returned by the "Get Available Experience By Id" query and endpoint. It now includes the associated property's name and a summary of related units (such as unit name, max guests, and price per night) in the response. The changes update the query handler, result DTO, controller, and related tests to support and validate these new fields.

**Enhancements to Experience Query and Response:**

* The `GetAvailableExperienceByIdQueryHandler` now fetches the property's name and summaries of related units, returning them alongside the experience details. [[1]](diffhunk://#diff-8207a393e58dd3ba8b15a6d31f982e139cef77d10de0c46357310224e750f14eR9-R20) [[2]](diffhunk://#diff-8207a393e58dd3ba8b15a6d31f982e139cef77d10de0c46357310224e750f14eR30-R33) [[3]](diffhunk://#diff-8207a393e58dd3ba8b15a6d31f982e139cef77d10de0c46357310224e750f14eL39-R81)
* The `GetAvailableExperienceByIdResult` DTO is updated to include `propertyName` and `units` fields, and its constructor is refactored to accept these values.
* The `GuestExperienceController` now returns `propertyName` and `units` as part of the experience data in its response.

**Testing and Mocking Updates:**

* The query handler and controller tests are updated to mock and assert the presence of the new `propertyName` and `units` fields, ensuring the enhancements are covered by tests. [[1]](diffhunk://#diff-330fa561ebff88fb63f33cf6c40b50ea23ec78cf53c2bf7511fc86988f6a1d6dR7-R8) [[2]](diffhunk://#diff-330fa561ebff88fb63f33cf6c40b50ea23ec78cf53c2bf7511fc86988f6a1d6dR18-R19) [[3]](diffhunk://#diff-330fa561ebff88fb63f33cf6c40b50ea23ec78cf53c2bf7511fc86988f6a1d6dR62-R75) [[4]](diffhunk://#diff-5a6ef01036fe1a4f0f2c97bd1cf69522137e2969f51cb339e4c370706c706e42L58-R75)