### PR TITLE
LYMON-1037 feat(guest): upload and update profile photo via presigned…

### DIFF
--- a/src/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.command.ts
+++ b/src/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.command.ts
@@ -1,0 +1,6 @@
+export class UpdateGuestProfilePhotoCommand {
+  constructor(
+    public readonly guestAccountId: string,
+    public readonly key: string,
+  ) {}
+}

--- a/src/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler.ts
+++ b/src/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler.ts
@@ -1,0 +1,63 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { BadRequestException, Inject, UnauthorizedException } from '@nestjs/common';
+import { UpdateGuestProfilePhotoCommand } from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.command';
+import { guestProfilePhotoPrefix } from '@/application/guest-auth/profile-photo/profile-photo-key';
+import {
+  GUEST_ACCOUNT_REPOSITORY,
+  type GuestAccountRepository,
+} from '@/domain/guest-account/repositories/guest-account.repository';
+import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
+
+export class UpdateGuestProfilePhotoResult {
+  constructor(public readonly profilePhotoUrl: string) {}
+}
+
+@CommandHandler(UpdateGuestProfilePhotoCommand)
+export class UpdateGuestProfilePhotoHandler
+  implements ICommandHandler<UpdateGuestProfilePhotoCommand>
+{
+  constructor(
+    @Inject(GUEST_ACCOUNT_REPOSITORY)
+    private readonly guestAccountRepository: GuestAccountRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storageService: R2StorageService,
+  ) {}
+
+  async execute(
+    command: UpdateGuestProfilePhotoCommand,
+  ): Promise<UpdateGuestProfilePhotoResult> {
+    // The key comes from the client; it must live under this guest's own prefix
+    // so a guest can't claim someone else's (or an arbitrary) object.
+    if (!command.key.startsWith(guestProfilePhotoPrefix(command.guestAccountId))) {
+      throw new BadRequestException('Invalid profile photo key');
+    }
+
+    const account = await this.guestAccountRepository.findById(
+      GuestAccountId.createFromString(command.guestAccountId),
+    );
+
+    if (!account) {
+      throw new UnauthorizedException('Account not found');
+    }
+
+    const previousUrl = account.getProfilePhotoUrl();
+    const oldKey = previousUrl
+      ? this.storageService.keyFromPublicUrl(previousUrl)
+      : null;
+
+    const profilePhotoUrl = this.storageService.getPublicUrl(command.key);
+    account.setProfilePhotoUrl(profilePhotoUrl);
+    await this.guestAccountRepository.save(account);
+
+    // Best-effort: remove the old photo once the new one is committed.
+    if (oldKey && oldKey !== command.key) {
+      await this.storageService.deleteObjects([oldKey]);
+    }
+
+    return new UpdateGuestProfilePhotoResult(profilePhotoUrl);
+  }
+}

--- a/src/application/guest-auth/guest-auth-application.module.ts
+++ b/src/application/guest-auth/guest-auth-application.module.ts
@@ -3,6 +3,7 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { GuestAuthModule } from '@/infrastructure/guest-auth/guest-auth.module';
 import { EmailModule } from '@/infrastructure/email/email.module';
+import { StorageModule } from '@/infrastructure/storage/storage.module';
 import { RegisterGuestAccountHandler } from '@/application/guest-auth/commands/register-guest-account/register-guest-account.handler';
 import { VerifyGuestEmailHandler } from '@/application/guest-auth/commands/verify-guest-email/verify-guest-email.handler';
 import { GuestLoginHandler } from '@/application/guest-auth/commands/login-guest/login-guest.handler';
@@ -11,6 +12,8 @@ import { ConfirmRecoverGuestPasswordHandler } from '@/application/guest-auth/com
 import { ChangeGuestPasswordHandler } from '@/application/guest-auth/commands/change-guest-password/change-guest-password.handler';
 import { RefreshGuestTokenHandler } from '@/application/guest-auth/commands/refresh-guest-token/refresh-guest-token.handler';
 import { LogoutGuestHandler } from '@/application/guest-auth/commands/logout-guest/logout-guest.handler';
