### PR TITLE
LYMON-1046 Add minimum participants condition to experiences in addit…

### DIFF
--- a/README-SETUP.md
+++ b/README-SETUP.md
@@ -3,6 +3,7 @@
 ## 🚀 Características Implementadas
 
 ### ✅ Sistema de Autenticación
+
 - **Registro de usuarios** (`POST /auth/register`)
 - **Login de usuarios** (`POST /auth/login`)
 - Autenticación mediante JWT (JSON Web Tokens)
@@ -10,6 +11,7 @@
 - Guards de protección para rutas privadas
 
 ### 🏨 Gestión de Hoteles
+
 - **Registro de hoteles** (`POST /hotels/register`) - Requiere autenticación
 - Campos del hotel:
   - Nombre del hotel
@@ -21,6 +23,7 @@
 - Relación automática con el usuario autenticado
 
 ### 🛏️ Gestión de Habitaciones
+
 - **Crear habitación** (`POST /rooms`) - Requiere autenticación
 - Campos de la habitación:
   - Número de habitación
@@ -51,7 +54,7 @@
    \`\`\`
 
 2. **Configurar variables de entorno:**
-   
+
    El archivo \`.env\` ya está configurado con:
    \`\`\`env
    MONGO_URI=yourMongoUrl
@@ -88,83 +91,87 @@ Aquí encontrarás la documentación interactiva completa con todos los endpoint
 ## 🔐 Flujo de Uso de la Aplicación
 
 ### 1. Registrar un Usuario
+
 \`\`\`http
 POST /auth/register
 Content-Type: application/json
 
 {
-  "email": "usuario@example.com",
-  "name": "Juan Pérez",
-  "password": "password123"
+"email": "usuario@example.com",
+"name": "Juan Pérez",
+"password": "password123"
 }
 \`\`\`
 
 **Respuesta:**
 \`\`\`json
 {
-  "user": {
-    "id": "user_...",
-    "email": "usuario@example.com",
-    "name": "Juan Pérez"
-  },
-  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+"user": {
+"id": "user\_...",
+"email": "usuario@example.com",
+"name": "Juan Pérez"
+},
+"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 }
 \`\`\`
 
 ### 2. Iniciar Sesión
+
 \`\`\`http
 POST /auth/login
 Content-Type: application/json
 
 {
-  "email": "usuario@example.com",
-  "password": "password123"
+"email": "usuario@example.com",
+"password": "password123"
 }
 \`\`\`
 
 **Respuesta:**
 \`\`\`json
 {
-  "user": {
-    "id": "user_...",
-    "email": "usuario@example.com",
-    "name": "Juan Pérez"
-  },
-  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+"user": {
+"id": "user\_...",
+"email": "usuario@example.com",
+"name": "Juan Pérez"
+},
+"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 }
 \`\`\`
 
 ### 3. Registrar un Hotel (con token JWT)
+
 \`\`\`http
 POST /hotels/register
 Authorization: Bearer YOUR_JWT_TOKEN
 Content-Type: application/json
 
 {
-  "name": "Hotel Paradise",
-  "subdomain": "paradise",
-  "location": "Calle Principal 123, Ciudad",
-  "image": "https://example.com/hotel.jpg",
-  "primaryColor": "#FF5733",
-  "description": "Un hotel de lujo con vistas al mar"
+"name": "Hotel Paradise",
+"subdomain": "paradise",
+"location": "Calle Principal 123, Ciudad",
+"image": "https://example.com/hotel.jpg",
+"primaryColor": "#FF5733",
+"description": "Un hotel de lujo con vistas al mar"
 }
 \`\`\`
 
 ### 4. Crear una Habitación (con token JWT)
+
 \`\`\`http
 POST /rooms
 Authorization: Bearer YOUR_JWT_TOKEN
 Content-Type: application/json
 
 {
-  "roomTypeId": "room-type-id-123",
-  "hotelId": "hotel-id-456",
-  "roomNumber": "101",
-  "name": "Suite Presidencial",
-  "floor": 1,
-  "image": "https://example.com/room.jpg",
-  "amenities": ["WiFi", "TV", "Aire acondicionado", "Minibar"],
-  "description": "Amplia suite con vista al mar"
+"roomTypeId": "room-type-id-123",
+"hotelId": "hotel-id-456",
+"roomNumber": "101",
+"name": "Suite Presidencial",
+"floor": 1,
+"image": "https://example.com/room.jpg",
+"amenities": ["WiFi", "TV", "Aire acondicionado", "Minibar"],
+"description": "Amplia suite con vista al mar"
 }
 \`\`\`
 
@@ -173,42 +180,42 @@ Content-Type: application/json
 \`\`\`
 src/
 ├── application/
-│   └── use-cases/              # Casos de uso (lógica de negocio)
-│       ├── auth.service.ts     # Registro y login
-│       ├── register-hotel.use-case.ts
-│       ├── create-room.use-case.ts
-│       └── ...
+│ └── use-cases/ # Casos de uso (lógica de negocio)
+│ ├── auth.service.ts # Registro y login
+│ ├── register-hotel.use-case.ts
+│ ├── create-room.use-case.ts
+│ └── ...
 ├── domain/
-│   ├── entities/               # Entidades del dominio
-│   │   ├── user.entity.ts
-│   │   ├── hotel.entity.ts
-│   │   └── room.entity.ts
-│   └── repositories/           # Interfaces de repositorios
-│       ├── user.repository.ts
-│       ├── hotel.repository.ts
-│       └── room.repository.ts
+│ ├── entities/ # Entidades del dominio
+│ │ ├── user.entity.ts
+│ │ ├── hotel.entity.ts
+│ │ └── room.entity.ts
+│ └── repositories/ # Interfaces de repositorios
+│ ├── user.repository.ts
+│ ├── hotel.repository.ts
+│ └── room.repository.ts
 ├── infrastructure/
-│   ├── auth/                   # Estrategias y guards de autenticación
-│   │   ├── jwt.strategy.ts
-│   │   └── jwt-auth.guard.ts
-│   ├── controllers/            # Controladores HTTP
-│   │   ├── auth/
-│   │   ├── hotel/
-│   │   └── rooms/
-│   ├── dtos/                   # Data Transfer Objects
-│   │   ├── register-user.dto.ts
-│   │   ├── login.dto.ts
-│   │   ├── register-hotel.dto.ts
-│   │   └── create-room.dto.ts
-│   ├── modules/                # Módulos de NestJS
-│   │   ├── auth/
-│   │   ├── hotels/
-│   │   └── rooms/
-│   └── persistence/
-│       └── mongoose/           # Implementación de repositorios con Mongoose
-│           ├── schemas/
-│           └── repositories/
-└── main.ts                     # Punto de entrada
+│ ├── auth/ # Estrategias y guards de autenticación
+│ │ ├── jwt.strategy.ts
+│ │ └── jwt-auth.guard.ts
+│ ├── controllers/ # Controladores HTTP
+│ │ ├── auth/
+│ │ ├── hotel/
+│ │ └── rooms/
+│ ├── dtos/ # Data Transfer Objects
+│ │ ├── register-user.dto.ts
+│ │ ├── login.dto.ts
+│ │ ├── register-hotel.dto.ts
+│ │ └── create-room.dto.ts
+│ ├── modules/ # Módulos de NestJS
+│ │ ├── auth/
+│ │ ├── hotels/
+│ │ └── rooms/
+│ └── persistence/
+│ └── mongoose/ # Implementación de repositorios con Mongoose
+│ ├── schemas/
+│ └── repositories/
+└── main.ts # Punto de entrada
 \`\`\`
 
 ## 🔑 Autenticación JWT
@@ -248,17 +255,20 @@ La aplicación crea automáticamente las siguientes colecciones:
 ## 🐛 Solución de Problemas
 
 ### Error de conexión a MongoDB
+
 \`\`\`
 ERROR [MongooseModule] Unable to connect to the database
 \`\`\`
 
 **Solución:**
+
 1. Ve a MongoDB Atlas (https://cloud.mongodb.com)
 2. Navega a: Network Access
 3. Agrega tu IP actual o usa "0.0.0.0/0" para permitir todas las IPs
 4. Espera 1-2 minutos y reinicia la aplicación
 
 ### Error de ejecución de scripts en PowerShell
+
 \`\`\`
 No se puede cargar el archivo ... porque la ejecución de scripts está deshabilitada
 \`\`\`
@@ -271,6 +281,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
 ## 📞 Contacto y Soporte
 
 Si tienes problemas o preguntas, revisa:
+
 1. La documentación de Swagger en `/api/docs`
 2. Los logs de la aplicación en la consola
 3. El estado de MongoDB Atlas

--- a/src/application/cart/commands/add-experience-to-cart/add-experience-to-cart.handler.ts
+++ b/src/application/cart/commands/add-experience-to-cart/add-experience-to-cart.handler.ts
@@ -50,6 +50,7 @@ export class AddExperienceToCartHandler implements ICommandHandler<AddExperience
         'This experience cannot be purchased standalone',
       );
     }
+    experience.validateParticipantQuantity(command.quantity);
 
     let cart = await this.cartRepository.findOpenByGuest(guestAccountId);
     cart ??= Cart.create({ guestAccountId });

--- a/src/application/experience/commands/create-experience.command.ts
+++ b/src/application/experience/commands/create-experience.command.ts
@@ -29,6 +29,7 @@ export class CreateExperienceCommand {
     public readonly category: ExperienceCategoryEnum,
     public readonly priceCop: number,
     public readonly durationHours: number,
+    public readonly minimumParticipants: number | undefined,
     public readonly capacity: number,
     public readonly coverImageUrl: string,
     public readonly location: CreateExperienceLocationInput,

--- a/src/application/experience/commands/create-experience.handler.ts
+++ b/src/application/experience/commands/create-experience.handler.ts
@@ -159,6 +159,7 @@ export class CreateExperienceHandler implements ICommandHandler<CreateExperience
         category: ExperienceCategory.create(command.category),
         priceCop: command.priceCop,
         durationHours: command.durationHours,
+        minimumParticipants: command.minimumParticipants,
         capacity: command.capacity,
         coverImageUrl: command.coverImageUrl,
         location: {

--- a/src/application/experience/queries/shared/experience-read.dto.ts
+++ b/src/application/experience/queries/shared/experience-read.dto.ts
@@ -42,6 +42,7 @@ export class PublicExperienceDto {
     public readonly category: string,
     public readonly priceCop: number,
     public readonly durationHours: number,
+    public readonly minimumParticipants: number,
     public readonly capacity: number,
     public readonly coverImageUrl: string,
     public readonly location: PublicExperienceLocationDto,

--- a/src/application/experience/queries/shared/experience.mapper.ts
+++ b/src/application/experience/queries/shared/experience.mapper.ts
@@ -21,6 +21,7 @@ export function mapExperienceToPublicDto(
     experience.getCategory().toString(),
     experience.getPriceCop(),
     experience.getDurationHours(),
+    experience.getMinimumParticipants(),
     experience.getCapacity(),
     experience.getCoverImageUrl(),
     new PublicExperienceLocationDto(

--- a/src/domain/experience/entities/experience.entity.ts
+++ b/src/domain/experience/entities/experience.entity.ts
@@ -8,6 +8,7 @@ import {
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
 import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
+import { DomainException } from '@/domain/shared/exceptions/domain.exception';
 
 export interface ExperienceLocation {
   label: string;
@@ -36,6 +37,7 @@ export interface ExperienceProps {
   category: ExperienceCategory;
   priceCop: number;
   durationHours: number;
+  minimumParticipants?: number;
   capacity: number;
   coverImageUrl: string;
   location: ExperienceLocation;
@@ -59,6 +61,7 @@ export interface ExperienceReconstituteData {
   category: ExperienceCategory;
   priceCop: number;
   durationHours: number;
+  minimumParticipants?: number;
   capacity: number;
   coverImageUrl: string;
   location: ExperienceLocation;
@@ -82,6 +85,7 @@ export interface ExperienceChanges {
   description?: string;
   priceCop?: number;
   durationHours?: number;
+  minimumParticipants?: number;
   capacity?: number;
   coverImageUrl?: string;
   location?: ExperienceLocation;
@@ -106,6 +110,7 @@ export class Experience {
     private readonly category: ExperienceCategory,
     private priceCop: number,
     private durationHours: number,
+    private minimumParticipants: number,
     private capacity: number,
     private coverImageUrl: string,
     private location: ExperienceLocation,
@@ -150,9 +155,8 @@ export class Experience {
       throw new Error('Experience duration must be greater than zero');
     }
 
-    if (!Number.isInteger(props.capacity) || props.capacity <= 0) {
-      throw new Error('Experience capacity must be a positive integer');
-    }
+    const minimumParticipants = props.minimumParticipants ?? 1;
+    Experience.validateParticipantLimits(minimumParticipants, props.capacity);
 
     if (!props.allowStandalonePurchase && !props.allowReservationPurchase) {
       throw new Error('Experience must be purchasable in at least one mode');
@@ -182,6 +186,7 @@ export class Experience {
       props.category,
       props.priceCop,
       props.durationHours,
+      minimumParticipants,
       props.capacity,
       props.coverImageUrl,
       {
@@ -218,6 +223,7 @@ export class Experience {
       data.category,
       data.priceCop,
       data.durationHours,
+      data.minimumParticipants ?? 1,
       data.capacity,
       data.coverImageUrl,
       data.location,
@@ -272,6 +278,10 @@ export class Experience {
 
   getDurationHours(): number {
     return this.durationHours;
+  }
+
+  getMinimumParticipants(): number {
+    return this.minimumParticipants;
   }
 
   getCapacity(): number {
@@ -367,10 +377,10 @@ export class Experience {
       throw new Error('Experience duration must be greater than zero');
     }
 
+    const minimumParticipants =
+      changes.minimumParticipants ?? this.minimumParticipants;
     const capacity = changes.capacity ?? this.capacity;
-    if (!Number.isInteger(capacity) || capacity <= 0) {
-      throw new Error('Experience capacity must be a positive integer');
-    }
+    Experience.validateParticipantLimits(minimumParticipants, capacity);
 
     const allowStandalonePurchase =
       changes.allowStandalonePurchase ?? this.allowStandalonePurchase;
@@ -404,6 +414,7 @@ export class Experience {
     this.description = description;
     this.priceCop = priceCop;
     this.durationHours = durationHours;
+    this.minimumParticipants = minimumParticipants;
     this.capacity = capacity;
     this.coverImageUrl = changes.coverImageUrl ?? this.coverImageUrl;
     this.location = {
@@ -428,6 +439,45 @@ export class Experience {
   softDelete(): void {
     this.deletedAt = new Date();
     this.updatedAt = new Date();
+  }
+
+  validateParticipantQuantity(quantity: number): void {
+    if (!Number.isInteger(quantity) || quantity <= 0) {
+      throw new DomainException('Participants must be a positive integer');
+    }
+
+    if (quantity < this.minimumParticipants) {
+      throw new DomainException(
+        `This experience requires at least ${this.minimumParticipants} participant${this.minimumParticipants === 1 ? '' : 's'}`,
+      );
+    }
+
+    if (quantity > this.capacity) {
+      throw new DomainException(
+        `This experience allows up to ${this.capacity} participant${this.capacity === 1 ? '' : 's'}`,
+      );
+    }
+  }
+
+  private static validateParticipantLimits(
+    minimumParticipants: number,
+    capacity: number,
+  ): void {
+    if (!Number.isInteger(minimumParticipants) || minimumParticipants <= 0) {
+      throw new Error(
+        'Experience minimum participants must be a positive integer',
+      );
+    }
+
+    if (!Number.isInteger(capacity) || capacity <= 0) {
+      throw new Error('Experience capacity must be a positive integer');
+    }
+
+    if (minimumParticipants > capacity) {
+      throw new Error(
+        'Experience minimum participants cannot exceed capacity',
+      );
+    }
   }
 
   private static validateLocation(location: ExperienceLocation): void {

--- a/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
@@ -42,6 +42,7 @@ export class MongoExperienceRepository implements ExperienceRepository {
       category: experience.getCategory().toString(),
       priceCop: experience.getPriceCop(),
       durationHours: experience.getDurationHours(),
+      minimumParticipants: experience.getMinimumParticipants(),
       capacity: experience.getCapacity(),
       coverImageUrl: experience.getCoverImageUrl(),
       location: experience.getLocation(),
@@ -206,6 +207,7 @@ export class MongoExperienceRepository implements ExperienceRepository {
       category: ExperienceCategory.create(document.category),
       priceCop: document.priceCop,
       durationHours: document.durationHours,
+      minimumParticipants: document.minimumParticipants ?? 1,
       capacity: document.capacity,
       coverImageUrl: document.coverImageUrl,
       location: {

--- a/src/infrastructure/persistence/schemas/counter.schema.ts
+++ b/src/infrastructure/persistence/schemas/counter.schema.ts
@@ -1,5 +1,9 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Schema as MongooseSchema } from 'mongoose';
+import {
+  Document,
+  Schema as MongooseSchema,
+  type Schema as MongooseSchemaType,
+} from 'mongoose';
 
 @Schema({ collection: 'counters', _id: false })
 export class CounterDocument extends Document<string> {
@@ -7,5 +11,6 @@ export class CounterDocument extends Document<string> {
   seq: number;
 }
 
-export const CounterSchema = SchemaFactory.createForClass(CounterDocument);
+export const CounterSchema: MongooseSchemaType<CounterDocument> =
+  SchemaFactory.createForClass(CounterDocument);
 CounterSchema.add({ _id: { type: MongooseSchema.Types.String } });

--- a/src/infrastructure/persistence/schemas/experience.schema.ts
+++ b/src/infrastructure/persistence/schemas/experience.schema.ts
@@ -76,6 +76,9 @@ export class ExperienceDocument extends Document {
   @Prop({ required: true })
   durationHours: number;
 
+  @Prop({ required: true, default: 1 })
+  minimumParticipants: number;
+
   @Prop({ required: true })
   capacity: number;
 

--- a/src/presentation/controllers/experience.controller.ts
+++ b/src/presentation/controllers/experience.controller.ts
@@ -147,6 +147,7 @@ export class ExperienceController {
           category: 'TRANSPORTATION',
           priceCop: 120000,
           durationHours: 2,
+          minimumParticipants: 2,
           capacity: 8,
           coverImageUrl: 'https://image.com/experience-cover.jpg',
           location: {
@@ -176,6 +177,7 @@ export class ExperienceController {
           category: 'TRANSPORTATION',
           priceCop: 80000,
           durationHours: 1,
+          minimumParticipants: 3,
           capacity: 12,
           coverImageUrl: 'https://image.com/tenant-shuttle.jpg',
           location: {
@@ -224,6 +226,7 @@ export class ExperienceController {
       dto.category,
       dto.priceCop,
       dto.durationHours,
+      dto.minimumParticipants,
       dto.capacity,
       dto.coverImageUrl,
       dto.location,
@@ -276,6 +279,7 @@ export class ExperienceController {
         description: dto.description,
         priceCop: dto.priceCop,
         durationHours: dto.durationHours,
+        minimumParticipants: dto.minimumParticipants,
         capacity: dto.capacity,
         coverImageUrl: dto.coverImageUrl,
         location: dto.location,

--- a/src/presentation/controllers/guest-experience.controller.ts
+++ b/src/presentation/controllers/guest-experience.controller.ts
@@ -93,6 +93,7 @@ export class GuestExperienceController {
       category: experience.category,
       priceCop: experience.priceCop,
       durationHours: experience.durationHours,
+      minimumParticipants: experience.minimumParticipants,
       capacity: experience.capacity,
       coverImageUrl: experience.coverImageUrl,
       location: new PublicExperienceLocationDto(
@@ -132,6 +133,7 @@ interface PublicExperienceCatalogDto {
   category: string;
   priceCop: number;
   durationHours: number;
+  minimumParticipants: number;
   capacity: number;
   coverImageUrl: string;
   location: PublicExperienceLocationDto;

--- a/src/presentation/dtos/experience/create-experience.dto.ts
+++ b/src/presentation/dtos/experience/create-experience.dto.ts
@@ -143,6 +143,17 @@ export class CreateExperienceDto {
   @Min(0.1)
   durationHours!: number;
 
+  @ApiPropertyOptional({
+    example: 2,
+    minimum: 1,
+    default: 1,
+    description: 'Minimum participants required for the experience to take place',
+  })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  minimumParticipants?: number;
+
   @ApiProperty({ example: 8, minimum: 1 })
   @IsInt()
   @Min(1)

--- a/src/presentation/dtos/experience/update-experience.dto.ts
+++ b/src/presentation/dtos/experience/update-experience.dto.ts
@@ -103,6 +103,16 @@ export class UpdateExperienceDto {
   @IsOptional()
   durationHours?: number;
 
+  @ApiPropertyOptional({
+    example: 2,
+    minimum: 1,
+    description: 'Minimum participants required for the experience to take place',
+  })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  minimumParticipants?: number;
+
   @ApiPropertyOptional({ example: 8, minimum: 1 })
   @IsInt()
   @Min(1)

--- a/test/application/cart/add-experience-to-cart.handler.spec.ts
+++ b/test/application/cart/add-experience-to-cart.handler.spec.ts
@@ -37,6 +37,7 @@ function makeArchivedExperience(): Experience {
     category: ExperienceCategory.create(ExperienceCategoryEnum.TRANSPORTATION),
     priceCop: 50000,
     durationHours: 2,
+    minimumParticipants: 1,
     capacity: 5,
     coverImageUrl: 'https://example.com/img.jpg',
     location: { label: 'Lobby', lat: 4.6097, lng: -74.0817 },
@@ -128,6 +129,24 @@ describe('AddExperienceToCartHandler', () => {
 
     await expect(handler.execute(makeCommand())).rejects.toThrow(
       DomainException,
+    );
+  });
+
+  it('throws DomainException when quantity is below the minimum participants', async () => {
+    const experience = makeExperience({ minimumParticipants: 3 });
+    experienceRepository.findById.mockResolvedValue(experience);
+
+    await expect(handler.execute(makeCommand({ quantity: 2 }))).rejects.toThrow(
+      'This experience requires at least 3 participants',
+    );
+  });
+
+  it('throws DomainException when quantity exceeds capacity', async () => {
+    const experience = makeExperience({ capacity: 2 });
+    experienceRepository.findById.mockResolvedValue(experience);
+
+    await expect(handler.execute(makeCommand({ quantity: 3 }))).rejects.toThrow(
+      'This experience allows up to 2 participants',
     );
   });
 });

--- a/test/application/experience/create-experience.handler.spec.ts
+++ b/test/application/experience/create-experience.handler.spec.ts
@@ -34,6 +34,7 @@ function makeCommand(
     overrides?.category ?? ExperienceCategoryEnum.TRANSPORTATION,
     overrides?.priceCop ?? 100000,
     overrides?.durationHours ?? 2,
+    overrides?.minimumParticipants,
     overrides?.capacity ?? 8,
     overrides?.coverImageUrl ?? 'https://cdn.example.com/transport.jpg',
     overrides?.location ?? {

--- a/test/presentation/controllers/guest-experience.controller.spec.ts
+++ b/test/presentation/controllers/guest-experience.controller.spec.ts
@@ -19,6 +19,7 @@ describe('GuestExperienceController', () => {
     category: 'ADVENTURE',
     priceCop: 100000,
     durationHours: 3,
+    minimumParticipants: 2,
     capacity: 10,
     coverImageUrl: 'https://img',
     location: { label: 'Dock', address: 'Address', lat: 1, lng: 2 },
@@ -52,6 +53,7 @@ describe('GuestExperienceController', () => {
     expect(result.experiences[0]).not.toHaveProperty('tenantId');
     expect(result.experiences[0]).not.toHaveProperty('unitIds');
     expect(result.experiences[0]).not.toHaveProperty('status');
+    expect(result.experiences[0].minimumParticipants).toBe(2);
   });
 
   it('by id endpoint dispatches query and returns propertyName and units', async () => {

--- a/test/shared/fixtures/experience.fixture.ts
+++ b/test/shared/fixtures/experience.fixture.ts
@@ -25,17 +25,14 @@ export const EXPERIENCE_FIXTURE_DEFAULTS = {
   description: 'Private transfer from the airport to the property',
   priceCop: 120000,
   durationHours: 2,
+  minimumParticipants: 1,
   capacity: 8,
   coverImageUrl: 'https://cdn.example.com/experience-cover.jpg',
   location: { label: 'Main lobby', lat: 4.6097, lng: -74.0817 },
 };
 
 export function makeExperience(
-  overrides?: Partial<{
-    id: string;
-    tenantId: string;
-    propertyId: string;
-  }>,
+  overrides?: Partial<typeof EXPERIENCE_FIXTURE_DEFAULTS>,
 ): Experience {
   const merged = { ...EXPERIENCE_FIXTURE_DEFAULTS, ...overrides };
   return Experience.reconstitute({
@@ -48,6 +45,7 @@ export function makeExperience(
     category: ExperienceCategory.create(ExperienceCategoryEnum.TRANSPORTATION),
     priceCop: merged.priceCop,
     durationHours: merged.durationHours,
+    minimumParticipants: merged.minimumParticipants,
     capacity: merged.capacity,
     coverImageUrl: merged.coverImageUrl,
     location: merged.location,


### PR DESCRIPTION
Experiences should support a minimum participants field in addition to the existing maximum (capacity). When a guest is selecting the number of participants:

The participants dropdown should start at the minimum (not always 1).

If the guest tries to book with fewer participants than the minimum, they should see a clear message explaining the requirement.

This field should also be exposed in the experience creation and editing form so tenants can set it when configuring an experience.