### PR TITLE
LYMON-1059 feat(tutorial): add tutorial completion functionality and …

### DIFF
--- a/src/application/application.module.ts
+++ b/src/application/application.module.ts
@@ -43,6 +43,7 @@ import { CartApplicationModule } from '@/application/cart/cart-application.modul
 import { RefundApplicationModule } from '@/application/refund/refund-application.module';
 import { ProcessWompiWebhookHandler } from '@/application/payment/commands/process-wompi-webhook/process-wompi-webhook.handler';
 import { GetPaymentSessionStatusHandler } from '@/application/payment/queries/get-payment-session-status/get-payment-session-status.handler';
+import { CompleteTutorialHandler } from '@/application/user/commands/complete-tutorial/complete-tutorial.handler';
 import { RoleAssignmentValidator } from '@/application/user/services/role-assignment-validator.service';
 
 const CommandHandlers = [
@@ -59,6 +60,7 @@ const CommandHandlers = [
   AddRolesHandler,
   RemoveAllRolesHandler,
   RemoveRoleHandler,
+  CompleteTutorialHandler,
   DeleteShiftCommandHandler,
   ProcessWompiWebhookHandler,
   GetPaymentSessionStatusHandler,

--- a/src/application/auth/commands/login.handler.ts
+++ b/src/application/auth/commands/login.handler.ts
@@ -44,6 +44,7 @@ export class LoginResult {
     public readonly emailVerified: boolean,
     public readonly accessToken: string,
     public readonly refreshToken: string,
+    public readonly tutorialCompleted: boolean,
   ) {}
 }
 
@@ -134,6 +135,7 @@ export class LoginHandler implements ICommandHandler<LoginCommand> {
       user.isEmailVerified(),
       accessToken,
       refreshToken,
+      user.getTutorialCompleted(),
     );
   }
 }

--- a/src/application/user/commands/complete-tutorial/complete-tutorial.command.ts
+++ b/src/application/user/commands/complete-tutorial/complete-tutorial.command.ts
@@ -1,0 +1,3 @@
+export class CompleteTutorialCommand {
+  constructor(public readonly userId: string) {}
+}

--- a/src/application/user/commands/complete-tutorial/complete-tutorial.handler.ts
+++ b/src/application/user/commands/complete-tutorial/complete-tutorial.handler.ts
@@ -1,0 +1,31 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { CompleteTutorialCommand } from '@/application/user/commands/complete-tutorial/complete-tutorial.command';
+import { Inject, NotFoundException } from '@nestjs/common';
+import {
+  type UserRepository,
+  USER_REPOSITORY,
+} from '@/domain/user/repositories/user.repository';
+import { UserId } from '@/domain/user/entities/user.entity';
+
+@CommandHandler(CompleteTutorialCommand)
+export class CompleteTutorialHandler
+  implements ICommandHandler<CompleteTutorialCommand>
+{
+  constructor(
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  async execute(command: CompleteTutorialCommand): Promise<void> {
+    const user = await this.userRepository.findById(
+      UserId.createFromString(command.userId),
+    );
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    user.completeTutorial();
+    await this.userRepository.save(user);
+  }
+}

--- a/src/domain/user/entities/user.entity.ts
+++ b/src/domain/user/entities/user.entity.ts
@@ -31,6 +31,7 @@ export interface UserReconstitutionData {
   deletedAt?: Date | null;
   readonly fullName?: string;
   readonly document?: string;
+  readonly tutorialCompleted?: boolean;
 }
 
 /** Kept for OWNER identity checks only. Staff roles are managed via RoleAssignment. */
@@ -79,6 +80,7 @@ export class User {
     private deletedAt: Date | null = null,
     private fullName?: string,
     private document?: string,
+    private tutorialCompleted: boolean = false,
   ) {}
 
   static createOwner(
@@ -147,6 +149,7 @@ export class User {
       data.deletedAt,
       data.fullName,
       data.document,
+      data.tutorialCompleted ?? false,
     );
   }
 
@@ -200,6 +203,15 @@ export class User {
 
   updateDocument(document?: string): void {
     this.document = document;
+    this.updatedAt = new Date();
+  }
+
+  getTutorialCompleted(): boolean {
+    return this.tutorialCompleted;
+  }
+
+  completeTutorial(): void {
+    this.tutorialCompleted = true;
     this.updatedAt = new Date();
   }
 

--- a/src/infrastructure/persistence/repositories/mongo-user.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-user.repository.ts
@@ -61,6 +61,7 @@ export class MongoUserRepository implements UserRepository, OnModuleInit {
       { key: 'passwordChangedAt', value: user.getPasswordChangedAt() },
       { key: 'fullName', value: user.getFullName() },
       { key: 'document', value: user.getDocument() },
+      { key: 'tutorialCompleted', value: user.getTutorialCompleted() },
     ] as const;
 
     for (const field of optionalFields) {
@@ -166,6 +167,7 @@ export class MongoUserRepository implements UserRepository, OnModuleInit {
       deletedAt: doc.deletedAt,
       fullName: doc.fullName,
       document: doc.document,
+      tutorialCompleted: doc.tutorialCompleted ?? false,
     });
   }
 }

--- a/src/infrastructure/persistence/schemas/user.schema.ts
+++ b/src/infrastructure/persistence/schemas/user.schema.ts
@@ -49,6 +49,9 @@ export class UserDocument extends Document {
 
   @Prop()
   document?: string;
+
+  @Prop({ default: false })
+  tutorialCompleted: boolean;
 }
 
 export const UserSchema = SchemaFactory.createForClass(UserDocument);