+import { UpdateGuestProfilePhotoHandler } from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler';
+import { GenerateGuestProfilePhotoUrlQueryHandler } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query-handler';
 
 const CommandHandlers = [
   RegisterGuestAccountHandler,
@@ -21,11 +24,20 @@ const CommandHandlers = [
   ChangeGuestPasswordHandler,
   RefreshGuestTokenHandler,
   LogoutGuestHandler,
+  UpdateGuestProfilePhotoHandler,
 ];
 
+const QueryHandlers = [GenerateGuestProfilePhotoUrlQueryHandler];
+
 @Module({
-  imports: [CqrsModule, PersistenceModule, GuestAuthModule, EmailModule],
-  providers: [...CommandHandlers],
-  exports: [...CommandHandlers, GuestAuthModule],
+  imports: [
+    CqrsModule,
+    PersistenceModule,
+    GuestAuthModule,
+    EmailModule,
+    StorageModule,
+  ],
+  providers: [...CommandHandlers, ...QueryHandlers],
+  exports: [...CommandHandlers, ...QueryHandlers, GuestAuthModule],
 })
 export class GuestAuthApplicationModule {}

--- a/src/application/guest-auth/profile-photo/profile-photo-key.ts
+++ b/src/application/guest-auth/profile-photo/profile-photo-key.ts
@@ -1,0 +1,11 @@
+/** Allowed image content types mapped to the extension used in the R2 key. */
+export const PROFILE_PHOTO_EXT_BY_CONTENT_TYPE: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+/** Dedicated R2 prefix a guest's profile photos live under. */
+export function guestProfilePhotoPrefix(guestAccountId: string): string {
+  return `guests/${guestAccountId}/profile/`;
+}

--- a/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query-handler.ts
+++ b/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query-handler.ts
@@ -1,0 +1,45 @@
+import { Inject, BadRequestException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
+import {
+  PROFILE_PHOTO_EXT_BY_CONTENT_TYPE,
+  guestProfilePhotoPrefix,
+} from '@/application/guest-auth/profile-photo/profile-photo-key';
+import { GenerateGuestProfilePhotoUrlQuery } from './generate-guest-profile-photo-url.query';
+import { GenerateGuestProfilePhotoUrlResult } from './generate-guest-profile-photo-url.result';
+
+@QueryHandler(GenerateGuestProfilePhotoUrlQuery)
+export class GenerateGuestProfilePhotoUrlQueryHandler
+  implements
+    IQueryHandler<
+      GenerateGuestProfilePhotoUrlQuery,
+      GenerateGuestProfilePhotoUrlResult
+    >
+{
+  constructor(
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storageService: R2StorageService,
+  ) {}
+
+  async execute(
+    query: GenerateGuestProfilePhotoUrlQuery,
+  ): Promise<GenerateGuestProfilePhotoUrlResult> {
+    const ext = PROFILE_PHOTO_EXT_BY_CONTENT_TYPE[query.contentType];
+    if (!ext) {
+      throw new BadRequestException('Unsupported image type');
+    }
+
+    const key = `${guestProfilePhotoPrefix(query.guestAccountId)}${Date.now()}.${ext}`;
+
+    const presignedUrl = await this.storageService.generatePresignedPutUrl(
+      key,
+      query.contentType,
+    );
+    const fileUrl = this.storageService.getPublicUrl(key);
+
+    return new GenerateGuestProfilePhotoUrlResult(presignedUrl, fileUrl, key);
+  }
+}

--- a/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query.ts
+++ b/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query.ts
@@ -1,0 +1,6 @@
+export class GenerateGuestProfilePhotoUrlQuery {
+  constructor(
+    public readonly guestAccountId: string,
+    public readonly contentType: string,
+  ) {}
+}

--- a/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.result.ts
+++ b/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.result.ts
@@ -1,0 +1,7 @@
+export class GenerateGuestProfilePhotoUrlResult {
+  constructor(
+    public readonly presignedUrl: string,
+    public readonly fileUrl: string,
+    public readonly key: string,
+  ) {}
+}

--- a/src/domain/guest-account/entities/guest-account.entity.ts
+++ b/src/domain/guest-account/entities/guest-account.entity.ts
@@ -21,6 +21,7 @@ export class GuestAccount {
     private passwordChangedAt: Date | null,
     private readonly createdAt: Date,
     private updatedAt: Date,
+    private profilePhotoUrl: string | null,
   ) {}
 
   static create(params: CreateGuestAccountParams): GuestAccount {
@@ -45,6 +46,7 @@ export class GuestAccount {
       null,
       new Date(),
       new Date(),
+      null,
     );
   }
 
@@ -65,6 +67,7 @@ export class GuestAccount {
       data.passwordChangedAt,
       data.createdAt,
       data.updatedAt,
+      data.profilePhotoUrl,
     );
   }
 
@@ -132,6 +135,15 @@ export class GuestAccount {
   suspend(): void {
     this.status = GuestAccountStatusEnum.SUSPENDED;
     this.touch();
+  }
+
+  setProfilePhotoUrl(url: string | null): void {
+    this.profilePhotoUrl = url;
+    this.touch();
+  }
+
+  getProfilePhotoUrl(): string | null {
+    return this.profilePhotoUrl;
   }
 
   getId(): GuestAccountId | null {

--- a/src/domain/guest-account/interfaces/guest-account.interface.ts
+++ b/src/domain/guest-account/interfaces/guest-account.interface.ts
@@ -18,4 +18,5 @@ export interface IGuestAccount {
   passwordChangedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+  profilePhotoUrl: string | null;
 }

--- a/src/infrastructure/persistence/repositories/mongo-guest-account.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-guest-account.repository.ts
@@ -30,6 +30,7 @@ export class MongoGuestAccountRepository implements GuestAccountRepository {
       passwordResetToken: account.getPasswordResetToken(),
       passwordResetExpiry: account.getPasswordResetExpiry(),
       passwordChangedAt: account.getPasswordChangedAt(),
+      profilePhotoUrl: account.getProfilePhotoUrl(),
       updatedAt: account.getUpdatedAt(),
     };
 
@@ -88,6 +89,7 @@ export class MongoGuestAccountRepository implements GuestAccountRepository {
       passwordChangedAt: doc.passwordChangedAt,
       createdAt: doc.createdAt,
       updatedAt: doc.updatedAt,
+      profilePhotoUrl: doc.profilePhotoUrl ?? null,
     });
   }
 }

