### PR TITLE
LYMON-1056 refactor(experience): remove scope references from experie…

### DIFF
--- a/src/application/experience/commands/create-experience.command.ts
+++ b/src/application/experience/commands/create-experience.command.ts
@@ -1,6 +1,5 @@
 import { ExperienceAvailabilityTypeEnum } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategoryEnum } from '@/domain/experience/value-objects/experience-category.vo';
-import { ExperienceScopeEnum } from '@/domain/experience/value-objects/experience-scope.vo';
 
 export interface CreateExperienceLocationInput {
   label: string;
@@ -23,7 +22,6 @@ export interface CreateExperienceRecurrenceInput {
 export class CreateExperienceCommand {
   constructor(
     public readonly tenantId: string,
-    public readonly scope: ExperienceScopeEnum,
     public readonly propertyId: string | undefined,
     public readonly unitIds: string[] | undefined,
     public readonly name: string,

--- a/src/application/experience/commands/create-experience.handler.ts
+++ b/src/application/experience/commands/create-experience.handler.ts
@@ -7,7 +7,6 @@ import {
 } from '@/domain/experience/repositories/experience.repository';
 import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
-import { ExperienceScope } from '@/domain/experience/value-objects/experience-scope.vo';
 import {
   AuditAction,
   AuditEntityType,
@@ -52,14 +51,8 @@ export class CreateExperienceHandler implements ICommandHandler<CreateExperience
   async execute(
     command: CreateExperienceCommand,
   ): Promise<CreateExperienceResult> {
-    const { tenantId, scope, propertyId, unitIds, experience } =
+    const { tenantId, propertyId, unitIds, experience } =
       this.buildDomainObjects(command);
-
-    if (scope.isPropertyScope() && !propertyId) {
-      throw new BadRequestException(
-        'propertyId is required for PROPERTY scope',
-      );
-    }
 
     const property = propertyId
       ? await this.propertyRepository.findById(propertyId)
@@ -144,14 +137,12 @@ export class CreateExperienceHandler implements ICommandHandler<CreateExperience
 
   private buildDomainObjects(command: CreateExperienceCommand): {
     tenantId: TenantId;
-    scope: ExperienceScope;
     propertyId?: PropertyId;
     unitIds: UnitId[];
     experience: Experience;
   } {
     try {
       const tenantId = TenantId.createFromString(command.tenantId);
-      const scope = ExperienceScope.create(command.scope);
       const propertyId = command.propertyId
         ? PropertyId.create(command.propertyId)
         : undefined;
@@ -161,7 +152,6 @@ export class CreateExperienceHandler implements ICommandHandler<CreateExperience
 
       const experience = Experience.create({
         tenantId,
-        scope,
         propertyId,
         unitIds,
         name: command.name,
@@ -193,7 +183,6 @@ export class CreateExperienceHandler implements ICommandHandler<CreateExperience
 
       return {
         tenantId,
-        scope,
         propertyId,
         unitIds,
         experience,

--- a/src/application/experience/queries/shared/experience-read.dto.ts
+++ b/src/application/experience/queries/shared/experience-read.dto.ts
@@ -35,7 +35,6 @@ export class PublicExperienceDto {
   constructor(
     public readonly id: string,
     public readonly tenantId: string,
-    public readonly scope: string,
     public readonly propertyId: string | null,
     public readonly unitIds: string[],
     public readonly name: string,

--- a/src/application/experience/queries/shared/experience.mapper.ts
+++ b/src/application/experience/queries/shared/experience.mapper.ts
@@ -14,7 +14,6 @@ export function mapExperienceToPublicDto(
   return new PublicExperienceDto(
     experience.getId()!.toString(),
     experience.getTenantId().toString(),
-    experience.getScope().toString(),
     experience.getPropertyId()?.toString() ?? null,
     experience.getUnitIds().map((unitId) => unitId.toString()),
     experience.getName(),

--- a/src/domain/experience/entities/experience.entity.ts
+++ b/src/domain/experience/entities/experience.entity.ts
@@ -7,7 +7,6 @@ import {
 } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
-import { ExperienceScope } from '@/domain/experience/value-objects/experience-scope.vo';
 import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
 
 export interface ExperienceLocation {
@@ -30,7 +29,6 @@ export interface ExperienceRecurrence {
 
 export interface ExperienceProps {
   tenantId: TenantId;
-  scope: ExperienceScope;
   propertyId?: PropertyId;
   unitIds?: UnitId[];
   name: string;
@@ -54,7 +52,6 @@ export interface ExperienceReconstituteData {
   id: ExperienceId;
   tenantId: TenantId;
   mediaKeys?: string[];
-  scope: ExperienceScope;
   propertyId?: PropertyId;
   unitIds: UnitId[];
   name: string;
@@ -102,7 +99,6 @@ export class Experience {
   private constructor(
     private readonly id: ExperienceId | null,
     private readonly tenantId: TenantId,
-    private readonly scope: ExperienceScope,
     private readonly propertyId: PropertyId | null,
     private readonly unitIds: UnitId[],
     private name: string,
@@ -162,10 +158,6 @@ export class Experience {
       throw new Error('Experience must be purchasable in at least one mode');
     }
 
-    if (props.scope.isPropertyScope() && !props.propertyId) {
-      throw new Error('Property scoped experiences require propertyId');
-    }
-
     if (props.unitIds && props.unitIds.length > 0 && !props.propertyId) {
       throw new Error('unitIds require propertyId');
     }
@@ -183,7 +175,6 @@ export class Experience {
     return new Experience(
       null,
       props.tenantId,
-      props.scope,
       props.propertyId ?? null,
       props.unitIds ?? [],
       name,
@@ -220,7 +211,6 @@ export class Experience {
     return new Experience(
       data.id,
       data.tenantId,
-      data.scope,
       data.propertyId ?? null,
       data.unitIds,
       data.name,
@@ -254,10 +244,6 @@ export class Experience {
 
   getTenantId(): TenantId {
     return this.tenantId;
-  }
-
-  getScope(): ExperienceScope {
-    return this.scope;
   }
 
   getPropertyId(): PropertyId | null {

--- a/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
@@ -6,7 +6,6 @@ import {
 import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
-import { ExperienceScope } from '@/domain/experience/value-objects/experience-scope.vo';
 import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TransactionContextData } from '@/domain/shared/transaction-manager.interface';
@@ -38,7 +37,6 @@ export class MongoExperienceRepository implements ExperienceRepository {
       unitIds: experience
         .getUnitIds()
         .map((unitId) => new Types.ObjectId(unitId.toString())),
-      scope: experience.getScope().toString(),
       name: experience.getName(),
       description: experience.getDescription(),
       category: experience.getCategory().toString(),
@@ -197,7 +195,6 @@ export class MongoExperienceRepository implements ExperienceRepository {
     return Experience.reconstitute({
       id: ExperienceId.create(document._id.toString()),
       tenantId: TenantId.createFromString(document.tenantId.toString()),
-      scope: ExperienceScope.create(document.scope),
       propertyId: document.propertyId
         ? PropertyId.create(document.propertyId.toString())
         : undefined,

--- a/src/infrastructure/persistence/schemas/experience.schema.ts
+++ b/src/infrastructure/persistence/schemas/experience.schema.ts
@@ -1,6 +1,5 @@
 import { ExperienceAvailabilityTypeEnum } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategoryEnum } from '@/domain/experience/value-objects/experience-category.vo';
-import { ExperienceScopeEnum } from '@/domain/experience/value-objects/experience-scope.vo';
 import { ExperienceStatusEnum } from '@/domain/experience/value-objects/experience-status.vo';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
@@ -61,9 +60,6 @@ export class ExperienceDocument extends Document {
 
   @Prop({ type: [{ type: Types.ObjectId, ref: 'UnitDocument' }], default: [] })
   unitIds: Types.ObjectId[];
-
-  @Prop({ required: true, enum: ExperienceScopeEnum })
-  scope: string;
 
   @Prop({ required: true })
   name: string;

--- a/src/presentation/controllers/experience.controller.ts
+++ b/src/presentation/controllers/experience.controller.ts
@@ -140,7 +140,6 @@ export class ExperienceController {
       propertyScopedDateRange: {
         summary: 'Property-scoped transportation experience',
         value: {
-          scope: 'PROPERTY',
           propertyId: '6650d0ef3f3d2d2d2d2d2d2d',
           unitIds: ['6650d0ef3f3d2d2d2d2d2d33'],
           name: 'Airport transfer',
@@ -170,9 +169,8 @@ export class ExperienceController {
         },
       },
       tenantRecurring: {
-        summary: 'Tenant-level recurring transportation service',
+        summary: 'Recurring transportation service',
         value: {
-          scope: 'TENANT',
           name: 'Daily shuttle service',
           description: 'Recurring daily transportation service',
           category: 'TRANSPORTATION',
@@ -201,8 +199,7 @@ export class ExperienceController {
   @ApiResponse({ status: 201, description: 'Experience created successfully' })
   @ApiResponse({
     status: 400,
-    description:
-      'Validation error. Example rule violation: TENANT scope cannot include unitIds.',
+    description: 'Validation error.',
     schema: {
       example: {
         statusCode: 400,
@@ -220,7 +217,6 @@ export class ExperienceController {
   ) {
     const command = new CreateExperienceCommand(
       user.tenantId,
-      dto.scope,
       dto.propertyId,
       dto.unitIds,
       dto.name,

--- a/src/presentation/controllers/guest-experience.controller.ts
+++ b/src/presentation/controllers/guest-experience.controller.ts
@@ -87,7 +87,6 @@ export class GuestExperienceController {
     return {
       id: experience.id,
       tenantId: experience.tenantId,
-      scope: experience.scope,
       propertyId: experience.propertyId,
       name: experience.name,
       description: experience.description,
@@ -127,7 +126,6 @@ export class GuestExperienceController {
 interface PublicExperienceCatalogDto {
   id: string;
   tenantId: string;
-  scope: string;
   propertyId: string | null;
   name: string;
   description: string;

--- a/src/presentation/dtos/experience/create-experience.dto.ts
+++ b/src/presentation/dtos/experience/create-experience.dto.ts
@@ -17,7 +17,6 @@ import {
 } from 'class-validator';
 import { ExperienceAvailabilityTypeEnum } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategoryEnum } from '@/domain/experience/value-objects/experience-category.vo';
-import { ExperienceScopeEnum } from '@/domain/experience/value-objects/experience-scope.vo';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 class ExperienceLocationDto {
@@ -98,27 +97,13 @@ class ExperienceBlackoutRangeDto {
 }
 
 export class CreateExperienceDto {
-  @ApiProperty({
-    enum: ExperienceScopeEnum,
-    example: ExperienceScopeEnum.PROPERTY,
-    description:
-      'Scope behavior: PROPERTY allows optional propertyId and optional unitIds filtering. TENANT is tenant-wide and must not include unitIds.',
-  })
-  @IsEnum(ExperienceScopeEnum)
-  scope!: ExperienceScopeEnum;
-
   @ApiPropertyOptional({ example: '6650d0ef3f3d2d2d2d2d2d2d' })
   @IsString()
   @IsOptional()
   propertyId?: string;
 
   @ApiPropertyOptional({
-    description: [
-      '**Rules for Scope:**',
-      '* **PROPERTY scope + empty unitIds:** All units in property.',
-      '* **PROPERTY scope + unitIds list:** Only listed units.',
-      '* **TENANT scope + unitIds:** Forbidden.',
-    ].join('\n'),
+    description: 'Optional list of unit IDs. Requires propertyId when provided.',
     type: [String],
     example: ['6650d0ef3f3d2d2d2d2d2d33'],
   })

--- a/test/application/cart/add-experience-to-cart.handler.spec.ts
+++ b/test/application/cart/add-experience-to-cart.handler.spec.ts
@@ -11,10 +11,6 @@ import {
   ExperienceStatusEnum,
 } from '@/domain/experience/value-objects/experience-status.vo';
 import {
-  ExperienceScope,
-  ExperienceScopeEnum,
-} from '@/domain/experience/value-objects/experience-scope.vo';
-import {
   ExperienceCategory,
   ExperienceCategoryEnum,
 } from '@/domain/experience/value-objects/experience-category.vo';
@@ -34,7 +30,6 @@ function makeArchivedExperience(): Experience {
   return Experience.reconstitute({
     id: ExperienceId.create(EXPERIENCE_ID),
     tenantId: TenantId.createFromString(TENANT_ID),
-    scope: ExperienceScope.create(ExperienceScopeEnum.PROPERTY),
     propertyId: null,
     unitIds: [],
     name: 'Test',

--- a/test/application/experience/create-experience.handler.spec.ts
+++ b/test/application/experience/create-experience.handler.spec.ts
@@ -11,7 +11,6 @@ import { PropertyRepository } from '@/domain/property/repositories/property.repo
 import { UnitRepository } from '@/domain/unit/repositories/unit.repository';
 import { ExperienceAvailabilityTypeEnum } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategoryEnum } from '@/domain/experience/value-objects/experience-category.vo';
-import { ExperienceScopeEnum } from '@/domain/experience/value-objects/experience-scope.vo';
 import { createExperienceRepositoryMock } from '@test/shared/mocks/repositories/experience-repository.mock';
 import { createPropertyRepositoryMock } from '@test/shared/mocks/repositories/property-repository.mock';
 import { createUnitRepositoryMock } from '@test/shared/mocks/repositories/unit-repository.mock';
@@ -28,7 +27,6 @@ function makeCommand(
 
   return new CreateExperienceCommand(
     overrides?.tenantId ?? '65f1a1a2b3c4d5e6f7a8b9c0',
-    overrides?.scope ?? ExperienceScopeEnum.PROPERTY,
     hasPropertyIdOverride ? overrides?.propertyId : '65f1a1a2b3c4d5e6f7a8b9c1',
     overrides?.unitIds,
     overrides?.name ?? 'Airport transfer',
@@ -95,7 +93,6 @@ describe('CreateExperienceHandler', () => {
 
   it('throws BadRequestException when unitIds are provided without propertyId', async () => {
     const command = makeCommand({
-      scope: ExperienceScopeEnum.TENANT,
       propertyId: undefined,
       unitIds: ['65f1a1a2b3c4d5e6f7a8b9c8'],
     });

--- a/test/application/experience/get-available-experience-by-id.spec.ts
+++ b/test/application/experience/get-available-experience-by-id.spec.ts
@@ -9,7 +9,6 @@ import type { UnitRepository } from '@/domain/unit/repositories/unit.repository'
 import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
-import { ExperienceScope } from '@/domain/experience/value-objects/experience-scope.vo';
 import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
@@ -24,7 +23,6 @@ function makeExperience(status: 'ACTIVE' | 'ARCHIVED' = 'ACTIVE') {
   return Experience.reconstitute({
     id: ExperienceId.create(EXPERIENCE_ID),
     tenantId: TenantId.createFromString('65f1a1a2b3c4d5e6f7a8b9c0'),
-    scope: ExperienceScope.create('PROPERTY'),
     propertyId: PropertyId.create('65f1a1a2b3c4d5e6f7a8b9c1'),
     unitIds: [UnitId.create('65f1a1a2b3c4d5e6f7a8b9c8')],
     name: 'Airport transfer',

--- a/test/application/experience/get-experiences-by-tenant.spec.ts
+++ b/test/application/experience/get-experiences-by-tenant.spec.ts
@@ -6,7 +6,6 @@ import type { ExperienceRepository } from '@/domain/experience/repositories/expe
 import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
-import { ExperienceScope } from '@/domain/experience/value-objects/experience-scope.vo';
 import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
@@ -31,7 +30,6 @@ function makeExperience(overrides?: Partial<{ id: string; tenantId: string }>) {
   return Experience.reconstitute({
     id: ExperienceId.create(overrides?.id ?? EXPERIENCE_ID),
     tenantId: TenantId.createFromString(overrides?.tenantId ?? TENANT_ID),
-    scope: ExperienceScope.create('PROPERTY'),
     propertyId: PropertyId.create('65f1a1a2b3c4d5e6f7a8b9c1'),
     unitIds: [UnitId.create('65f1a1a2b3c4d5e6f7a8b9c8')],
     name: 'Airport transfer',

--- a/test/application/experience/update-experience.handler.spec.ts
+++ b/test/application/experience/update-experience.handler.spec.ts
@@ -19,7 +19,6 @@ import {
 } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
-import { ExperienceScope } from '@/domain/experience/value-objects/experience-scope.vo';
 import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
@@ -43,7 +42,6 @@ function makeExperience(overrides?: {
   return Experience.reconstitute({
     id: ExperienceId.create(EXPERIENCE_ID),
     tenantId: TenantId.createFromString(overrides?.tenantId ?? TENANT_ID),
-    scope: ExperienceScope.create('PROPERTY'),
     propertyId: PropertyId.create('65f1a1a2b3c4d5e6f7a8b9c1'),
     unitIds: [UnitId.create('65f1a1a2b3c4d5e6f7a8b9c8')],
     name: 'Airport transfer',

--- a/test/presentation/controllers/guest-experience.controller.spec.ts
+++ b/test/presentation/controllers/guest-experience.controller.spec.ts
@@ -12,7 +12,6 @@ describe('GuestExperienceController', () => {
   const experience = {
     id: 'exp-1',
     tenantId: 'tenant-1',
-    scope: 'PROPERTY',
     propertyId: 'prop-1',
     unitIds: ['unit-1'],
     name: 'Kayak tour',

--- a/test/shared/fixtures/experience.fixture.ts
+++ b/test/shared/fixtures/experience.fixture.ts
@@ -1,10 +1,6 @@
 import { Experience } from '@/domain/experience/entities/experience.entity';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
 import {
-  ExperienceScope,
-  ExperienceScopeEnum,
-} from '@/domain/experience/value-objects/experience-scope.vo';
-import {
   ExperienceCategory,
   ExperienceCategoryEnum,
 } from '@/domain/experience/value-objects/experience-category.vo';
@@ -45,7 +41,6 @@ export function makeExperience(
   return Experience.reconstitute({
     id: ExperienceId.create(merged.id),
     tenantId: TenantId.createFromString(merged.tenantId),
-    scope: ExperienceScope.create(ExperienceScopeEnum.PROPERTY),
     propertyId: PropertyId.create(merged.propertyId),
     unitIds: [],
     name: merged.name,


### PR DESCRIPTION
This pull request removes the concept of "scope" (and all related types, fields, and validation) from the Experience domain model and API. The changes simplify the creation, persistence, and exposure of experiences by eliminating the `scope` field, instead relying on the presence of `propertyId` and `unitIds` to determine experience context. Validation and documentation are updated accordingly.

### Domain Model and Persistence Simplification

* Removed the `scope` property from `Experience` and all related value objects, interfaces, and methods in `experience.entity.ts`. [[1]](diffhunk://#diff-bb8b41b2503d278a4c3e4eafedae5051360a5b90a2152eabd44859467045d099L33) [[2]](diffhunk://#diff-bb8b41b2503d278a4c3e4eafedae5051360a5b90a2152eabd44859467045d099L57) [[3]](diffhunk://#diff-bb8b41b2503d278a4c3e4eafedae5051360a5b90a2152eabd44859467045d099L105) [[4]](diffhunk://#diff-bb8b41b2503d278a4c3e4eafedae5051360a5b90a2152eabd44859467045d099L165-L168) [[5]](diffhunk://#diff-bb8b41b2503d278a4c3e4eafedae5051360a5b90a2152eabd44859467045d099L186) [[6]](diffhunk://#diff-bb8b41b2503d278a4c3e4eafedae5051360a5b90a2152eabd44859467045d099L223) [[7]](diffhunk://#diff-bb8b41b2503d278a4c3e4eafedae5051360a5b90a2152eabd44859467045d099L259-L262)
* Removed `scope` from persistence layer: database schema (`experience.schema.ts`), repository save/load logic (`mongo-experience.repository.ts`), and all references to `ExperienceScope` and `ExperienceScopeEnum`. [[1]](diffhunk://#diff-a806fcad44101358ada412fed5ce4b4d0afd5197516a76d959d8bed2a205e2a2L65-L67) [[2]](diffhunk://#diff-da46ad7b16f261d06bc712bbebadc382e875a165d666d6831ec74a19b8391882L41) [[3]](diffhunk://#diff-da46ad7b16f261d06bc712bbebadc382e875a165d666d6831ec74a19b8391882L200)

### Application and API Changes

* Removed `scope` from the `CreateExperienceCommand`, DTOs, and all controller endpoints. Updated validation and documentation to reflect the new approach, relying on `propertyId` and `unitIds` only. [[1]](diffhunk://#diff-43d6dbee3571db4993441960fd8cd2022c472c029a638fb8054af9b32b8a467dL26) [[2]](diffhunk://#diff-3bcb6202647b0a790c274d2cdb82c296defb204d093cd411a57765005a5e07bdL101-R106) [[3]](diffhunk://#diff-276256878cabeac42468106bda5a3f140e896ba2ea461c5a639665d0e5ec2e03L223) [[4]](diffhunk://#diff-276256878cabeac42468106bda5a3f140e896ba2ea461c5a639665d0e5ec2e03L143) [[5]](diffhunk://#diff-276256878cabeac42468106bda5a3f140e896ba2ea461c5a639665d0e5ec2e03L173-L175) [[6]](diffhunk://#diff-276256878cabeac42468106bda5a3f140e896ba2ea461c5a639665d0e5ec2e03L204-R202)
* Updated query DTOs and mappers to remove the `scope` field from public representations of experiences. [[1]](diffhunk://#diff-8c51019519cf08f71bdc123644d040c081389f651bee40f83a185a52023c7692L38) [[2]](diffhunk://#diff-6dbaa8e7e60fd62c45de18e6aef0108098e09d8439dd50de4671fa40c3edb1cfL17) [[3]](diffhunk://#diff-b1ab48ca547fa81539f9b90b1fe314562f1b5456d89ebc679da79941b60711a3L90) [[4]](diffhunk://#diff-b1ab48ca547fa81539f9b90b1fe314562f1b5456d89ebc679da79941b60711a3L130)

### Test and Import Cleanup

* Removed all imports and usage of `ExperienceScope` and `ExperienceScopeEnum` from tests and supporting files. [[1]](diffhunk://#diff-51a52ef5511e1dd3349482fcf10ce818a4f054f36ccef6d744879d63c4a5de9cL13-L16) [[2]](diffhunk://#diff-51a52ef5511e1dd3349482fcf10ce818a4f054f36ccef6d744879d63c4a5de9cL37) [[3]](diffhunk://#diff-0fe4931d7c3ac78cce71ce64f52366f84b8a5b1e5406df8c0731a68d9834e205L14)
* Cleaned up related imports from all affected files. [[1]](diffhunk://#diff-43d6dbee3571db4993441960fd8cd2022c472c029a638fb8054af9b32b8a467dL3) [[2]](diffhunk://#diff-a94343a81e1e6b3f88f365f63f70c30be2ac16cd3fd7e4726a8b8e93ebc69a93L10) [[3]](diffhunk://#diff-bb8b41b2503d278a4c3e4eafedae5051360a5b90a2152eabd44859467045d099L10) [[4]](diffhunk://#diff-da46ad7b16f261d06bc712bbebadc382e875a165d666d6831ec74a19b8391882L9) [[5]](diffhunk://#diff-a806fcad44101358ada412fed5ce4b4d0afd5197516a76d959d8bed2a205e2a2L3) [[6]](diffhunk://#diff-3bcb6202647b0a790c274d2cdb82c296defb204d093cd411a57765005a5e07bdL20)

These changes streamline the experience creation process and reduce complexity by removing an unnecessary abstraction.