### PR TITLE
LYMON-1035 feat(storage): enforce image type and 5MB size limit on pr…

### DIFF
--- a/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query-handler.ts
+++ b/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query-handler.ts
@@ -37,6 +37,7 @@ export class GenerateGuestProfilePhotoUrlQueryHandler
     const presignedUrl = await this.storageService.generatePresignedPutUrl(
       key,
       query.contentType,
+      query.fileSize,
     );
     const fileUrl = this.storageService.getPublicUrl(key);
 

--- a/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query.ts
+++ b/src/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query.ts
@@ -2,5 +2,6 @@ export class GenerateGuestProfilePhotoUrlQuery {
   constructor(
     public readonly guestAccountId: string,
     public readonly contentType: string,
+    public readonly fileSize: number,
   ) {}
 }

--- a/src/application/storage/image-upload.constants.ts
+++ b/src/application/storage/image-upload.constants.ts
@@ -1,0 +1,7 @@
+export const ALLOWED_IMAGE_CONTENT_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+] as const;
+
+export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB

--- a/src/application/storage/queries/generate-presigned-url/generate-presigned-url.query-handler.ts
+++ b/src/application/storage/queries/generate-presigned-url/generate-presigned-url.query-handler.ts
@@ -26,6 +26,7 @@ export class GeneratePresignedUrlQueryHandler implements IQueryHandler<
     const presignedUrl = await this.storageService.generatePresignedPutUrl(
       key,
       query.contentType,
+      query.fileSize,
     );
     const fileUrl = this.storageService.getPublicUrl(key);
 

