### PR TITLE
Lymon 1060 change the access to the images from public ur ls in the database to media keys in the database

### DIFF
--- a/src/application/experience/commands/create-experience.command.ts
+++ b/src/application/experience/commands/create-experience.command.ts
@@ -32,7 +32,6 @@ export class CreateExperienceCommand {
     public readonly priceCop: number,
     public readonly durationHours: number,
     public readonly capacity: number,
-    public readonly coverImageUrl: string,
     public readonly location: CreateExperienceLocationInput,
     public readonly availabilityType: ExperienceAvailabilityTypeEnum,
     public readonly startAt: string | undefined,
@@ -43,6 +42,7 @@ export class CreateExperienceCommand {
       | undefined,
     public readonly allowStandalonePurchase: boolean,
     public readonly allowReservationPurchase: boolean,
+    public readonly mediaKeys: string[] | undefined,
     public readonly actorId: string,
     public readonly actorEmail: string,
   ) {}

--- a/src/application/experience/commands/create-experience.handler.ts
+++ b/src/application/experience/commands/create-experience.handler.ts
@@ -170,7 +170,6 @@ export class CreateExperienceHandler implements ICommandHandler<CreateExperience
         priceCop: command.priceCop,
         durationHours: command.durationHours,
         capacity: command.capacity,
-        coverImageUrl: command.coverImageUrl,
         location: {
           label: command.location.label,
           address: command.location.address,
@@ -189,6 +188,7 @@ export class CreateExperienceHandler implements ICommandHandler<CreateExperience
         })),
         allowStandalonePurchase: command.allowStandalonePurchase,
         allowReservationPurchase: command.allowReservationPurchase,
+        mediaKeys: command.mediaKeys,
       });
 
       return {

--- a/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query-handler.ts
+++ b/src/application/experience/queries/GetAvailableExperienceById/get-available-experience-by-id.query-handler.ts
@@ -18,6 +18,10 @@ import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo
 import { ExperienceStatus } from '@/domain/experience/value-objects/experience-status.vo';
 import { mapExperienceToPublicDto } from '@/application/experience/queries/shared/experience.mapper';
 import { ExperienceUnitSummaryDto } from '@/application/experience/queries/shared/experience-read.dto';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetAvailableExperienceByIdQuery)
 export class GetAvailableExperienceByIdQueryHandler implements IQueryHandler<
@@ -31,6 +35,8 @@ export class GetAvailableExperienceByIdQueryHandler implements IQueryHandler<
     private readonly propertyRepository: PropertyRepository,
     @Inject(UNIT_REPOSITORY)
     private readonly unitRepository: UnitRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -49,7 +55,9 @@ export class GetAvailableExperienceByIdQueryHandler implements IQueryHandler<
       );
     }
 
-    const dto = mapExperienceToPublicDto(experience);
+    const dto = mapExperienceToPublicDto(experience, (k) =>
+      this.storage.getPublicUrl(k),
+    );
 
     const propertyId = experience.getPropertyId();
     let propertyName: string | null = null;

--- a/src/application/experience/queries/GetAvailableExperiences/get-available-experiences.query-handler.ts
+++ b/src/application/experience/queries/GetAvailableExperiences/get-available-experiences.query-handler.ts
@@ -10,6 +10,10 @@ import { ExperienceCategory } from '@/domain/experience/value-objects/experience
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { mapExperienceToPublicDto } from '@/application/experience/queries/shared/experience.mapper';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 function tryCreate<T>(
   value: string | undefined,
@@ -31,6 +35,8 @@ export class GetAvailableExperiencesQueryHandler implements IQueryHandler<
   constructor(
     @Inject(EXPERIENCE_REPOSITORY)
     private readonly experienceRepository: ExperienceRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -52,7 +58,9 @@ export class GetAvailableExperiencesQueryHandler implements IQueryHandler<
       );
 
     return new GetAvailableExperiencesResult(
-      experiences.map(mapExperienceToPublicDto),
+      experiences.map((exp) =>
+        mapExperienceToPublicDto(exp, (k) => this.storage.getPublicUrl(k)),
+      ),
       total,
       query.page,
       query.limit,

--- a/src/application/experience/queries/GetExperienceById/get-experience-by-id.query-handler.ts
+++ b/src/application/experience/queries/GetExperienceById/get-experience-by-id.query-handler.ts
@@ -19,6 +19,10 @@ import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
 import { mapExperienceToPublicDto } from '@/application/experience/queries/shared/experience.mapper';
 import { ExperienceUnitSummaryDto } from '@/application/experience/queries/shared/experience-read.dto';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetExperienceByIdQuery)
 export class GetExperienceByIdQueryHandler implements IQueryHandler<
@@ -32,6 +36,8 @@ export class GetExperienceByIdQueryHandler implements IQueryHandler<
     private readonly propertyRepository: PropertyRepository,
     @Inject(UNIT_REPOSITORY)
     private readonly unitRepository: UnitRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -72,7 +78,7 @@ export class GetExperienceByIdQueryHandler implements IQueryHandler<
     );
 
     return new GetExperienceByIdResult(
-      mapExperienceToPublicDto(experience),
+      mapExperienceToPublicDto(experience, (k) => this.storage.getPublicUrl(k)),
       property?.getName() ?? null,
       unitSummaries,
     );

--- a/src/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler.ts
+++ b/src/application/experience/queries/GetExperiencesByTenant/get-experiences-by-tenant.query-handler.ts
@@ -9,6 +9,10 @@ import {
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { mapExperienceToPublicDto } from '@/application/experience/queries/shared/experience.mapper';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetExperiencesByTenantQuery)
 export class GetExperiencesByTenantQueryHandler implements IQueryHandler<
