### PR TITLE
LYMON-1057 fix(shift): handle errors during staff assignment and upda…

### DIFF
--- a/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts
+++ b/src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts
@@ -90,13 +90,20 @@ export class AssignStaffToShiftCommandHandler implements ICommandHandler<AssignS
     const previousSnapshot = this.auditDiffService.snapshot(shift);
 
     // Update shift with merged staff list
-    shift.update(
-      {
-        staffMemberIds: allStaffMemberIds,
-        name: shift.getName(),
-      },
-      new Date(),
-    );
+    try {
+      shift.update(
+        {
+          staffMemberIds: allStaffMemberIds,
+          name: shift.getName(),
+        },
+        new Date(),
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
 
     // Snapshot after update
     const nextSnapshot = this.auditDiffService.snapshot(shift);

--- a/src/domain/shift/entities/shift.entity.ts
+++ b/src/domain/shift/entities/shift.entity.ts
@@ -207,13 +207,7 @@ export class Shift {
     this.validateDateInvariants(nextStartDate, nextEndDate);
 
     // Check for changes that cannot happen after shift starts
-    this.validateImmutableChanges(
-      nextStaffMemberIds,
-      nextPropertyId,
-      nextName,
-      nextStartDate,
-      now,
-    );
+    this.validateImmutableChanges(nextPropertyId, nextName, nextStartDate, now);
 
     // Apply updates
     this.applyUpdates({
@@ -296,14 +290,12 @@ export class Shift {
   }
 
   private validateImmutableChanges(
-    nextStaffMemberIds: UserId[],
     nextPropertyId: PropertyId,
     nextName: string,
     nextStartDate: Date,
     now: Date,
   ): void {
     const hasImmutableChangesAfterStart =
-      !this.haveSameStaffMembers(nextStaffMemberIds) ||
       !this.propertyId.equals(nextPropertyId) ||
       this.name !== nextName ||
       this.startDate.getTime() !== nextStartDate.getTime();
@@ -319,7 +311,7 @@ export class Shift {
 
     if (hasImmutableChangesAfterStart) {
       throw new Error(
-        'This shift already started or is in the past. Only endDate, startHour, endHour, and notes can be edited.',
+        'This shift already started or is in the past. Only staffMembers, endDate, startHour, endHour, and notes can be edited.',
       );
     }
   }
@@ -342,8 +334,8 @@ export class Shift {
     const now = new Date();
     const canUpdateAllFields = now.getTime() < shiftStartAt.getTime();
 
+    this.staffMemberIds = updates.staffMemberIds;
     if (canUpdateAllFields) {
-      this.staffMemberIds = updates.staffMemberIds;
       this.propertyId = updates.propertyId;
       this.name = updates.name;
       this.startDate = updates.startDate;


### PR DESCRIPTION
This pull request updates the logic for assigning staff to shifts and refines the shift entity's validation rules. The main focus is to allow staff member assignments to be updated even after a shift has started, while still preventing changes to other immutable fields. The error handling for shift updates is also improved.

**Shift update validation and logic changes:**

* Removed staff member IDs from the list of immutable fields in `Shift.validateImmutableChanges`, so staff assignments can now be changed after a shift starts. (`src/domain/shift/entities/shift.entity.ts`, [[1]](diffhunk://#diff-d6702b27630bd6193c118cb68312d77e6837d8826bcd653da6ff2e2b5ccefe74L210-R210) [[2]](diffhunk://#diff-d6702b27630bd6193c118cb68312d77e6837d8826bcd653da6ff2e2b5ccefe74L299-L306)
* Updated the error message in `validateImmutableChanges` to clarify that staff member assignments, in addition to end date, start/end hour, and notes, can be edited after a shift has started. (`src/domain/shift/entities/shift.entity.ts`, [src/domain/shift/entities/shift.entity.tsL322-R314](diffhunk://#diff-d6702b27630bd6193c118cb68312d77e6837d8826bcd653da6ff2e2b5ccefe74L322-R314))
* Changed the update logic in `applyUpdates` so that `staffMemberIds` can always be updated, regardless of whether the shift has started, while other fields remain restricted. (`src/domain/shift/entities/shift.entity.ts`, [src/domain/shift/entities/shift.entity.tsL345-R338](diffhunk://#diff-d6702b27630bd6193c118cb68312d77e6837d8826bcd653da6ff2e2b5ccefe74L345-R338))

**Error handling improvements:**

* Wrapped the shift update call in a try/catch block in the command handler and rethrows any errors as `BadRequestException` for better error reporting. (`src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.ts`, [src/application/shift/commands/assign-staff-to-shift/assign-staff-to-shift.handler.tsR93-R106](diffhunk://#diff-86633a43c36c165339fed2aea873252e6c92e37af374c2021e8547aabbfaac1aR93-R106))