--- a/src/application/storage/queries/generate-presigned-url/generate-presigned-url.query.ts
+++ b/src/application/storage/queries/generate-presigned-url/generate-presigned-url.query.ts
@@ -4,6 +4,7 @@ export class GeneratePresignedUrlQuery {
   constructor(
     public readonly fileName: string,
     public readonly contentType: string,
+    public readonly fileSize: number,
     public readonly tenantId: string,
     public readonly category: MediaCategory,
   ) {}

--- a/src/infrastructure/storage/r2-storage.service.ts
+++ b/src/infrastructure/storage/r2-storage.service.ts
@@ -36,12 +36,15 @@ export class R2StorageService {
   async generatePresignedPutUrl(
     key: string,
     contentType: string,
+    contentLength?: number,
     expiresInSeconds = 300,
   ): Promise<string> {
     const command = new PutObjectCommand({
       Bucket: this.bucket,
       Key: key,
       ContentType: contentType,
+      // Signed Content-Length: R2 rejects any PUT whose body size differs, at the edge.
+      ...(contentLength != null ? { ContentLength: contentLength } : {}),
     });
 
     return getSignedUrl(this.client, command, { expiresIn: expiresInSeconds });

--- a/src/presentation/controllers/guest.controller.ts
+++ b/src/presentation/controllers/guest.controller.ts
@@ -180,6 +180,7 @@ export class GuestController {
       new GenerateGuestProfilePhotoUrlQuery(
         guest.guestAccountId,
         dto.contentType,
+        dto.fileSize,
       ),
     );
 

--- a/src/presentation/controllers/storage.controller.ts
+++ b/src/presentation/controllers/storage.controller.ts
@@ -37,6 +37,7 @@ export class StorageController {
       new GeneratePresignedUrlQuery(
         dto.fileName,
         dto.contentType,
+        dto.fileSize,
         user.tenantId,
         dto.category,
       ),

--- a/src/presentation/dtos/generate-presigned-url.dto.ts
+++ b/src/presentation/dtos/generate-presigned-url.dto.ts
@@ -1,6 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsIn, IsString, MaxLength } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsEnum, IsIn, IsInt, IsString, Max, MaxLength, Min } from 'class-validator';
 import { MediaCategory } from '@/application/storage/media-category.enum';
+import {
+  ALLOWED_IMAGE_CONTENT_TYPES,
+  MAX_IMAGE_SIZE_BYTES,
+} from '@/application/storage/image-upload.constants';
 
 export class GeneratePresignedUrlDto {
   @ApiProperty({ example: 'photo.jpg' })
@@ -8,16 +13,20 @@ export class GeneratePresignedUrlDto {
   @MaxLength(255)
   fileName: string;
 
-  @ApiProperty({ example: 'image/jpeg' })
+  @ApiProperty({
+    example: 'image/jpeg',
+    enum: ALLOWED_IMAGE_CONTENT_TYPES,
+  })
   @IsString()
-  @IsIn([
-    'image/jpeg',
-    'image/png',
-    'image/webp',
-    'image/gif',
-    'application/pdf',
-  ])
+  @IsIn(ALLOWED_IMAGE_CONTENT_TYPES)
   contentType: string;
+
+  @ApiProperty({ example: 102400, description: 'File size in bytes' })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(MAX_IMAGE_SIZE_BYTES, { message: 'File exceeds the 5 MB maximum' })
+  fileSize: number;
 
   @ApiProperty({ enum: MediaCategory, example: MediaCategory.Experiences })
   @IsEnum(MediaCategory)

--- a/src/presentation/dtos/guest/guest-profile-photo-url.dto.ts
+++ b/src/presentation/dtos/guest/guest-profile-photo-url.dto.ts
@@ -1,12 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsIn, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsString, Max, Min } from 'class-validator';
+import {
+  ALLOWED_IMAGE_CONTENT_TYPES,
+  MAX_IMAGE_SIZE_BYTES,
+} from '@/application/storage/image-upload.constants';
 
 export class GuestProfilePhotoUrlDto {
   @ApiProperty({
     example: 'image/jpeg',
-    enum: ['image/jpeg', 'image/png', 'image/webp'],
+    enum: ALLOWED_IMAGE_CONTENT_TYPES,
   })
   @IsString()
-  @IsIn(['image/jpeg', 'image/png', 'image/webp'])
+  @IsIn(ALLOWED_IMAGE_CONTENT_TYPES)
   contentType: string;
+
+  @ApiProperty({ example: 102400, description: 'File size in bytes' })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(MAX_IMAGE_SIZE_BYTES, { message: 'File exceeds the 5 MB maximum' })
+  fileSize: number;
 }

--- a/test/application/guest-auth/generate-guest-profile-photo-url.query-handler.spec.ts
+++ b/test/application/guest-auth/generate-guest-profile-photo-url.query-handler.spec.ts
@@ -26,7 +26,7 @@ describe('GenerateGuestProfilePhotoUrlQueryHandler', () => {
 
   it('builds a key under the guest profile prefix with the right extension', async () => {
     const result = await handler.execute(
-      new GenerateGuestProfilePhotoUrlQuery(ACCOUNT_ID, 'image/webp'),
+      new GenerateGuestProfilePhotoUrlQuery(ACCOUNT_ID, 'image/webp', 102400),
     );
 
     expect(result).toBeInstanceOf(GenerateGuestProfilePhotoUrlResult);
@@ -36,6 +36,7 @@ describe('GenerateGuestProfilePhotoUrlQueryHandler', () => {
     expect(storageService.generatePresignedPutUrl).toHaveBeenCalledWith(
       result.key,
       'image/webp',
+      102400,
     );
     expect(result.fileUrl).toBe(`${PUBLIC_BASE}/${result.key}`);
     expect(result.presignedUrl).toBe('https://r2/put');
@@ -44,7 +45,11 @@ describe('GenerateGuestProfilePhotoUrlQueryHandler', () => {
   it('rejects an unsupported content type', async () => {
     await expect(
       handler.execute(
-        new GenerateGuestProfilePhotoUrlQuery(ACCOUNT_ID, 'application/pdf'),
+        new GenerateGuestProfilePhotoUrlQuery(
+          ACCOUNT_ID,
+          'application/pdf',
+          102400,
+        ),
       ),
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(storageService.generatePresignedPutUrl).not.toHaveBeenCalled();

--- a/test/application/storage/generate-presigned-url.query-handler.spec.ts
+++ b/test/application/storage/generate-presigned-url.query-handler.spec.ts
@@ -5,6 +5,7 @@ import { createR2StorageServiceMock } from '@test/shared/mocks/services/r2-stora
 import { MediaCategory } from '@/application/storage/media-category.enum';
 
 const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c0';
+const FILE_SIZE = 102400;
 const PRESIGNED_URL =
   'https://bucket.account.r2.cloudflarestorage.com/key?X-Amz-Signature=abc';
 const PUBLIC_URL = 'https://pub-xxx.r2.dev';
@@ -29,6 +30,7 @@ describe('GeneratePresignedUrlQueryHandler', () => {
         new GeneratePresignedUrlQuery(
           'photo.jpg',
           'image/jpeg',
+          FILE_SIZE,
           TENANT_ID,
           MediaCategory.Experiences,
         ),
@@ -49,6 +51,7 @@ describe('GeneratePresignedUrlQueryHandler', () => {
         new GeneratePresignedUrlQuery(
           'photo.jpg',
           'image/jpeg',
+          FILE_SIZE,
           TENANT_ID,
           MediaCategory.Experiences,
         ),
@@ -65,6 +68,7 @@ describe('GeneratePresignedUrlQueryHandler', () => {
         new GeneratePresignedUrlQuery(
           'photo.jpg',
           'image/jpeg',
+          FILE_SIZE,
           TENANT_ID,
           MediaCategory.Properties,
         ),
@@ -83,6 +87,7 @@ describe('GeneratePresignedUrlQueryHandler', () => {
         new GeneratePresignedUrlQuery(
           'my photo (1).jpg',
           'image/jpeg',
+          FILE_SIZE,
           TENANT_ID,
           MediaCategory.Units,
         ),
@@ -101,6 +106,7 @@ describe('GeneratePresignedUrlQueryHandler', () => {
         new GeneratePresignedUrlQuery(
           'photo.jpg',
           'image/png',
+          FILE_SIZE,
           TENANT_ID,
           MediaCategory.Experiences,
         ),
@@ -109,6 +115,7 @@ describe('GeneratePresignedUrlQueryHandler', () => {
       expect(storageService.generatePresignedPutUrl).toHaveBeenCalledWith(
         expect.stringContaining(TENANT_ID),
         'image/png',
+        FILE_SIZE,
       );
     });
 
@@ -120,6 +127,7 @@ describe('GeneratePresignedUrlQueryHandler', () => {
         new GeneratePresignedUrlQuery(
           'photo.jpg',
           'image/jpeg',
+          FILE_SIZE,
           TENANT_ID,
           MediaCategory.Experiences,
         ),

--- a/test/presentation/dtos/generate-presigned-url.dto.spec.ts
+++ b/test/presentation/dtos/generate-presigned-url.dto.spec.ts
@@ -1,0 +1,37 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { GeneratePresignedUrlDto } from '@/presentation/dtos/generate-presigned-url.dto';
+import { MediaCategory } from '@/application/storage/media-category.enum';
+import { MAX_IMAGE_SIZE_BYTES } from '@/application/storage/image-upload.constants';
+
+const base = {
+  fileName: 'photo.jpg',
+  contentType: 'image/jpeg',
+  fileSize: 102400,
+  category: MediaCategory.Experiences,
+};
+
+const errorsFor = (overrides: Partial<typeof base>) =>
+  validateSync(plainToInstance(GeneratePresignedUrlDto, { ...base, ...overrides }));
+
+describe('GeneratePresignedUrlDto', () => {
+  it('accepts a valid image upload', () => {
+    expect(errorsFor({})).toHaveLength(0);
+  });
+
+  it('coerces a numeric-string fileSize', () => {
+    expect(errorsFor({ fileSize: '102400' as unknown as number })).toHaveLength(
+      0,
+    );
+  });
+
+  it('rejects a file over the size limit', () => {
+    const errors = errorsFor({ fileSize: MAX_IMAGE_SIZE_BYTES + 1 });
+    expect(errors.some((e) => e.property === 'fileSize')).toBe(true);
+  });
+
+  it('rejects a non-image content type', () => {
+    const errors = errorsFor({ contentType: 'application/pdf' });
+    expect(errors.some((e) => e.property === 'contentType')).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds backend validation so only proper images can be uploaded via the
presigned-URL flow, capped at a reasonable size.

- **Type:** presigned-URL endpoints now accept only `image/jpeg`, `image/png`,
  `image/webp` (the general `/storage/presigned-url` endpoint previously also
  allowed gif/pdf). Content type was already baked into the signed
  `PutObjectCommand`, so R2 rejects mismatches.
- **Size:** requests must include `fileSize` (bytes), capped at **5 MB**. The
  size is signed into the presigned PUT via `ContentLength`, so R2 rejects an
  oversized upload **at the edge** — the client can't bypass it by lying.
- **Clear errors:** invalid type / oversized file return a 400 with a readable
  message (`"File exceeds the 5 MB maximum"`) via the existing global
  `ValidationPipe`, so the frontend can surface it.

## How

- New shared constants `ALLOWED_IMAGE_CONTENT_TYPES` / `MAX_IMAGE_SIZE_BYTES`.
- `fileSize` added to `GeneratePresignedUrlDto` and `GuestProfilePhotoUrlDto`
  (`@IsInt`, `@Min(1)`, `@Max(5MB)`, `@Type(() => Number)` so a stringified
  value still coerces).
- `fileSize` threaded through the queries/handlers into
  `R2StorageService.generatePresignedPutUrl`, which now signs `ContentLength`.