@@ -18,6 +22,8 @@ export class GetExperiencesByTenantQueryHandler implements IQueryHandler<
   constructor(
     @Inject(EXPERIENCE_REPOSITORY)
     private readonly experienceRepository: ExperienceRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -38,7 +44,9 @@ export class GetExperiencesByTenantQueryHandler implements IQueryHandler<
       );
 
     return new GetExperiencesByTenantResult(
-      experiences.map(mapExperienceToPublicDto),
+      experiences.map((exp) =>
+        mapExperienceToPublicDto(exp, (k) => this.storage.getPublicUrl(k)),
+      ),
       total,
       query.page,
       query.limit,

--- a/src/application/experience/queries/shared/experience-read.dto.ts
+++ b/src/application/experience/queries/shared/experience-read.dto.ts
@@ -44,7 +44,6 @@ export class PublicExperienceDto {
     public readonly priceCop: number,
     public readonly durationHours: number,
     public readonly capacity: number,
-    public readonly coverImageUrl: string,
     public readonly location: PublicExperienceLocationDto,
     public readonly availabilityType: string,
     public readonly startAt: Date | null,
@@ -56,5 +55,6 @@ export class PublicExperienceDto {
     public readonly minNoticeHours: number,
     public readonly purchaseCutoffHours: number,
     public readonly status: string,
+    public readonly mediaUrls: string[],
   ) {}
 }

--- a/src/application/experience/queries/shared/experience.mapper.ts
+++ b/src/application/experience/queries/shared/experience.mapper.ts
@@ -8,6 +8,7 @@ import {
 
 export function mapExperienceToPublicDto(
   experience: Experience,
+  getPublicUrl: (key: string) => string,
 ): PublicExperienceDto {
   const recurrence = experience.getRecurrence();
 
@@ -23,7 +24,6 @@ export function mapExperienceToPublicDto(
     experience.getPriceCop(),
     experience.getDurationHours(),
     experience.getCapacity(),
-    experience.getCoverImageUrl(),
     new PublicExperienceLocationDto(
       experience.getLocation().label,
       experience.getLocation().address,
@@ -51,5 +51,6 @@ export function mapExperienceToPublicDto(
     experience.getMinNoticeHours(),
     experience.getPurchaseCutoffHours(),
     experience.getStatus().toString(),
+    experience.getMediaKeys().map(getPublicUrl),
   );
 }

--- a/src/application/property/commands/create-property.command.ts
+++ b/src/application/property/commands/create-property.command.ts
@@ -18,5 +18,6 @@ export class CreatePropertyCommand {
     public readonly autoCreateUnit: boolean,
     public readonly actorId: string,
     public readonly actorEmail: string,
+    public readonly imageKey?: string,
   ) {}
 }

--- a/src/application/property/commands/create-property.handler.ts
+++ b/src/application/property/commands/create-property.handler.ts
@@ -77,6 +77,7 @@ export class CreatePropertyHandler implements ICommandHandler<CreatePropertyComm
       cancellationPolicy: CancellationPolicy.create(command.cancellationPolicy),
       hostPhone: command.hostPhone,
       hostEmail: command.hostEmail,
+      imageKey: command.imageKey,
     });
 
     const shouldAutoCreate =

--- a/src/application/property/commands/update-property.command.ts
+++ b/src/application/property/commands/update-property.command.ts
@@ -17,5 +17,6 @@ export class UpdatePropertyCommand {
     public readonly hostEmail: string | undefined,
     public readonly actorId: string,
     public readonly actorEmail: string,
+    public readonly imageKey?: string,
   ) {}
 }

--- a/src/application/property/commands/update-property.handler.ts
+++ b/src/application/property/commands/update-property.handler.ts
@@ -20,6 +20,10 @@ import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { PropertyUpdateData } from '@/domain/property/entities/property.entity';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @CommandHandler(UpdatePropertyCommand)
 export class UpdatePropertyHandler implements ICommandHandler<
@@ -30,6 +34,8 @@ export class UpdatePropertyHandler implements ICommandHandler<
     @Inject(PROPERTY_REPOSITORY)
     private readonly propertyRepository: PropertyRepository,
     private readonly eventEmitter: EventEmitter2,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(command: UpdatePropertyCommand): Promise<UpdatePropertyResult> {
@@ -85,7 +91,20 @@ export class UpdatePropertyHandler implements ICommandHandler<
       );
     }
 
+    let orphanedImageKey: string | null = null;
+    if (command.imageKey !== undefined) {
+      const oldKey = property.getImageKey();
+      if (oldKey && oldKey !== command.imageKey) {
+        orphanedImageKey = oldKey;
+      }
+      property.updateImageKey(command.imageKey);
+    }
+
     const updatedPropertyId = await this.propertyRepository.save(property);
+
+    if (orphanedImageKey) {
+      await this.storage.deleteObjects([orphanedImageKey]);
+    }
 
     this.eventEmitter.emit(
       AUDIT_LOG_EVENT,
@@ -117,6 +136,7 @@ export class UpdatePropertyHandler implements ICommandHandler<
       command.cancellationPolicy,
       command.hostPhone,
       command.hostEmail,
+      command.imageKey,
     ].some((field) => field !== undefined);
   }
 

--- a/src/application/property/property-application.module.ts
+++ b/src/application/property/property-application.module.ts
@@ -6,6 +6,7 @@ import { DeletePropertyHandler } from '@/application/property/commands/delete-pr
 import { GetPropertiesByTenantQueryHandler } from '@/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.query-handler';
 import { GetPropertyByIdQueryHandler } from '@/application/property/queries/GetPropertyById/get-property-by-id.query-handler';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