--- a/src/infrastructure/persistence/schemas/guest-account.schema.ts
+++ b/src/infrastructure/persistence/schemas/guest-account.schema.ts
@@ -44,6 +44,9 @@ export class GuestAccountDocument extends Document {
   @Prop({ type: Date, default: null })
   passwordChangedAt: Date | null;
 
+  @Prop({ type: String, default: null })
+  profilePhotoUrl: string | null;
+
   @Prop()
   createdAt: Date;
 

--- a/src/infrastructure/storage/r2-storage.service.ts
+++ b/src/infrastructure/storage/r2-storage.service.ts
@@ -65,4 +65,10 @@ export class R2StorageService {
   getPublicUrl(key: string): string {
     return `${this.publicUrl}/${key}`;
   }
+
+  /** Inverse of getPublicUrl; null if the URL isn't one of ours. */
+  keyFromPublicUrl(url: string): string | null {
+    const prefix = `${this.publicUrl}/`;
+    return url.startsWith(prefix) ? url.slice(prefix.length) : null;
+  }
 }

--- a/src/presentation/controllers/guest.controller.ts
+++ b/src/presentation/controllers/guest.controller.ts
@@ -1,6 +1,10 @@
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { ChangeGuestPasswordCommand } from '@/application/guest-auth/commands/change-guest-password/change-guest-password.command';
 import { ChangeGuestPasswordResult } from '@/application/guest-auth/commands/change-guest-password/change-guest-password.handler';
+import { UpdateGuestProfilePhotoCommand } from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.command';
+import { UpdateGuestProfilePhotoResult } from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler';
+import { GenerateGuestProfilePhotoUrlQuery } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query';
+import { GenerateGuestProfilePhotoUrlResult } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.result';
 import { type GuestJwtPayload } from '@/application/guest-auth/services/guest-jwt.service';
 import { CreateGuestCommand } from '@/application/guest/commands/create-guest.command';
 import { CreateGuestResult } from '@/application/guest/commands/create-guest.result';
@@ -39,6 +43,8 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
+import { GuestProfilePhotoUrlDto } from '@/presentation/dtos/guest/guest-profile-photo-url.dto';
+import { SaveGuestProfilePhotoDto } from '@/presentation/dtos/guest/save-guest-profile-photo.dto';
 
 @ApiTags('guests')
 @ApiBearerAuth('JWT-auth')
@@ -152,6 +158,63 @@ export class GuestController {
     );
 
     return { message: result.message };
+  }
+
+  @Public()
+  @UseGuards(GuestJwtAuthGuard)
+  @Post('profile-photo/presigned-url')
+  @ApiBearerAuth('GuestJWT-auth')
+  @ApiOperation({
+    summary: 'Get a presigned R2 URL to upload the guest profile photo',
+  })
+  @ApiResponse({ status: 201, description: 'Presigned URL generated' })
+  @ApiResponse({ status: 400, description: 'Unsupported image type' })
+  async getProfilePhotoUploadUrl(
+    @CurrentGuest() guest: GuestJwtPayload,
+    @Body() dto: GuestProfilePhotoUrlDto,
+  ) {
+    const result = await this.queryBus.execute<
+      GenerateGuestProfilePhotoUrlQuery,
+      GenerateGuestProfilePhotoUrlResult
+    >(
+      new GenerateGuestProfilePhotoUrlQuery(
+        guest.guestAccountId,
+        dto.contentType,
+      ),
+    );
+
+    return {
+      message: 'Presigned URL generated',
+      data: {
+        presignedUrl: result.presignedUrl,
+        fileUrl: result.fileUrl,
+        key: result.key,
+      },
+    };
+  }
+
+  @Public()
+  @UseGuards(GuestJwtAuthGuard)
+  @Post('profile-photo')
+  @ApiBearerAuth('GuestJWT-auth')
+  @ApiOperation({
+    summary: 'Save the uploaded profile photo and remove the previous one',
+  })
+  @ApiResponse({ status: 201, description: 'Profile photo updated successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid profile photo key' })
+  async saveProfilePhoto(
+    @CurrentGuest() guest: GuestJwtPayload,
+    @Body() dto: SaveGuestProfilePhotoDto,
+  ) {
+    const result = await this.commandBus.execute<
+      UpdateGuestProfilePhotoCommand,
+      UpdateGuestProfilePhotoResult
+    >(new UpdateGuestProfilePhotoCommand(guest.guestAccountId, dto.key));
+
+    return {
+      message: 'Profile photo updated successfully',
+      data: { profilePhotoUrl: result.profilePhotoUrl },
+    };
   }
 
   @Get(':guestId')

