### PR TITLE
Lymon 1036 organize r 2 storage with per tenant subfolders by image category

### DIFF
--- a/src/application/storage/media-category.enum.ts
+++ b/src/application/storage/media-category.enum.ts
@@ -1,0 +1,5 @@
+export enum MediaCategory {
+  Experiences = 'experiences',
+  Units = 'units',
+  Properties = 'properties',
+}

--- a/src/application/storage/queries/generate-presigned-url/generate-presigned-url.query-handler.ts
+++ b/src/application/storage/queries/generate-presigned-url/generate-presigned-url.query-handler.ts
@@ -21,7 +21,7 @@ export class GeneratePresignedUrlQueryHandler implements IQueryHandler<
     query: GeneratePresignedUrlQuery,
   ): Promise<GeneratePresignedUrlResult> {
     const sanitizedName = query.fileName.replace(/[^a-zA-Z0-9._-]/g, '_');
-    const key = `${query.tenantId}/${Date.now()}-${sanitizedName}`;
+    const key = `${query.tenantId}/${query.category}/${Date.now()}-${sanitizedName}`;
 
     const presignedUrl = await this.storageService.generatePresignedPutUrl(
       key,

--- a/src/application/storage/queries/generate-presigned-url/generate-presigned-url.query.ts
+++ b/src/application/storage/queries/generate-presigned-url/generate-presigned-url.query.ts
@@ -1,7 +1,10 @@
+import { MediaCategory } from '@/application/storage/media-category.enum';
+
 export class GeneratePresignedUrlQuery {
   constructor(
     public readonly fileName: string,
     public readonly contentType: string,
     public readonly tenantId: string,
+    public readonly category: MediaCategory,
   ) {}
 }

--- a/src/presentation/controllers/storage.controller.ts
+++ b/src/presentation/controllers/storage.controller.ts
@@ -38,6 +38,7 @@ export class StorageController {
         dto.fileName,
         dto.contentType,
         user.tenantId,
+        dto.category,
       ),
     );
 

--- a/src/presentation/dtos/generate-presigned-url.dto.ts
+++ b/src/presentation/dtos/generate-presigned-url.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsIn, IsString, MaxLength } from 'class-validator';
+import { IsEnum, IsIn, IsString, MaxLength } from 'class-validator';
+import { MediaCategory } from '@/application/storage/media-category.enum';
 
 export class GeneratePresignedUrlDto {
   @ApiProperty({ example: 'photo.jpg' })
@@ -17,4 +18,8 @@ export class GeneratePresignedUrlDto {
     'application/pdf',
   ])
   contentType: string;
+
+  @ApiProperty({ enum: MediaCategory, example: MediaCategory.Experiences })
+  @IsEnum(MediaCategory)
+  category: MediaCategory;
 }

--- a/test/application/storage/generate-presigned-url.query-handler.spec.ts
+++ b/test/application/storage/generate-presigned-url.query-handler.spec.ts
@@ -2,6 +2,7 @@ import { GeneratePresignedUrlQueryHandler } from '@/application/storage/queries/
 import { GeneratePresignedUrlQuery } from '@/application/storage/queries/generate-presigned-url/generate-presigned-url.query';
 import { GeneratePresignedUrlResult } from '@/application/storage/queries/generate-presigned-url/generate-presigned-url.result';
 import { createR2StorageServiceMock } from '@test/shared/mocks/services/r2-storage.mock';
+import { MediaCategory } from '@/application/storage/media-category.enum';
 
 const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c0';
 const PRESIGNED_URL =