+import { StorageModule } from '@/infrastructure/storage/storage.module';
 
 const CommandHandlers = [
   CreatePropertyHandler,
@@ -18,7 +19,7 @@ const QueryHandlers = [
 ];
 
 @Module({
-  imports: [CqrsModule, PersistenceModule],
+  imports: [CqrsModule, PersistenceModule, StorageModule],
   providers: [...CommandHandlers, ...QueryHandlers],
   exports: [...CommandHandlers, ...QueryHandlers],
 })

--- a/src/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.query-handler.ts
+++ b/src/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.query-handler.ts
@@ -8,6 +8,10 @@ import {
 import { PROPERTY_REPOSITORY } from '@/domain/property/repositories/property.repository';
 import type { PropertyRepository } from '@/domain/property/repositories/property.repository';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetPropertiesByTenantQuery)
 export class GetPropertiesByTenantQueryHandler implements IQueryHandler<
@@ -17,6 +21,8 @@ export class GetPropertiesByTenantQueryHandler implements IQueryHandler<
   constructor(
     @Inject(PROPERTY_REPOSITORY)
     private readonly propertyRepository: PropertyRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -40,6 +46,9 @@ export class GetPropertiesByTenantQueryHandler implements IQueryHandler<
           property.getAddress(),
           property.getCity(),
           property.getCreatedAt(),
+          property.getImageKey()
+            ? this.storage.getPublicUrl(property.getImageKey()!)
+            : null,
         ),
     );
 

--- a/src/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.result.ts
+++ b/src/application/property/queries/GetPropertiesByTenant/get-properties-by-tenant.result.ts
@@ -7,6 +7,7 @@ export class PropertyDto {
     public readonly address: string,
     public readonly city: string,
     public readonly createdAt: Date,
+    public readonly imageUrl: string | null,
   ) {}
 }
 

--- a/src/application/property/queries/GetPropertyById/get-property-by-id.query-handler.ts
+++ b/src/application/property/queries/GetPropertyById/get-property-by-id.query-handler.ts
@@ -9,6 +9,10 @@ import { PROPERTY_REPOSITORY } from '@/domain/property/repositories/property.rep
 import type { PropertyRepository } from '@/domain/property/repositories/property.repository';
 import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetPropertyByIdQuery)
 export class GetPropertyByIdQueryHandler implements IQueryHandler<
@@ -18,6 +22,8 @@ export class GetPropertyByIdQueryHandler implements IQueryHandler<
   constructor(
     @Inject(PROPERTY_REPOSITORY)
     private readonly propertyRepository: PropertyRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(query: GetPropertyByIdQuery): Promise<GetPropertyByIdResult> {
@@ -48,6 +54,9 @@ export class GetPropertyByIdQueryHandler implements IQueryHandler<
       property.getHostEmail(),
       property.getCreatedAt(),
       property.getUpdatedAt(),
+      property.getImageKey()
+        ? this.storage.getPublicUrl(property.getImageKey()!)
+        : null,
     );
 
     return new GetPropertyByIdResult(dto);

--- a/src/application/property/queries/GetPropertyById/get-property-by-id.result.ts
+++ b/src/application/property/queries/GetPropertyById/get-property-by-id.result.ts
@@ -17,6 +17,7 @@ export class PropertyFullDto {
     public readonly hostEmail: string,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
+    public readonly imageUrl: string | null,
   ) {}
 }
 

--- a/src/application/reservation/queries/shared/unit.mapper.ts
+++ b/src/application/reservation/queries/shared/unit.mapper.ts
@@ -5,7 +5,10 @@ import {
 } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.result';
 import { Unit } from '@/domain/unit/entities/unit.entity';
 
-export function mapUnitToPublicDto(unit: Unit): PublicUnitDto {
+export function mapUnitToPublicDto(
+  unit: Unit,
+  getPublicUrl: (key: string) => string,
+): PublicUnitDto {
   const unitId = unit.getId();
   const bedrooms = unit.getBedrooms().map(
     (bedroom) =>
@@ -28,5 +31,6 @@ export function mapUnitToPublicDto(unit: Unit): PublicUnitDto {
     unit.getTenantId().toString(),
     unit.getPropertyId().toString(),
     unit.getRating(),
+    unit.getMediaKeys().map(getPublicUrl),
   );
 }

--- a/src/application/unit/commands/create-unit.command.ts
+++ b/src/application/unit/commands/create-unit.command.ts
@@ -22,5 +22,6 @@ export class CreateUnitCommand {
     },
     public readonly actorId?: string,
     public readonly actorEmail?: string,
+    public readonly mediaKeys?: string[],
   ) {}
 }

--- a/src/application/unit/commands/create-unit.handler.ts
+++ b/src/application/unit/commands/create-unit.handler.ts
@@ -96,6 +96,7 @@ export class CreateUnitHandler implements ICommandHandler<CreateUnitCommand> {
         command.externalIds?.bookingId,
         command.externalIds?.vrboId,
       ),
+      mediaKeys: command.mediaKeys,
     });
 
     const unitId = await this.unitRepository.save(unit);

--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
@@ -12,6 +12,10 @@ import {
 } from '@/domain/reservation/repositories/reservation.repository';
 import { AvailabilityChecker } from '@/domain/reservation/services/availability-checker.domain-service';
 import { DateRange } from '@/domain/reservation/value-objects/date-range.vo';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetAllPublicUnitsQuery)
 export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
@@ -23,6 +27,8 @@ export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
     private readonly unitRepository: UnitRepository,
     @Inject(RESERVATION_REPOSITORY)
     private readonly reservationRepository: ReservationRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -70,7 +76,7 @@ export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
       const total = availableUnits.length;
       const skip = (query.page - 1) * query.limit;
       const paginatedUnits = availableUnits.slice(skip, skip + query.limit);
-      const dtos = paginatedUnits.map(mapUnitToPublicDto);
+      const dtos = paginatedUnits.map((u) => mapUnitToPublicDto(u, (k) => this.storage.getPublicUrl(k)));
 
       return new GetAllPublicUnitsResult(dtos, total, query.page, query.limit);
     }