--- a/src/presentation/dtos/guest/guest-profile-photo-url.dto.ts
+++ b/src/presentation/dtos/guest/guest-profile-photo-url.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsString } from 'class-validator';
+
+export class GuestProfilePhotoUrlDto {
+  @ApiProperty({
+    example: 'image/jpeg',
+    enum: ['image/jpeg', 'image/png', 'image/webp'],
+  })
+  @IsString()
+  @IsIn(['image/jpeg', 'image/png', 'image/webp'])
+  contentType: string;
+}

--- a/src/presentation/dtos/guest/save-guest-profile-photo.dto.ts
+++ b/src/presentation/dtos/guest/save-guest-profile-photo.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SaveGuestProfilePhotoDto {
+  @ApiProperty({
+    example: 'guests/65f1.../profile/1719236872000.jpg',
+    description: 'R2 key returned by the presigned-url endpoint',
+  })
+  @IsString()
+  @IsNotEmpty()
+  key: string;
+}

--- a/test/application/guest-auth/generate-guest-profile-photo-url.query-handler.spec.ts
+++ b/test/application/guest-auth/generate-guest-profile-photo-url.query-handler.spec.ts
@@ -1,0 +1,52 @@
+import { GenerateGuestProfilePhotoUrlQueryHandler } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query-handler';
+import { GenerateGuestProfilePhotoUrlQuery } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query';
+import { GenerateGuestProfilePhotoUrlResult } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.result';
+import { R2StorageService } from '@/infrastructure/storage/r2-storage.service';
+import { BadRequestException } from '@nestjs/common';
+
+const PUBLIC_BASE = 'https://cdn.example.com';
+const ACCOUNT_ID = '65f1a1a2b3c4d5e6f7a8b9c5';
+
+describe('GenerateGuestProfilePhotoUrlQueryHandler', () => {
+  let handler: GenerateGuestProfilePhotoUrlQueryHandler;
+  let storageService: jest.Mocked<
+    Pick<R2StorageService, 'generatePresignedPutUrl' | 'getPublicUrl'>
+  >;
+
+  beforeEach(() => {
+    storageService = {
+      generatePresignedPutUrl: jest.fn().mockResolvedValue('https://r2/put'),
+      getPublicUrl: jest.fn((key: string) => `${PUBLIC_BASE}/${key}`),
+    };
+
+    handler = new GenerateGuestProfilePhotoUrlQueryHandler(
+      storageService as unknown as R2StorageService,
+    );
+  });
+
+  it('builds a key under the guest profile prefix with the right extension', async () => {
+    const result = await handler.execute(
+      new GenerateGuestProfilePhotoUrlQuery(ACCOUNT_ID, 'image/webp'),
+    );
+
+    expect(result).toBeInstanceOf(GenerateGuestProfilePhotoUrlResult);
+    expect(result.key).toMatch(
+      new RegExp(`^guests/${ACCOUNT_ID}/profile/\\d+\\.webp$`),
+    );
+    expect(storageService.generatePresignedPutUrl).toHaveBeenCalledWith(
+      result.key,
+      'image/webp',
+    );
+    expect(result.fileUrl).toBe(`${PUBLIC_BASE}/${result.key}`);
+    expect(result.presignedUrl).toBe('https://r2/put');
+  });
+
+  it('rejects an unsupported content type', async () => {
+    await expect(
+      handler.execute(
+        new GenerateGuestProfilePhotoUrlQuery(ACCOUNT_ID, 'application/pdf'),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(storageService.generatePresignedPutUrl).not.toHaveBeenCalled();
+  });
+});

--- a/test/application/guest-auth/update-guest-profile-photo.handler.spec.ts
+++ b/test/application/guest-auth/update-guest-profile-photo.handler.spec.ts
@@ -1,0 +1,95 @@
+import {
+  UpdateGuestProfilePhotoHandler,
+  UpdateGuestProfilePhotoResult,
+} from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler';
+import { UpdateGuestProfilePhotoCommand } from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.command';
+import { GuestAccountRepository } from '@/domain/guest-account/repositories/guest-account.repository';
+import { R2StorageService } from '@/infrastructure/storage/r2-storage.service';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { createGuestAccountRepositoryMock } from '@test/shared/mocks/repositories/guest-account-repository.mock';
+import {
+  makeGuestAccount,
+  GUEST_ACCOUNT_FIXTURE_DEFAULTS,
+} from '@test/shared/fixtures/guest-account.fixture';
+
+const PUBLIC_BASE = 'https://cdn.example.com';
+const ACCOUNT_ID = GUEST_ACCOUNT_FIXTURE_DEFAULTS.id;
+const KEY = `guests/${ACCOUNT_ID}/profile/222.png`;
+
+describe('UpdateGuestProfilePhotoHandler', () => {
+  let handler: UpdateGuestProfilePhotoHandler;
+  let guestAccountRepository: jest.Mocked<GuestAccountRepository>;
+  let storageService: jest.Mocked<
+    Pick<R2StorageService, 'deleteObjects' | 'getPublicUrl' | 'keyFromPublicUrl'>
+  >;
+
+  beforeEach(() => {
+    guestAccountRepository = createGuestAccountRepositoryMock();
+    storageService = {
+      deleteObjects: jest.fn(),
+      getPublicUrl: jest.fn((key: string) => `${PUBLIC_BASE}/${key}`),
+      keyFromPublicUrl: jest.fn((url: string) =>
+        url.startsWith(`${PUBLIC_BASE}/`)
+          ? url.slice(PUBLIC_BASE.length + 1)
+          : null,
+      ),
+    };
+
+    handler = new UpdateGuestProfilePhotoHandler(
+      guestAccountRepository,
+      storageService as unknown as R2StorageService,
+    );
+  });
+
+  it('rejects a key outside the guest own prefix', async () => {
+    await expect(
+      handler.execute(
+        new UpdateGuestProfilePhotoCommand(
+          ACCOUNT_ID,
+          'guests/someone-else/profile/1.png',
+        ),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(guestAccountRepository.findById).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown account', async () => {
+    guestAccountRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new UpdateGuestProfilePhotoCommand(ACCOUNT_ID, KEY)),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('saves the public URL derived from the key', async () => {
+    guestAccountRepository.findById.mockResolvedValue(makeGuestAccount());
+
+    const result = await handler.execute(
+      new UpdateGuestProfilePhotoCommand(ACCOUNT_ID, KEY),
+    );
+
+    expect(result).toBeInstanceOf(UpdateGuestProfilePhotoResult);
+    const saved = guestAccountRepository.save.mock.calls[0][0];
+    expect(saved.getProfilePhotoUrl()).toBe(`${PUBLIC_BASE}/${KEY}`);
+    expect(result.profilePhotoUrl).toBe(`${PUBLIC_BASE}/${KEY}`);
+  });
+
+  it('deletes the previous photo after committing the new one', async () => {
+    const oldKey = `guests/${ACCOUNT_ID}/profile/111.jpg`;
+    guestAccountRepository.findById.mockResolvedValue(
+      makeGuestAccount({ profilePhotoUrl: `${PUBLIC_BASE}/${oldKey}` }),
+    );
+
+    await handler.execute(new UpdateGuestProfilePhotoCommand(ACCOUNT_ID, KEY));
+
+    expect(storageService.deleteObjects).toHaveBeenCalledWith([oldKey]);
+  });
+
+  it('does not delete anything on the first upload', async () => {
+    guestAccountRepository.findById.mockResolvedValue(makeGuestAccount());
+
+    await handler.execute(new UpdateGuestProfilePhotoCommand(ACCOUNT_ID, KEY));
+
+    expect(storageService.deleteObjects).not.toHaveBeenCalled();
+  });
+});

--- a/test/shared/fixtures/guest-account.fixture.ts
+++ b/test/shared/fixtures/guest-account.fixture.ts
@@ -14,6 +14,7 @@ export const GUEST_ACCOUNT_FIXTURE_DEFAULTS = {
   emailVerified: false,
   emailVerificationToken: null as string | null,
   emailVerificationExpiry: null as Date | null,
+  profilePhotoUrl: null as string | null,
 };
 
 export function makeGuestAccount(
@@ -28,6 +29,7 @@ export function makeGuestAccount(
     emailVerified: boolean;
     emailVerificationToken: string | null;
     emailVerificationExpiry: Date | null;
+    profilePhotoUrl: string | null;
   }>,
 ): GuestAccount {
   const merged = { ...GUEST_ACCOUNT_FIXTURE_DEFAULTS, ...overrides };
@@ -47,5 +49,6 @@ export function makeGuestAccount(
     passwordChangedAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
+    profilePhotoUrl: merged.profilePhotoUrl,
   });
 }


### PR DESCRIPTION
Guests previously had no way to set a profile picture. This adds a `profilePhotoUrl`
  to the guest's account and a guest-authenticated flow to upload/replace it, reusing the
  existing presigned-R2 upload pattern (no bytes proxied through the backend).

  ## How it works

  Photo lives on **`GuestAccount`** (the platform-wide login identity), not the per-tenant
  CRM `Guest` record — the guest JWT only carries `guestAccountId`, and a `GuestAccount`
  always exists for an authenticated guest.

  Two guest-authed endpoints (presigned flow, matching the tenant `storage` pattern):

  1. `POST /guests/profile-photo/presigned-url` — body `{ contentType }`. Returns
     `{ presignedUrl, fileUrl, key }`. Key is account-scoped: `guests/{accountId}/profile/{ts}.{ext}`.
  2. Client `PUT`s the file directly to R2.
  3. `POST /guests/profile-photo` — body `{ key }`. Validates the key belongs to the
     caller's prefix, saves `profilePhotoUrl`, and **deletes the previous photo** (best-effort).

  ## Changes

  - **Domain:** `profilePhotoUrl` on `GuestAccount` (+ getter/setter, interface, schema, repo mapping). MongoDB — no migration; `null`
  default covers existing docs.
  - **R2 service:** added `keyFromPublicUrl()` (inverse of `getPublicUrl`, used to resolve the old key for deletion). Reuses existing
  `generatePresignedPutUrl` / `getPublicUrl` / `deleteObjects`.
  - **CQRS:** `GenerateGuestProfilePhotoUrlQuery` (sign + build key) and `UpdateGuestProfilePhotoCommand` (validate ownership, save, delete
  old). Shared key helper in `profile-photo/profile-photo-key.ts`.
  - **DTOs:** `GuestProfilePhotoUrlDto` (allowed types: jpeg/png/webp), `SaveGuestProfilePhotoDto`.

  ## Notes

  - Request body differs from the tenant presigned endpoint by design: a profile photo has one slot, so no `category`, and the filename is
  timestamp-based so no `fileName` (extension derived from `contentType`).
  - Ownership check rejects keys outside `guests/{accountId}/profile/` — a guest can't claim another's object.
  - Orphan window: if a client requests a URL and uploads but never calls save, the object is left behind (best-effort cleanup, same
  tradeoff as the existing tenant flow).