### PR TITLE
LYMON-1064 Location and DurationHours fields are optional

### DIFF
--- a/src/application/experience/commands/create-experience.command.ts
+++ b/src/application/experience/commands/create-experience.command.ts
@@ -2,10 +2,10 @@ import { ExperienceAvailabilityTypeEnum } from '@/domain/experience/value-object
 import { ExperienceCategoryEnum } from '@/domain/experience/value-objects/experience-category.vo';
 
 export interface CreateExperienceLocationInput {
-  label: string;
+  label?: string;
   address?: string;
-  lat: number;
-  lng: number;
+  lat?: number;
+  lng?: number;
 }
 
 export interface CreateExperienceBlackoutRangeInput {
@@ -28,11 +28,11 @@ export class CreateExperienceCommand {
     public readonly description: string,
     public readonly category: ExperienceCategoryEnum,
     public readonly priceCop: number,
-    public readonly durationHours: number,
+    public readonly durationHours: number | undefined,
     public readonly minimumParticipants: number | undefined,
     public readonly capacity: number,
     public readonly coverImageUrl: string,
-    public readonly location: CreateExperienceLocationInput,
+    public readonly location: CreateExperienceLocationInput | undefined,
     public readonly availabilityType: ExperienceAvailabilityTypeEnum,
     public readonly startAt: string | undefined,
     public readonly endAt: string | undefined,

--- a/src/application/experience/commands/create-experience.handler.ts
+++ b/src/application/experience/commands/create-experience.handler.ts
@@ -162,12 +162,7 @@ export class CreateExperienceHandler implements ICommandHandler<CreateExperience
         minimumParticipants: command.minimumParticipants,
         capacity: command.capacity,
         coverImageUrl: command.coverImageUrl,
-        location: {
-          label: command.location.label,
-          address: command.location.address,
-          lat: command.location.lat,
-          lng: command.location.lng,
-        },
+        location: command.location,
         availabilityType: ExperienceAvailabilityType.create(
           command.availabilityType,
         ),

--- a/src/application/experience/queries/shared/experience-read.dto.ts
+++ b/src/application/experience/queries/shared/experience-read.dto.ts
@@ -1,9 +1,9 @@
 export class PublicExperienceLocationDto {
   constructor(
-    public readonly label: string,
+    public readonly label: string | undefined,
     public readonly address: string | undefined,
-    public readonly lat: number,
-    public readonly lng: number,
+    public readonly lat: number | undefined,
+    public readonly lng: number | undefined,
   ) {}
 }
 
@@ -41,11 +41,11 @@ export class PublicExperienceDto {
     public readonly description: string,
     public readonly category: string,
     public readonly priceCop: number,
-    public readonly durationHours: number,
+    public readonly durationHours: number | null,
     public readonly minimumParticipants: number,
     public readonly capacity: number,
     public readonly coverImageUrl: string,
-    public readonly location: PublicExperienceLocationDto,
+    public readonly location: PublicExperienceLocationDto | null,
     public readonly availabilityType: string,
     public readonly startAt: Date | null,
     public readonly endAt: Date | null,

--- a/src/application/experience/queries/shared/experience.mapper.ts
+++ b/src/application/experience/queries/shared/experience.mapper.ts
@@ -10,6 +10,7 @@ export function mapExperienceToPublicDto(
   experience: Experience,
 ): PublicExperienceDto {
   const recurrence = experience.getRecurrence();
+  const location = experience.getLocation();
 
   return new PublicExperienceDto(
     experience.getId()!.toString(),
@@ -24,12 +25,14 @@ export function mapExperienceToPublicDto(
     experience.getMinimumParticipants(),
     experience.getCapacity(),
     experience.getCoverImageUrl(),
-    new PublicExperienceLocationDto(
-      experience.getLocation().label,
-      experience.getLocation().address,
-      experience.getLocation().lat,
-      experience.getLocation().lng,
-    ),
+    location
+      ? new PublicExperienceLocationDto(
+          location.label,
+          location.address,
+          location.lat,
+          location.lng,
+        )
+      : null,
     experience.getAvailabilityType().toString(),
     experience.getStartAt(),
     experience.getEndAt(),

--- a/src/domain/experience/entities/experience.entity.ts
+++ b/src/domain/experience/entities/experience.entity.ts
@@ -11,10 +11,10 @@ import { ExperienceStatus } from '@/domain/experience/value-objects/experience-s
 import { DomainException } from '@/domain/shared/exceptions/domain.exception';
 
 export interface ExperienceLocation {
-  label: string;
+  label?: string;
   address?: string;
-  lat: number;
-  lng: number;
+  lat?: number;
+  lng?: number;
 }
 
 export interface ExperienceBlackoutRange {
@@ -36,11 +36,11 @@ export interface ExperienceProps {
   description: string;
   category: ExperienceCategory;
   priceCop: number;
-  durationHours: number;
+  durationHours?: number | null;
   minimumParticipants?: number;
   capacity: number;
   coverImageUrl: string;
-  location: ExperienceLocation;
+  location?: ExperienceLocation | null;
   availabilityType: ExperienceAvailabilityType;
   startAt?: Date;
   endAt?: Date;
@@ -60,11 +60,11 @@ export interface ExperienceReconstituteData {
   description: string;
   category: ExperienceCategory;
   priceCop: number;
-  durationHours: number;
+  durationHours?: number | null;
   minimumParticipants?: number;
   capacity: number;
   coverImageUrl: string;
-  location: ExperienceLocation;
+  location?: ExperienceLocation | null;
   availabilityType: ExperienceAvailabilityType;
   startAt?: Date;
   endAt?: Date;
@@ -84,11 +84,11 @@ export interface ExperienceChanges {
   name?: string;
   description?: string;
   priceCop?: number;
-  durationHours?: number;
+  durationHours?: number | null;
   minimumParticipants?: number;
   capacity?: number;
   coverImageUrl?: string;
-  location?: ExperienceLocation;
+  location?: ExperienceLocation | null;
   availabilityType?: ExperienceAvailabilityTypeEnum;
   startAt?: Date;
   endAt?: Date;
@@ -109,11 +109,11 @@ export class Experience {
     private description: string,
     private readonly category: ExperienceCategory,
     private priceCop: number,
-    private durationHours: number,
+    private durationHours: number | null,
     private minimumParticipants: number,
     private capacity: number,
     private coverImageUrl: string,
-    private location: ExperienceLocation,
+    private location: ExperienceLocation | null,
     private availabilityType: ExperienceAvailabilityType,
     private startAt: Date | null,
     private endAt: Date | null,
@@ -151,9 +151,7 @@ export class Experience {
       throw new Error('Experience price must be greater than zero');
     }
 
-    if (!Number.isFinite(props.durationHours) || props.durationHours <= 0) {
-      throw new Error('Experience duration must be greater than zero');
-    }
+    Experience.validateDurationHours(props.durationHours);
 
     const minimumParticipants = props.minimumParticipants ?? 1;
     Experience.validateParticipantLimits(minimumParticipants, props.capacity);
@@ -166,7 +164,7 @@ export class Experience {
       throw new Error('unitIds require propertyId');
     }
 
-    Experience.validateLocation(props.location);
+    const location = Experience.normalizeLocation(props.location);
     Experience.validateAvailability(
       props.availabilityType,
       props.startAt,
@@ -185,16 +183,11 @@ export class Experience {
       description,
       props.category,
       props.priceCop,
-      props.durationHours,
+      props.durationHours ?? null,
       minimumParticipants,
       props.capacity,
       props.coverImageUrl,
-      {
-        label: props.location.label.trim(),
-        address: props.location.address?.trim() || undefined,
-        lat: props.location.lat,
-        lng: props.location.lng,
-      },
+      location,
       props.availabilityType,
       props.startAt ?? null,
       props.endAt ?? null,
@@ -222,11 +215,11 @@ export class Experience {
       data.description,
       data.category,
       data.priceCop,
-      data.durationHours,
+      data.durationHours ?? null,
       data.minimumParticipants ?? 1,
       data.capacity,
       data.coverImageUrl,
-      data.location,
+      data.location ?? null,
       data.availabilityType,
       data.startAt ?? null,
       data.endAt ?? null,
@@ -276,7 +269,7 @@ export class Experience {
     return this.priceCop;
   }
 
-  getDurationHours(): number {
+  getDurationHours(): number | null {
     return this.durationHours;
   }
 
@@ -292,7 +285,7 @@ export class Experience {
     return this.coverImageUrl;
   }
 
-  getLocation(): ExperienceLocation {
+  getLocation(): ExperienceLocation | null {
     return this.location;
   }
 
@@ -372,10 +365,11 @@ export class Experience {
       throw new Error('Experience price must be greater than zero');
     }
 
-    const durationHours = changes.durationHours ?? this.durationHours;
-    if (!Number.isFinite(durationHours) || durationHours <= 0) {
-      throw new Error('Experience duration must be greater than zero');
-    }
+    const durationHours =
+      changes.durationHours === undefined
+        ? this.durationHours
+        : changes.durationHours;
+    Experience.validateDurationHours(durationHours);
 
     const minimumParticipants =
       changes.minimumParticipants ?? this.minimumParticipants;
@@ -390,8 +384,10 @@ export class Experience {
       throw new Error('Experience must be purchasable in at least one mode');
     }
 
-    const location = changes.location ?? this.location;
-    Experience.validateLocation(location);
+    const location =
+      changes.location === undefined
+        ? this.location
+        : Experience.mergeLocation(this.location, changes.location);
 
     const availabilityType = changes.availabilityType
       ? ExperienceAvailabilityType.create(changes.availabilityType)
@@ -417,12 +413,7 @@ export class Experience {
     this.minimumParticipants = minimumParticipants;
     this.capacity = capacity;
     this.coverImageUrl = changes.coverImageUrl ?? this.coverImageUrl;
-    this.location = {
-      label: location.label.trim(),
-      address: location.address?.trim() || undefined,
-      lat: location.lat,
-      lng: location.lng,
-    };
+    this.location = location;
     this.availabilityType = availabilityType;
     this.startAt = startAt ?? null;
     this.endAt = endAt ?? null;
@@ -474,29 +465,68 @@ export class Experience {
     }
 
     if (minimumParticipants > capacity) {
-      throw new Error(
-        'Experience minimum participants cannot exceed capacity',
-      );
+      throw new Error('Experience minimum participants cannot exceed capacity');
     }
   }
 
-  private static validateLocation(location: ExperienceLocation): void {
-    if (!location?.label || location.label.trim() === '') {
-      throw new Error('Experience location label cannot be empty');
+  private static validateDurationHours(
+    durationHours: number | null | undefined,
+  ): void {
+    if (durationHours === null || durationHours === undefined) {
+      return;
     }
 
+    if (!Number.isFinite(durationHours) || durationHours <= 0) {
+      throw new Error('Experience duration must be greater than zero');
+    }
+  }
+
+  private static normalizeLocation(
+    location: ExperienceLocation | null | undefined,
+  ): ExperienceLocation | null {
+    if (!location) {
+      return null;
+    }
+
+    Experience.validateLocation(location);
+
+    return {
+      label: location.label?.trim() || undefined,
+      address: location.address?.trim() || undefined,
+      lat: location.lat,
+      lng: location.lng,
+    };
+  }
+
+  private static mergeLocation(
+    current: ExperienceLocation | null,
+    changes: ExperienceLocation | null,
+  ): ExperienceLocation | null {
+    if (changes === null) {
+      return null;
+    }
+
+    return Experience.normalizeLocation({
+      ...(current ?? {}),
+      ...changes,
+    });
+  }
+
+  private static validateLocation(location: ExperienceLocation): void {
     if (
-      !Number.isFinite(location.lat) ||
-      location.lat < -90 ||
-      location.lat > 90
+      location.lat !== undefined &&
+      (!Number.isFinite(location.lat) ||
+        location.lat < -90 ||
+        location.lat > 90)
     ) {
       throw new Error('Experience location latitude is invalid');
     }
 
     if (
-      !Number.isFinite(location.lng) ||
-      location.lng < -180 ||
-      location.lng > 180
+      location.lng !== undefined &&
+      (!Number.isFinite(location.lng) ||
+        location.lng < -180 ||
+        location.lng > 180)
     ) {
       throw new Error('Experience location longitude is invalid');
     }

--- a/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
@@ -210,12 +210,14 @@ export class MongoExperienceRepository implements ExperienceRepository {
       minimumParticipants: document.minimumParticipants ?? 1,
       capacity: document.capacity,
       coverImageUrl: document.coverImageUrl,
-      location: {
-        label: document.location.label,
-        address: document.location.address,
-        lat: document.location.lat,
-        lng: document.location.lng,
-      },
+      location: document.location
+        ? {
+            label: document.location.label,
+            address: document.location.address,
+            lat: document.location.lat,
+            lng: document.location.lng,
+          }
+        : null,
       availabilityType: ExperienceAvailabilityType.create(
         document.availabilityType,
       ),

--- a/src/infrastructure/persistence/schemas/experience.schema.ts
+++ b/src/infrastructure/persistence/schemas/experience.schema.ts
@@ -27,17 +27,17 @@ class ExperienceBlackoutRangeSchema {
 
 @Schema({ _id: false })
 class ExperienceLocationSchema {
-  @Prop({ required: true })
-  label: string;
+  @Prop()
+  label?: string;
 
   @Prop()
   address?: string;
 
-  @Prop({ type: Number, required: true })
-  lat: number;
+  @Prop({ type: Number })
+  lat?: number;
 
-  @Prop({ type: Number, required: true })
-  lng: number;
+  @Prop({ type: Number })
+  lng?: number;
 }
 
 @Schema({ collection: 'experiences', timestamps: true })
@@ -73,8 +73,8 @@ export class ExperienceDocument extends Document {
   @Prop({ required: true })
   priceCop: number;
 
-  @Prop({ required: true })
-  durationHours: number;
+  @Prop({ type: Number, default: null })
+  durationHours: number | null;
 
   @Prop({ required: true, default: 1 })
   minimumParticipants: number;
@@ -85,8 +85,8 @@ export class ExperienceDocument extends Document {
   @Prop({ required: true })
   coverImageUrl: string;
 
-  @Prop({ type: ExperienceLocationSchema, required: true })
-  location: ExperienceLocationSchema;
+  @Prop({ type: ExperienceLocationSchema, default: null })
+  location: ExperienceLocationSchema | null;
 
   @Prop({ required: true, enum: ExperienceAvailabilityTypeEnum })
   availabilityType: string;

--- a/src/presentation/controllers/guest-experience.controller.ts
+++ b/src/presentation/controllers/guest-experience.controller.ts
@@ -96,12 +96,14 @@ export class GuestExperienceController {
       minimumParticipants: experience.minimumParticipants,
       capacity: experience.capacity,
       coverImageUrl: experience.coverImageUrl,
-      location: new PublicExperienceLocationDto(
-        experience.location.label,
-        experience.location.address,
-        experience.location.lat,
-        experience.location.lng,
-      ),
+      location: experience.location
+        ? new PublicExperienceLocationDto(
+            experience.location.label,
+            experience.location.address,
+            experience.location.lat,
+            experience.location.lng,
+          )
+        : null,
       availabilityType: experience.availabilityType,
       startAt: experience.startAt,
       endAt: experience.endAt,
@@ -132,11 +134,11 @@ interface PublicExperienceCatalogDto {
   description: string;
   category: string;
   priceCop: number;
-  durationHours: number;
+  durationHours: number | null;
   minimumParticipants: number;
   capacity: number;
   coverImageUrl: string;
-  location: PublicExperienceLocationDto;
+  location: PublicExperienceLocationDto | null;
   availabilityType: string;
   startAt: Date | null;
   endAt: Date | null;

--- a/src/presentation/dtos/experience/create-experience.dto.ts
+++ b/src/presentation/dtos/experience/create-experience.dto.ts
@@ -20,13 +20,13 @@ import { ExperienceCategoryEnum } from '@/domain/experience/value-objects/experi
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 class ExperienceLocationDto {
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: 'Main lobby pickup point',
     description: 'Short place label shown to guests',
   })
   @IsString()
-  @IsNotEmpty()
-  label!: string;
+  @IsOptional()
+  label?: string;
 
   @ApiPropertyOptional({
     example: 'Cra 10 #20-30, Bogota',
@@ -36,17 +36,19 @@ class ExperienceLocationDto {
   @IsOptional()
   address?: string;
 
-  @ApiProperty({ example: 4.6097, minimum: -90, maximum: 90 })
+  @ApiPropertyOptional({ example: 4.6097, minimum: -90, maximum: 90 })
   @IsNumber()
   @Min(-90)
   @Max(90)
-  lat!: number;
+  @IsOptional()
+  lat?: number;
 
-  @ApiProperty({ example: -74.0817, minimum: -180, maximum: 180 })
+  @ApiPropertyOptional({ example: -74.0817, minimum: -180, maximum: 180 })
   @IsNumber()
   @Min(-180)
   @Max(180)
-  lng!: number;
+  @IsOptional()
+  lng?: number;
 }
 
 class ExperienceRecurrenceDto {
@@ -138,10 +140,11 @@ export class CreateExperienceDto {
   @Min(0.01)
   priceCop!: number;
 
-  @ApiProperty({ example: 2, minimum: 0.1 })
+  @ApiPropertyOptional({ example: 2, minimum: 0.1 })
   @IsNumber()
   @Min(0.1)
-  durationHours!: number;
+  @IsOptional()
+  durationHours?: number;
 
   @ApiPropertyOptional({
     example: 2,
@@ -163,10 +166,11 @@ export class CreateExperienceDto {
   @IsUrl()
   coverImageUrl!: string;
 
-  @ApiProperty({ type: () => ExperienceLocationDto })
+  @ApiPropertyOptional({ type: () => ExperienceLocationDto })
   @ValidateNested()
   @Type(() => ExperienceLocationDto)
-  location!: ExperienceLocationDto;
+  @IsOptional()
+  location?: ExperienceLocationDto;
 
   @ApiProperty({
     enum: ExperienceAvailabilityTypeEnum,

--- a/src/presentation/dtos/experience/update-experience.dto.ts
+++ b/src/presentation/dtos/experience/update-experience.dto.ts
@@ -21,8 +21,8 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 class UpdateExperienceLocationDto {
   @ApiPropertyOptional({ example: 'Main lobby pickup point' })
   @IsString()
-  @IsNotEmpty()
-  label!: string;
+  @IsOptional()
+  label?: string;
 
   @ApiPropertyOptional({ example: 'Cra 10 #20-30, Bogota' })
   @IsString()
@@ -33,13 +33,15 @@ class UpdateExperienceLocationDto {
   @IsNumber()
   @Min(-90)
   @Max(90)
-  lat!: number;
+  @IsOptional()
+  lat?: number;
 
   @ApiPropertyOptional({ example: -74.0817, minimum: -180, maximum: 180 })
   @IsNumber()
   @Min(-180)
   @Max(180)
-  lng!: number;
+  @IsOptional()
+  lng?: number;
 }
 
 class UpdateExperienceRecurrenceDto {

--- a/test/application/experience/create-experience.handler.spec.ts
+++ b/test/application/experience/create-experience.handler.spec.ts
@@ -24,6 +24,10 @@ function makeCommand(
 ): CreateExperienceCommand {
   const hasPropertyIdOverride =
     overrides !== undefined && Object.hasOwn(overrides, 'propertyId');
+  const hasDurationHoursOverride =
+    overrides !== undefined && Object.hasOwn(overrides, 'durationHours');
+  const hasLocationOverride =
+    overrides !== undefined && Object.hasOwn(overrides, 'location');
 
   return new CreateExperienceCommand(
     overrides?.tenantId ?? '65f1a1a2b3c4d5e6f7a8b9c0',
@@ -33,15 +37,17 @@ function makeCommand(
     overrides?.description ?? 'Roundtrip transportation service',
     overrides?.category ?? ExperienceCategoryEnum.TRANSPORTATION,
     overrides?.priceCop ?? 100000,
-    overrides?.durationHours ?? 2,
+    hasDurationHoursOverride ? overrides?.durationHours : 2,
     overrides?.minimumParticipants,
     overrides?.capacity ?? 8,
     overrides?.coverImageUrl ?? 'https://cdn.example.com/transport.jpg',
-    overrides?.location ?? {
-      label: 'Main lobby',
-      lat: 4.6097,
-      lng: -74.0817,
-    },
+    hasLocationOverride
+      ? overrides?.location
+      : {
+          label: 'Main lobby',
+          lat: 4.6097,
+          lng: -74.0817,
+        },
     overrides?.availabilityType ?? ExperienceAvailabilityTypeEnum.DATE_RANGE,
     overrides?.startAt ?? '2099-01-10T10:00:00.000Z',
     overrides?.endAt ?? '2099-01-20T10:00:00.000Z',
@@ -119,5 +125,17 @@ describe('CreateExperienceHandler', () => {
     expect(result).toBeInstanceOf(CreateExperienceResult);
     expect(result.experienceId).toBe(EXPERIENCE_ID);
     expect(eventEmitter.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates experience without durationHours or location', async () => {
+    propertyRepository.findById.mockResolvedValue(makeProperty());
+    experienceRepository.existsByPropertyIdAndName.mockResolvedValue(false);
+    experienceRepository.save.mockResolvedValue(EXPERIENCE_ID);
+
+    await expect(
+      handler.execute(
+        makeCommand({ durationHours: undefined, location: undefined }),
+      ),
+    ).resolves.toBeInstanceOf(CreateExperienceResult);
   });
 });


### PR DESCRIPTION
durationHours can now be omitted and is saved/returned as null if it's not included.

location can now be omitted entirely; in public responses, it returns as null.

location.label, address, lat, and lng are no longer required if location is sent.

MongoDB persistence now accepts durationHours as null and location as null. 

Mappers no longer assume experience.location.label, preventing errors when a location is missing.

Tests have been added to create an experience without durationHours or location.