--- a/src/presentation/controllers/auth.controller.ts
+++ b/src/presentation/controllers/auth.controller.ts
@@ -87,6 +87,7 @@ export class AuthController {
         emailVerified: result.emailVerified,
         accessToken: result.accessToken,
         refreshToken: result.refreshToken,
+        tutorialCompleted: result.tutorialCompleted,
       },
     };
   }

--- a/src/presentation/controllers/user.controller.ts
+++ b/src/presentation/controllers/user.controller.ts
@@ -27,6 +27,7 @@ import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decor
 import { type JwtPayload } from '@/application/auth/services/jwt.service';
 import { ChangePasswordCommand } from '@/application/user/commands/change-password/change-password.command';
 import { ChangePasswordResult } from '@/application/user/commands/change-password/change-password.handler';
+import { CompleteTutorialCommand } from '@/application/user/commands/complete-tutorial/complete-tutorial.command';
 import { ChangePasswordDto } from '@/presentation/dtos/auth/change-password.dto';
 import { InviteStaffDto } from '@/presentation/dtos/tenant/invite-staff.dto';
 import { InviteStaffCommand } from '@/application/user/commands/invite-staff/invite-staff.command';
@@ -79,6 +80,24 @@ export class UserController {
 
     return {
       message: result.message,
+    };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('complete-tutorial')
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Mark tutorial as completed for current user' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Tutorial marked as completed',
+  })
+  async completeTutorial(@CurrentUser() jwtPayload: JwtPayload) {
+    await this.commandBus.execute(
+      new CompleteTutorialCommand(jwtPayload.userId),
+    );
+
+    return {
+      message: 'Tutorial completed successfully',
     };
   }
 

--- a/test/application/auth/login.handler.spec.ts
+++ b/test/application/auth/login.handler.spec.ts
@@ -69,6 +69,7 @@ describe('LoginHandler', () => {
       expect(result.emailVerified).toBe(true);
       expect(result.accessToken).toBe('access-token');
       expect(result.refreshToken).toBe('refresh-token');
+      expect(result.tutorialCompleted).toBe(false);
     });
   });
 


### PR DESCRIPTION
This pull request introduces a new feature that allows tracking and updating whether a user has completed the tutorial. It adds a new command and handler for marking the tutorial as completed, updates the user entity and persistence layers to store this information, and exposes the status in authentication results and via a new endpoint.

**Tutorial Completion Feature**

* Added `tutorialCompleted` property to the `User` entity, including getter and setter methods, and updated entity reconstitution logic to handle this field. [[1]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR34) [[2]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR83) [[3]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR152) [[4]](diffhunk://#diff-eacbea1a6a34dc1ccbacfadf41f0c2e12b00587acc23d0c52f5533bac51248bcR209-R217)
* Updated the MongoDB user schema, repository, and reconstitution to persist and retrieve the `tutorialCompleted` status. [[1]](diffhunk://#diff-e195548b2cb2f55b25ffb3ca8a40022dd733df9e83bc531ff21e3e51ba3b030dR52-R54) [[2]](diffhunk://#diff-2f09f54a7de95399179b03b0961a21e91e1c66ceb51f86b33f862864a0898186R64) [[3]](diffhunk://#diff-2f09f54a7de95399179b03b0961a21e91e1c66ceb51f86b33f862864a0898186R170)

**New Command and Handler**

* Introduced `CompleteTutorialCommand` and `CompleteTutorialHandler` to encapsulate the logic for marking the tutorial as completed for a user. Registered the handler in the application module. [[1]](diffhunk://#diff-c78514a8b7021387026080619ad41fec95fb17aba32a9528ccc76dca17f33755R1-R3) [[2]](diffhunk://#diff-cfaa0c5bda4eb3eb00deba2a1b6d0cfa2cb10e8602794bdbf7360113816bcfb2R1-R31) [[3]](diffhunk://#diff-1071142531f939978fbe46e8dfd04b13a41e33ff5b75bc85b407bfc1982dc053R46) [[4]](diffhunk://#diff-1071142531f939978fbe46e8dfd04b13a41e33ff5b75bc85b407bfc1982dc053R63)

**API and Auth Integration**

* Added a new endpoint (`PATCH /users/complete-tutorial`) in `UserController` to allow the current user to mark the tutorial as completed. [[1]](diffhunk://#diff-6db978913882dad9b948903f0e33cf417c214694aa561bb43ff3f292ba057ed5R30) [[2]](diffhunk://#diff-6db978913882dad9b948903f0e33cf417c214694aa561bb43ff3f292ba057ed5R86-R103)
* Updated the authentication flow to include `tutorialCompleted` in the login result and response, and updated the login handler and tests accordingly. [[1]](diffhunk://#diff-b1ef8bad9bc194222faa048113212d53691722706d3216f5558b14a8970cc70cR47) [[2]](diffhunk://#diff-b1ef8bad9bc194222faa048113212d53691722706d3216f5558b14a8970cc70cR138) [[3]](diffhunk://#diff-e889aca2d42ee29723cc0d871706050087b8ac56ee3be56f65f1bab0a01bc13fR90) [[4]](diffhunk://#diff-435f3a2ae29dc52c4e167bf6caba7f654861dfbe7b76ee9d00db09584e79c05aR72)