@@ -83,7 +89,7 @@ export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
       query.propertyId,
       query.sortByPrice,
     );
-    const dtos = units.map(mapUnitToPublicDto);
+    const dtos = units.map((u) => mapUnitToPublicDto(u, (k) => this.storage.getPublicUrl(k)));
 
     return new GetAllPublicUnitsResult(dtos, total, query.page, query.limit);
   }

--- a/src/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query-handler.ts
+++ b/src/application/unit/queries/GetPublicUnitById/get-public-unit-by-id.query-handler.ts
@@ -6,6 +6,10 @@ import { UNIT_REPOSITORY } from '@/domain/unit/repositories/unit.repository';
 import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
 import { UnitId } from '@/domain/unit/value-objects/unit-id.vo';
 import { mapUnitToPublicDto } from '@/application/reservation/queries/shared/unit.mapper';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetPublicUnitByIdQuery)
 export class GetPublicUnitByIdQueryHandler implements IQueryHandler<
@@ -15,6 +19,8 @@ export class GetPublicUnitByIdQueryHandler implements IQueryHandler<
   constructor(
     @Inject(UNIT_REPOSITORY)
     private readonly unitRepository: UnitRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -27,7 +33,7 @@ export class GetPublicUnitByIdQueryHandler implements IQueryHandler<
       throw new NotFoundException('Unit not found');
     }
 
-    const dto = mapUnitToPublicDto(unit);
+    const dto = mapUnitToPublicDto(unit, (k) => this.storage.getPublicUrl(k));
 
     return new GetPublicUnitByIdResult(dto);
   }

--- a/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler.ts
+++ b/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.query-handler.ts
@@ -14,6 +14,10 @@ import {
 } from '@/domain/reservation/repositories/reservation.repository';
 import { AvailabilityChecker } from '@/domain/reservation/services/availability-checker.domain-service';
 import { DateRange } from '@/domain/reservation/value-objects/date-range.vo';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetPublicUnitsByTenantQuery)
 export class GetPublicUnitsByTenantQueryHandler implements IQueryHandler<
@@ -27,6 +31,8 @@ export class GetPublicUnitsByTenantQueryHandler implements IQueryHandler<
     private readonly tenantRepository: TenantRepository,
     @Inject(RESERVATION_REPOSITORY)
     private readonly reservationRepository: ReservationRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -70,7 +76,7 @@ export class GetPublicUnitsByTenantQueryHandler implements IQueryHandler<
       const total = availableUnits.length;
       const skip = (query.page - 1) * query.limit;
       const paginatedUnits = availableUnits.slice(skip, skip + query.limit);
-      const dtos = paginatedUnits.map(mapUnitToPublicDto);
+      const dtos = paginatedUnits.map((u) => mapUnitToPublicDto(u, (k) => this.storage.getPublicUrl(k)));
 
       return new GetPublicUnitsByTenantResult(
         dtos,
@@ -86,7 +92,7 @@ export class GetPublicUnitsByTenantQueryHandler implements IQueryHandler<
       query.limit,
       query.minGuests,
     );
-    const dtos = units.map(mapUnitToPublicDto);
+    const dtos = units.map((u) => mapUnitToPublicDto(u, (k) => this.storage.getPublicUrl(k)));
 
     return new GetPublicUnitsByTenantResult(
       dtos,

--- a/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.result.ts
+++ b/src/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.result.ts
@@ -27,6 +27,7 @@ export class PublicUnitDto {
     public readonly tenantId: string,
     public readonly propertyId: string,
     public readonly rating: number | null,
+    public readonly mediaUrls: string[],
   ) {}
 }
 

--- a/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler.ts
+++ b/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.query-handler.ts
@@ -13,6 +13,10 @@ import {
   PublicBedDto,
   PublicBedroomDto,
 } from '@/application/unit/queries/GetPublicUnitsByTenant/get-public-units-by-tenant.result';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetUnitWithExternalIdsByIdQuery)
 export class GetUnitWithExternalIdsByIdQueryHandler implements IQueryHandler<
@@ -22,6 +26,8 @@ export class GetUnitWithExternalIdsByIdQueryHandler implements IQueryHandler<
   constructor(
     @Inject(UNIT_REPOSITORY)
     private readonly unitRepository: UnitRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -63,6 +69,7 @@ export class GetUnitWithExternalIdsByIdQueryHandler implements IQueryHandler<
       unit.getTenantId().toString(),
       unit.getPropertyId().toString(),
       unit.getRating(),
+      unit.getMediaKeys().map((k) => this.storage.getPublicUrl(k)),
       externalIdsDto,
     );
 

--- a/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result.ts
+++ b/src/application/unit/queries/GetUnitWithExternalIdsById/get-unit-with-external-ids-by-id.result.ts
@@ -26,6 +26,7 @@ export class UnitWithExternalIdsDto extends PublicUnitDto {
     tenantId: string,
     propertyId: string,
     rating: number | null,
+    mediaUrls: string[],
     public readonly externalIds: ExternalIdsDto,
   ) {
     super(
@@ -42,6 +43,7 @@ export class UnitWithExternalIdsDto extends PublicUnitDto {
       tenantId,
       propertyId,
       rating,
+      mediaUrls,
     );
   }
 }

--- a/src/application/unit/queries/GetUnitsByProperty/get-units-by-property.query-handler.ts
+++ b/src/application/unit/queries/GetUnitsByProperty/get-units-by-property.query-handler.ts
@@ -11,6 +11,10 @@ import { PROPERTY_REPOSITORY } from '@/domain/property/repositories/property.rep
 import { UNIT_REPOSITORY } from '@/domain/unit/repositories/unit.repository';
 import type { PropertyRepository } from '@/domain/property/repositories/property.repository';
 import type { UnitRepository } from '@/domain/unit/repositories/unit.repository';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
 
 @QueryHandler(GetUnitsByPropertyQuery)
 export class GetUnitsByPropertyQueryHandler implements IQueryHandler<