@@ -25,7 +26,12 @@ describe('GeneratePresignedUrlQueryHandler', () => {
       );
 
       const result = await handler.execute(
-        new GeneratePresignedUrlQuery('photo.jpg', 'image/jpeg', TENANT_ID),
+        new GeneratePresignedUrlQuery(
+          'photo.jpg',
+          'image/jpeg',
+          TENANT_ID,
+          MediaCategory.Experiences,
+        ),
       );
 
       expect(result).toBeInstanceOf(GeneratePresignedUrlResult);
@@ -40,10 +46,33 @@ describe('GeneratePresignedUrlQueryHandler', () => {
       storageService.getPublicUrl.mockReturnValue(`${PUBLIC_URL}/key`);
 
       const result = await handler.execute(
-        new GeneratePresignedUrlQuery('photo.jpg', 'image/jpeg', TENANT_ID),
+        new GeneratePresignedUrlQuery(
+          'photo.jpg',
+          'image/jpeg',
+          TENANT_ID,
+          MediaCategory.Experiences,
+        ),
       );
 
       expect(result.key.startsWith(TENANT_ID)).toBe(true);
+    });
+
+    it('places the key under the category subfolder', async () => {
+      storageService.generatePresignedPutUrl.mockResolvedValue(PRESIGNED_URL);
+      storageService.getPublicUrl.mockReturnValue(`${PUBLIC_URL}/key`);
+
+      const result = await handler.execute(
+        new GeneratePresignedUrlQuery(
+          'photo.jpg',
+          'image/jpeg',
+          TENANT_ID,
+          MediaCategory.Properties,
+        ),
+      );
+
+      expect(result.key).toMatch(
+        new RegExp(`^${TENANT_ID}/${MediaCategory.Properties}/\\d+-photo\\.jpg$`),
+      );
     });
 
     it('sanitizes special characters in filename', async () => {
@@ -55,6 +84,7 @@ describe('GeneratePresignedUrlQueryHandler', () => {
           'my photo (1).jpg',
           'image/jpeg',
           TENANT_ID,
+          MediaCategory.Units,
         ),
       );
 
@@ -68,7 +98,12 @@ describe('GeneratePresignedUrlQueryHandler', () => {
       storageService.getPublicUrl.mockReturnValue(`${PUBLIC_URL}/key`);
 
       await handler.execute(
-        new GeneratePresignedUrlQuery('photo.jpg', 'image/png', TENANT_ID),
+        new GeneratePresignedUrlQuery(
+          'photo.jpg',
+          'image/png',
+          TENANT_ID,
+          MediaCategory.Experiences,
+        ),
       );
 
       expect(storageService.generatePresignedPutUrl).toHaveBeenCalledWith(
@@ -82,7 +117,12 @@ describe('GeneratePresignedUrlQueryHandler', () => {
       storageService.getPublicUrl.mockReturnValue(`${PUBLIC_URL}/key`);
 
       await handler.execute(
-        new GeneratePresignedUrlQuery('photo.jpg', 'image/jpeg', TENANT_ID),
+        new GeneratePresignedUrlQuery(
+          'photo.jpg',
+          'image/jpeg',
+          TENANT_ID,
+          MediaCategory.Experiences,
+        ),
       );
 
       const keyUsedForPresigned = (


### PR DESCRIPTION
 ## Summary

  R2 object keys were flat under the tenant prefix (`{tenantId}/{timestamp}-{filename}`),
  mixing experience, unit, and property images in one namespace. This adds a required
  `category` to the presigned-url flow so keys become
  `{tenantId}/{category}/{timestamp}-{filename}`, making storage browsable per type.

  ## Changes

  **Application**
  - New `MediaCategory` enum: `experiences`, `units`, `properties`
  - `GeneratePresignedUrlQuery` carries `category`; handler builds the key with the subfolder

  **Presentation**
  - `GeneratePresignedUrlDto` gains a required, `@IsEnum`-validated `category` field
  - `StorageController` passes `dto.category` into the query

  **Test**
  - New assertion covering the `{tenantId}/{category}/...` key shape

  ## API contract change 

  `POST /storage/presigned-url` now **requires** `category` in the body:

  ```jsonc
  { "fileName": "photo.jpg", "contentType": "image/jpeg", "category": "experiences" }
  { "fileName": "photo.jpg", "contentType": "image/jpeg", "category": "experiences" }

  Allowed values: experiences, units, properties. Omitting it or sending an unknown
  value returns 400. Response shape is unchanged (presignedUrl, fileUrl, key).