@@ -22,6 +26,8 @@ export class GetUnitsByPropertyQueryHandler implements IQueryHandler<
     private readonly propertyRepository: PropertyRepository,
     @Inject(UNIT_REPOSITORY)
     private readonly unitRepository: UnitRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storage: R2StorageService,
   ) {}
 
   async execute(
@@ -65,6 +71,7 @@ export class GetUnitsByPropertyQueryHandler implements IQueryHandler<
         unit.getPricePerNight(),
         unit.getCreatedAt(),
         unit.getRating(),
+        unit.getMediaKeys().map((k) => this.storage.getPublicUrl(k)),
       );
     });
 

--- a/src/application/unit/queries/GetUnitsByProperty/get-units-by-property.result.ts
+++ b/src/application/unit/queries/GetUnitsByProperty/get-units-by-property.result.ts
@@ -12,6 +12,7 @@ export class UnitDto {
     public readonly pricePerNight: number,
     public readonly createdAt: Date,
     public readonly rating: number | null,
+    public readonly mediaUrls: string[],
   ) {}
 }
 

--- a/src/domain/experience/entities/experience.entity.ts
+++ b/src/domain/experience/entities/experience.entity.ts
@@ -39,7 +39,6 @@ export interface ExperienceProps {
   priceCop: number;
   durationHours: number;
   capacity: number;
-  coverImageUrl: string;
   location: ExperienceLocation;
   availabilityType: ExperienceAvailabilityType;
   startAt?: Date;
@@ -48,6 +47,7 @@ export interface ExperienceProps {
   blackoutRanges?: ExperienceBlackoutRange[];
   allowStandalonePurchase: boolean;
   allowReservationPurchase: boolean;
+  mediaKeys?: string[];
 }
 
 export interface ExperienceReconstituteData {
@@ -63,7 +63,6 @@ export interface ExperienceReconstituteData {
   priceCop: number;
   durationHours: number;
   capacity: number;
-  coverImageUrl: string;
   location: ExperienceLocation;
   availabilityType: ExperienceAvailabilityType;
   startAt?: Date;
@@ -86,7 +85,6 @@ export interface ExperienceChanges {
   priceCop?: number;
   durationHours?: number;
   capacity?: number;
-  coverImageUrl?: string;
   location?: ExperienceLocation;
   availabilityType?: ExperienceAvailabilityTypeEnum;
   startAt?: Date;
@@ -111,7 +109,6 @@ export class Experience {
     private priceCop: number,
     private durationHours: number,
     private capacity: number,
-    private coverImageUrl: string,
     private location: ExperienceLocation,
     private availabilityType: ExperienceAvailabilityType,
     private startAt: Date | null,
@@ -192,7 +189,6 @@ export class Experience {
       props.priceCop,
       props.durationHours,
       props.capacity,
-      props.coverImageUrl,
       {
         label: props.location.label.trim(),
         address: props.location.address?.trim() || undefined,
@@ -212,7 +208,7 @@ export class Experience {
       now,
       now,
       null,
-      [],
+      props.mediaKeys ?? [],
     );
   }
 
@@ -229,7 +225,6 @@ export class Experience {
       data.priceCop,
       data.durationHours,
       data.capacity,
-      data.coverImageUrl,
       data.location,
       data.availabilityType,
       data.startAt ?? null,
@@ -290,10 +285,6 @@ export class Experience {
 
   getCapacity(): number {
     return this.capacity;
-  }
-
-  getCoverImageUrl(): string {
-    return this.coverImageUrl;
   }
 
   getLocation(): ExperienceLocation {
@@ -419,7 +410,6 @@ export class Experience {
     this.priceCop = priceCop;
     this.durationHours = durationHours;
     this.capacity = capacity;
-    this.coverImageUrl = changes.coverImageUrl ?? this.coverImageUrl;
     this.location = {
       label: location.label.trim(),
       address: location.address?.trim() || undefined,

--- a/src/domain/property/entities/property.entity.ts
+++ b/src/domain/property/entities/property.entity.ts
@@ -20,6 +20,7 @@ export interface PropertyProps {
   cancellationPolicy: CancellationPolicy;
   hostPhone: string;
   hostEmail: string;
+  imageKey?: string;
 }
 
 export interface PropertyUpdateData {
@@ -50,6 +51,7 @@ export interface PropertyReconstituteData {
   cancellationPolicy: CancellationPolicy;
   hostPhone: string;
   hostEmail: string;
+  imageKey?: string | null;
   createdAt: Date;
   updatedAt: Date;
   deletedAt?: Date | null;
@@ -73,6 +75,7 @@ export class Property {
     private cancellationPolicy: CancellationPolicy,
     private hostPhone: string,
     private hostEmail: string,
+    private imageKey: string | null,
     private readonly createdAt: Date,
     private updatedAt: Date,
     private deletedAt: Date | null,
@@ -104,6 +107,7 @@ export class Property {
       props.cancellationPolicy,
       props.hostPhone,
       props.hostEmail,
+      props.imageKey ?? null,
       new Date(),
       new Date(),
       null,
@@ -128,6 +132,7 @@ export class Property {
       data.cancellationPolicy,
       data.hostPhone,
       data.hostEmail,
+      data.imageKey ?? null,
       data.createdAt,
       data.updatedAt,
       data.deletedAt ?? null,
@@ -196,6 +201,15 @@ export class Property {
 
   getHostEmail(): string {
     return this.hostEmail;
+  }
+
+  getImageKey(): string | null {
+    return this.imageKey;
+  }
+
+  updateImageKey(imageKey: string | null): void {
+    this.imageKey = imageKey;
+    this.updatedAt = new Date();
   }
 
   getCreatedAt(): Date {

--- a/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
@@ -45,7 +45,6 @@ export class MongoExperienceRepository implements ExperienceRepository {
       priceCop: experience.getPriceCop(),
       durationHours: experience.getDurationHours(),
       capacity: experience.getCapacity(),
-      coverImageUrl: experience.getCoverImageUrl(),
       location: experience.getLocation(),
       availabilityType: experience.getAvailabilityType().toString(),
       startAt: experience.getStartAt(),
@@ -210,7 +209,6 @@ export class MongoExperienceRepository implements ExperienceRepository {
       priceCop: document.priceCop,
       durationHours: document.durationHours,
       capacity: document.capacity,
-      coverImageUrl: document.coverImageUrl,
       location: {
         label: document.location.label,
         address: document.location.address,

--- a/src/infrastructure/persistence/repositories/mongo-property.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-property.repository.ts
@@ -41,6 +41,7 @@ export class MongoPropertyRepository implements PropertyRepository {
       cancellationPolicy: property.getCancellationPolicy().toString(),
       hostPhone: property.getHostPhone(),
       hostEmail: property.getHostEmail(),
+      imageKey: property.getImageKey() ?? undefined,
       updatedAt: property.getUpdatedAt(),
     };
 
@@ -119,6 +120,7 @@ export class MongoPropertyRepository implements PropertyRepository {
       ),
       hostPhone: document.hostPhone,
       hostEmail: document.hostEmail,
+      imageKey: document.imageKey ?? null,
       createdAt: document.createdAt,
       updatedAt: document.updatedAt,
       deletedAt: document.deletedAt ?? null,

--- a/src/infrastructure/persistence/schemas/experience.schema.ts
+++ b/src/infrastructure/persistence/schemas/experience.schema.ts
@@ -83,9 +83,6 @@ export class ExperienceDocument extends Document {
   @Prop({ required: true })
   capacity: number;
 
-  @Prop({ required: true })
-  coverImageUrl: string;
-
   @Prop({ type: ExperienceLocationSchema, required: true })
   location: ExperienceLocationSchema;
 

--- a/src/infrastructure/persistence/schemas/property.schema.ts
+++ b/src/infrastructure/persistence/schemas/property.schema.ts
@@ -65,6 +65,9 @@ export class PropertyDocument extends Document {
   hostEmail: string;
 
   @Prop()
+  imageKey?: string;
+
+  @Prop()
   createdAt: Date;
 
   @Prop()

--- a/src/presentation/controllers/experience.controller.ts
+++ b/src/presentation/controllers/experience.controller.ts
@@ -149,7 +149,6 @@ export class ExperienceController {
           priceCop: 120000,
           durationHours: 2,
           capacity: 8,
-          coverImageUrl: 'https://image.com/experience-cover.jpg',
           location: {
             label: 'Main lobby pickup point',
             address: 'Cra 10 #20-30, Bogota',
@@ -179,7 +178,6 @@ export class ExperienceController {
           priceCop: 80000,
           durationHours: 1,
           capacity: 12,
-          coverImageUrl: 'https://image.com/tenant-shuttle.jpg',
           location: {
             label: 'Terminal norte',
             address: 'Terminal del Norte',
@@ -229,7 +227,6 @@ export class ExperienceController {
       dto.priceCop,
       dto.durationHours,
       dto.capacity,
-      dto.coverImageUrl,
       dto.location,
       dto.availabilityType,
       dto.startAt,
@@ -238,6 +235,7 @@ export class ExperienceController {
       dto.blackoutRanges,
       dto.allowStandalonePurchase,
       dto.allowReservationPurchase,
+      dto.mediaKeys,
       user.userId,
       user.email,
     );
@@ -281,7 +279,6 @@ export class ExperienceController {
         priceCop: dto.priceCop,
         durationHours: dto.durationHours,
         capacity: dto.capacity,
-        coverImageUrl: dto.coverImageUrl,
         location: dto.location,
         availabilityType: dto.availabilityType,
         recurrence: dto.recurrence,

--- a/src/presentation/controllers/guest-experience.controller.ts
+++ b/src/presentation/controllers/guest-experience.controller.ts
@@ -95,7 +95,7 @@ export class GuestExperienceController {
       priceCop: experience.priceCop,
       durationHours: experience.durationHours,
       capacity: experience.capacity,
-      coverImageUrl: experience.coverImageUrl,
+      mediaUrls: experience.mediaUrls,
       location: new PublicExperienceLocationDto(
         experience.location.label,
         experience.location.address,
@@ -135,7 +135,7 @@ interface PublicExperienceCatalogDto {
   priceCop: number;
   durationHours: number;
   capacity: number;
-  coverImageUrl: string;
+  mediaUrls: string[];
   location: PublicExperienceLocationDto;
   availabilityType: string;
   startAt: Date | null;

--- a/src/presentation/controllers/property.controller.ts
+++ b/src/presentation/controllers/property.controller.ts
@@ -84,6 +84,7 @@ export class PropertyController {
       autoCreateUnit,
       user.userId,
       user.email,
+      dto.imageKey,
     );
 
     const result = await this.commandBus.execute<
@@ -208,6 +209,7 @@ export class PropertyController {
       dto.hostEmail,
       user.userId,
       user.email,
+      dto.imageKey,
     );
 
     const result = await this.commandBus.execute<

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -122,6 +122,7 @@ export class UnitController {
       dto.externalIds,
       user.userId,
       user.email,
+      dto.mediaKeys,
     );
 
     const result = await this.commandBus.execute<

--- a/src/presentation/dtos/experience/create-experience.dto.ts
+++ b/src/presentation/dtos/experience/create-experience.dto.ts
@@ -9,7 +9,6 @@ import {
   IsNumber,
   IsOptional,
   IsString,
-  IsUrl,
   Max,
   MaxLength,
   Min,
@@ -163,10 +162,6 @@ export class CreateExperienceDto {
   @Min(1)
   capacity!: number;
 
-  @ApiProperty({ example: 'https://image.com/experience-cover.jpg' })
-  @IsUrl()
-  coverImageUrl!: string;
-
   @ApiProperty({ type: () => ExperienceLocationDto })
   @ValidateNested()
   @Type(() => ExperienceLocationDto)
@@ -223,4 +218,14 @@ export class CreateExperienceDto {
   @ApiProperty({ example: true })
   @IsBoolean()
   allowReservationPurchase!: boolean;
+
+  @ApiPropertyOptional({
+    example: ['tenantId/experiences/1234-photo.jpg'],
+    description: 'R2 object keys for uploaded media files',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  mediaKeys?: string[];
 }

--- a/src/presentation/dtos/experience/update-experience.dto.ts
+++ b/src/presentation/dtos/experience/update-experience.dto.ts
@@ -9,7 +9,6 @@ import {
   IsNumber,
   IsOptional,
   IsString,
-  IsUrl,
   Max,
   MaxLength,
   Min,
@@ -108,11 +107,6 @@ export class UpdateExperienceDto {
   @Min(1)
   @IsOptional()
   capacity?: number;
-
-  @ApiPropertyOptional({ example: 'https://image.com/experience-cover.jpg' })
-  @IsUrl()
-  @IsOptional()
-  coverImageUrl?: string;
 
   @ApiPropertyOptional({ type: () => UpdateExperienceLocationDto })
   @ValidateNested()

--- a/src/presentation/dtos/property/create-property.dto.ts
+++ b/src/presentation/dtos/property/create-property.dto.ts
@@ -6,6 +6,7 @@ import {
   Min,
   Max,
   IsEmail,
+  IsOptional,
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -85,4 +86,13 @@ export class CreatePropertyDto {
   @IsEmail()
   @IsNotEmpty()
   hostEmail: string;
+
+  @ApiProperty({
+    required: false,
+    example: 'tenantId/properties/1234-photo.jpg',
+    description: 'R2 object key for the property image',
+  })
+  @IsString()
+  @IsOptional()
+  imageKey?: string;
 }

--- a/src/presentation/dtos/property/get-property-by-id-response.dto.ts
+++ b/src/presentation/dtos/property/get-property-by-id-response.dto.ts
@@ -59,6 +59,9 @@ export class GetPropertyByIdResponseDto {
 
   @ApiProperty()
   updatedAt: Date;
+
+  @ApiProperty({ nullable: true })
+  imageUrl: string | null;
 }
 
 export class GetPropertyByIdSuccessResponseDto {

--- a/src/presentation/dtos/property/update-property.dto.ts
+++ b/src/presentation/dtos/property/update-property.dto.ts
@@ -116,4 +116,12 @@ export class UpdatePropertyDto {
   @IsEmail()
   @IsNotEmpty()
   hostEmail?: string;
+
+  @ApiPropertyOptional({
+    example: 'tenantId/properties/1234-photo.jpg',
+    description: 'R2 object key for the property image',
+  })
+  @IsString()
+  @IsOptional()
+  imageKey?: string;
 }

--- a/src/presentation/dtos/unit/create-unit.dto.ts
+++ b/src/presentation/dtos/unit/create-unit.dto.ts
@@ -174,4 +174,15 @@ export class CreateUnitDto {
   @Type(() => ExternalIdsDto)
   @IsOptional()
   externalIds?: ExternalIdsDto;
+
+  @ApiProperty({
+    example: ['tenantId/units/1234-photo.jpg'],
+    description: 'R2 object keys for uploaded media files',
+    type: [String],
+    required: false,
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  mediaKeys?: string[];
 }

--- a/test/application/cart/add-experience-to-cart.handler.spec.ts
+++ b/test/application/cart/add-experience-to-cart.handler.spec.ts
@@ -43,7 +43,6 @@ function makeArchivedExperience(): Experience {
     priceCop: 50000,
     durationHours: 2,
     capacity: 5,
-    coverImageUrl: 'https://example.com/img.jpg',
     location: { label: 'Lobby', lat: 4.6097, lng: -74.0817 },
     availabilityType: ExperienceAvailabilityType.create(
       ExperienceAvailabilityTypeEnum.DATE_RANGE,

--- a/test/application/experience/create-experience.handler.spec.ts
+++ b/test/application/experience/create-experience.handler.spec.ts
@@ -37,7 +37,6 @@ function makeCommand(
     overrides?.priceCop ?? 100000,
     overrides?.durationHours ?? 2,
     overrides?.capacity ?? 8,
-    overrides?.coverImageUrl ?? 'https://cdn.example.com/transport.jpg',
     overrides?.location ?? {
       label: 'Main lobby',
       lat: 4.6097,
@@ -50,6 +49,7 @@ function makeCommand(
     overrides?.blackoutRanges,
     overrides?.allowStandalonePurchase ?? true,
     overrides?.allowReservationPurchase ?? true,
+    overrides?.mediaKeys,
     overrides?.actorId ?? 'user-123',
     overrides?.actorEmail ?? 'host@example.com',
   );

--- a/test/application/experience/get-available-experience-by-id.spec.ts
+++ b/test/application/experience/get-available-experience-by-id.spec.ts
@@ -33,7 +33,6 @@ function makeExperience(status: 'ACTIVE' | 'ARCHIVED' = 'ACTIVE') {
     priceCop: 120000,
     durationHours: 2,
     capacity: 8,
-    coverImageUrl: 'https://image.example.com/cover.jpg',
     location: {
       label: 'Main lobby',
       address: 'Cra 10 #20-30, Bogota',
@@ -70,6 +69,7 @@ describe('GetAvailableExperienceByIdQueryHandler', () => {
       experienceRepository,
       propertyRepository,
       unitRepository,
+      { getPublicUrl: (k: string) => k } as any,
     );
     propertyRepository.findById.mockResolvedValue(null);
     unitRepository.findByIds.mockResolvedValue([]);

--- a/test/application/experience/get-available-experiences.query-handler.spec.ts
+++ b/test/application/experience/get-available-experiences.query-handler.spec.ts
@@ -14,7 +14,9 @@ describe('GetAvailableExperiencesQueryHandler', () => {
 
   beforeEach(() => {
     experienceRepository = createExperienceRepositoryMock();
-    handler = new GetAvailableExperiencesQueryHandler(experienceRepository);
+    handler = new GetAvailableExperiencesQueryHandler(experienceRepository, {
+      getPublicUrl: (k: string) => k,
+    } as any);
   });
 
   describe('with no filters', () => {

--- a/test/application/experience/get-experiences-by-tenant.spec.ts
+++ b/test/application/experience/get-experiences-by-tenant.spec.ts
@@ -40,7 +40,6 @@ function makeExperience(overrides?: Partial<{ id: string; tenantId: string }>) {
     priceCop: 120000,
     durationHours: 2,
     capacity: 8,
-    coverImageUrl: 'https://image.example.com/cover.jpg',
     location: {
       label: 'Main lobby',
       address: 'Cra 10 #20-30, Bogota',
@@ -77,11 +76,16 @@ describe('GetExperiencesByTenant', () => {
     propertyRepository = createPropertyRepositoryMock();
     unitRepository = createUnitRepositoryMock();
 
-    handler = new GetExperiencesByTenantQueryHandler(experienceRepository);
+    const storage = { getPublicUrl: (k: string) => k } as any;
+    handler = new GetExperiencesByTenantQueryHandler(
+      experienceRepository,
+      storage,
+    );
     getByIdHandler = new GetExperienceByIdQueryHandler(
       experienceRepository,
       propertyRepository,
       unitRepository,
+      storage,
     );
 
     const module: TestingModule = await Test.createTestingModule({

--- a/test/application/experience/update-experience.handler.spec.ts
+++ b/test/application/experience/update-experience.handler.spec.ts
@@ -52,7 +52,6 @@ function makeExperience(overrides?: {
     priceCop: 120000,
     durationHours: 2,
     capacity: 8,
-    coverImageUrl: 'https://image.example.com/cover.jpg',
     location: {
       label: 'Main lobby',
       lat: 4.6097,

--- a/test/presentation/controllers/guest-experience.controller.spec.ts
+++ b/test/presentation/controllers/guest-experience.controller.spec.ts
@@ -21,7 +21,7 @@ describe('GuestExperienceController', () => {
     priceCop: 100000,
     durationHours: 3,
     capacity: 10,
-    coverImageUrl: 'https://img',
+    mediaUrls: ['https://img'],
     location: { label: 'Dock', address: 'Address', lat: 1, lng: 2 },
     availabilityType: 'DATE_RANGE',
     startAt: null,

--- a/test/shared/fixtures/experience.fixture.ts
+++ b/test/shared/fixtures/experience.fixture.ts
@@ -30,7 +30,6 @@ export const EXPERIENCE_FIXTURE_DEFAULTS = {
   priceCop: 120000,
   durationHours: 2,
   capacity: 8,
-  coverImageUrl: 'https://cdn.example.com/experience-cover.jpg',
   location: { label: 'Main lobby', lat: 4.6097, lng: -74.0817 },
 };
 
@@ -54,7 +53,6 @@ export function makeExperience(
     priceCop: merged.priceCop,
     durationHours: merged.durationHours,
     capacity: merged.capacity,
-    coverImageUrl: merged.coverImageUrl,
     location: merged.location,
     availabilityType: ExperienceAvailabilityType.create(
       ExperienceAvailabilityTypeEnum.DATE_RANGE,


### PR DESCRIPTION
## Summary
Moves image access off **URLs stored in the database** and onto **R2 object keys**. The DB now persists keys (stable identifiers); the public URL is derived at read time (`R2_PUBLIC_URL + key`). This makes image URLs disposable — we can rotate the CDN/bucket via one env var with no data migration, deletes/orphan-cleanup work off keys, and signed/private URLs stay possible later.

Builds on the presigned-upload foundation (LYMON-1035/1036/1037).

## What changed, by area

### Experience
- Reads now return `mediaUrls: string[]`, derived from stored keys.
- Create accepts `mediaKeys`.
- **Removed `coverImageUrl` entirely** — cover is now `mediaUrls[0]` by convention. Touches entity, schema, repo, DTOs, mapper, and the guest catalog.

### Unit
- Create accepts `mediaKeys`; all five read paths now expose `mediaUrls`.
- (Write side + orphan cleanup already existed.)

### Property
- New single image via `imageKey` (one string, not an array).
- Reads expose `imageUrl` (or `null`); update deletes the previous R2 object when the image is replaced.

## Client contract
| Entity | Write | Read |
|---|---|---|
| Experience | `mediaKeys: [...]` (cover = `[0]`) | `mediaUrls: string[]` |
| Unit | `mediaKeys: [...]` | `mediaUrls: string[]` |
| Property | `imageKey: "..."` | `imageUrl: string \| null` |

`mediaKeys` is replace-all on update — send the full desired list; omitted keys are 
`mediaKeys` is replace-all on update — send the full desired list; omitted keys are treated as orphaned and deleted from R2.

