### PR TITLE
LYMON-1053 Add tenant endpoint to list experience purchases

### DIFF
--- a/src/application/application.module.ts
+++ b/src/application/application.module.ts
@@ -42,6 +42,7 @@ import { StorageApplicationModule } from '@/application/storage/storage-applicat
 import { UnitRatingApplicationModule } from '@/application/unit-rating/unit-rating-application.module';
 import { CartApplicationModule } from '@/application/cart/cart-application.module';
 import { RefundApplicationModule } from '@/application/refund/refund-application.module';
+import { ExperiencePurchaseApplicationModule } from '@/application/experience-purchase/experience-purchase-application.module';
 import { ProcessWompiWebhookHandler } from '@/application/payment/commands/process-wompi-webhook/process-wompi-webhook.handler';
 import { GetPaymentSessionStatusHandler } from '@/application/payment/queries/get-payment-session-status/get-payment-session-status.handler';
 import { CompleteTutorialHandler } from '@/application/user/commands/complete-tutorial/complete-tutorial.handler';
@@ -98,6 +99,7 @@ const QueryHandlers = [GetShiftsHandler];
     UnitRatingApplicationModule,
     CartApplicationModule,
     RefundApplicationModule,
+    ExperiencePurchaseApplicationModule,
   ],
   providers: [...CommandHandlers, ...QueryHandlers, RoleAssignmentValidator],
   exports: [

--- a/src/application/experience-purchase/experience-purchase-application.module.ts
+++ b/src/application/experience-purchase/experience-purchase-application.module.ts
@@ -3,10 +3,12 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { PersistenceModule } from '@/infrastructure/persistence/persistence.module';
 import { GetExperiencePurchasesByGuestHandler } from '@/application/experience-purchase/queries/get-experience-purchases-by-guest/get-experience-purchases-by-guest.handler';
 import { GetExperiencePurchaseByIdHandler } from '@/application/experience-purchase/queries/get-experience-purchase-by-id/get-experience-purchase-by-id.handler';
+import { GetExperiencePurchasesByTenantHandler } from '@/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.handler';
 
 const QueryHandlers = [
   GetExperiencePurchasesByGuestHandler,
   GetExperiencePurchaseByIdHandler,
+  GetExperiencePurchasesByTenantHandler,
 ];
 
 @Module({

--- a/src/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.handler.ts
+++ b/src/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.handler.ts
@@ -1,0 +1,53 @@
+import { Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import {
+  EXPERIENCE_PURCHASE_REPOSITORY,
+  type ExperiencePurchaseRepository,
+  type TenantExperiencePurchaseFilters,
+} from '@/domain/experience-purchase/repositories/experience-purchase.repository';
+import { GetExperiencePurchasesByTenantQuery } from './get-experience-purchases-by-tenant.query';
+import { GetExperiencePurchasesByTenantResult } from './get-experience-purchases-by-tenant.result';
+
+@QueryHandler(GetExperiencePurchasesByTenantQuery)
+export class GetExperiencePurchasesByTenantHandler implements IQueryHandler<GetExperiencePurchasesByTenantQuery> {
+  constructor(
+    @Inject(EXPERIENCE_PURCHASE_REPOSITORY)
+    private readonly purchaseRepository: ExperiencePurchaseRepository,
+  ) {}
+
+  async execute(
+    query: GetExperiencePurchasesByTenantQuery,
+  ): Promise<GetExperiencePurchasesByTenantResult> {
+    const tenantId = TenantId.createFromString(query.tenantId);
+    const filters = this.buildFilters(query);
+
+    const [purchases, total] = await Promise.all([
+      this.purchaseRepository.findByTenantIdPaginated(
+        tenantId,
+        query.page,
+        query.limit,
+        filters,
+      ),
+      this.purchaseRepository.countByTenantId(tenantId, filters),
+    ]);
+
+    return new GetExperiencePurchasesByTenantResult(
+      purchases,
+      total,
+      query.page,
+      query.limit,
+    );
+  }
+
+  private buildFilters(
+    query: GetExperiencePurchasesByTenantQuery,
+  ): TenantExperiencePurchaseFilters {
+    return {
+      experienceId: query.experienceId,
+      dateFrom: query.dateFrom ? new Date(query.dateFrom) : undefined,
+      dateTo: query.dateTo ? new Date(query.dateTo) : undefined,
+      status: query.status,
+    };
+  }
+}

--- a/src/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.query.ts
+++ b/src/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.query.ts
@@ -1,0 +1,13 @@
+import { ExperiencePurchaseStatusEnum } from '@/domain/experience-purchase/value-objects/experience-purchase-status.vo';
+
+export class GetExperiencePurchasesByTenantQuery {
+  constructor(
+    readonly tenantId: string,
+    readonly page: number = 1,
+    readonly limit: number = 20,
+    readonly experienceId?: string,
+    readonly dateFrom?: string,
+    readonly dateTo?: string,
+    readonly status?: ExperiencePurchaseStatusEnum,
+  ) {}
+}

--- a/src/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.result.ts
+++ b/src/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.result.ts
@@ -1,0 +1,25 @@
+export interface TenantExperiencePurchaseDto {
+  id: string;
+  experienceId: string;
+  experienceName: string;
+  guestAccountId: string;
+  guestName: string;
+  purchasedAt: Date;
+  scheduledDate: Date | null;
+  quantity: number;
+  totalPriceCop: number;
+  status: string;
+}
+
+export class GetExperiencePurchasesByTenantResult {
+  readonly totalPages: number;
+
+  constructor(
+    readonly purchases: TenantExperiencePurchaseDto[],
+    readonly total: number,
+    readonly page: number,
+    readonly limit: number,
+  ) {
+    this.totalPages = Math.ceil(total / limit);
+  }
+}

--- a/src/domain/experience-purchase/repositories/experience-purchase.repository.ts
+++ b/src/domain/experience-purchase/repositories/experience-purchase.repository.ts
@@ -3,8 +3,29 @@ import { ExperiencePurchaseId } from '@/domain/experience-purchase/value-objects
 import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
 import { TransactionContextData } from '@/domain/shared/transaction-manager.interface';
+import { ExperiencePurchaseStatusEnum } from '@/domain/experience-purchase/value-objects/experience-purchase-status.vo';
 
 export const EXPERIENCE_PURCHASE_REPOSITORY = 'EXPERIENCE_PURCHASE_REPOSITORY';
+
+export interface TenantExperiencePurchaseFilters {
+  experienceId?: string;
+  dateFrom?: Date;
+  dateTo?: Date;
+  status?: ExperiencePurchaseStatusEnum;
+}
+
+export interface TenantExperiencePurchaseReadModel {
+  id: string;
+  experienceId: string;
+  experienceName: string;
+  guestAccountId: string;
+  guestName: string;
+  purchasedAt: Date;
+  scheduledDate: Date | null;
+  quantity: number;
+  totalPriceCop: number;
+  status: string;
+}
 
 export interface ExperiencePurchaseRepository {
   save(
@@ -21,6 +42,16 @@ export interface ExperiencePurchaseRepository {
   countByGuestAccountId(
     guestAccountId: GuestAccountId,
     tenantId: TenantId,
+  ): Promise<number>;
+  findByTenantIdPaginated(
+    tenantId: TenantId,
+    page: number,
+    limit: number,
+    filters?: TenantExperiencePurchaseFilters,
+  ): Promise<TenantExperiencePurchaseReadModel[]>;
+  countByTenantId(
+    tenantId: TenantId,
+    filters?: TenantExperiencePurchaseFilters,
   ): Promise<number>;
   countConfirmedByExperienceAndDate(
     experienceId: string,

--- a/src/infrastructure/persistence/repositories/mongo-experience-purchase.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience-purchase.repository.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { ClientSession, Model, Types } from 'mongoose';
-import type { ExperiencePurchaseRepository } from '@/domain/experience-purchase/repositories/experience-purchase.repository';
+import { ClientSession, Model, PipelineStage, Types } from 'mongoose';
+import type {
+  ExperiencePurchaseRepository,
+  TenantExperiencePurchaseFilters,
+  TenantExperiencePurchaseReadModel,
+} from '@/domain/experience-purchase/repositories/experience-purchase.repository';
 import { ExperiencePurchase } from '@/domain/experience-purchase/entities/experience-purchase.entity';
 import { ExperiencePurchaseId } from '@/domain/experience-purchase/value-objects/experience-purchase-id.vo';
 import {
@@ -96,6 +100,45 @@ export class MongoExperiencePurchaseRepository implements ExperiencePurchaseRepo
     });
   }
 
+  async findByTenantIdPaginated(
+    tenantId: TenantId,
+    page: number,
+    limit: number,
+    filters?: TenantExperiencePurchaseFilters,
+  ): Promise<TenantExperiencePurchaseReadModel[]> {
+    const match = this.buildTenantFilter(tenantId, filters);
+    const docs =
+      await this.purchaseModel.aggregate<TenantPurchaseAggregationResult>([
+        { $match: match },
+        { $sort: { createdAt: -1 } },
+        { $skip: (page - 1) * limit },
+        { $limit: limit },
+        ...this.tenantPurchaseLookupStages(),
+      ]);
+
+    return docs.map((doc) => ({
+      id: doc._id.toString(),
+      experienceId: doc.experienceId.toString(),
+      experienceName: doc.experience?.name ?? 'Unknown experience',
+      guestAccountId: doc.guestAccountId.toString(),
+      guestName: doc.guestAccount?.fullName ?? 'Unknown guest',
+      purchasedAt: doc.createdAt,
+      scheduledDate: doc.selectedDate ?? null,
+      quantity: doc.quantity,
+      totalPriceCop: doc.totalPriceCop,
+      status: doc.status,
+    }));
+  }
+
+  async countByTenantId(
+    tenantId: TenantId,
+    filters?: TenantExperiencePurchaseFilters,
+  ): Promise<number> {
+    return this.purchaseModel.countDocuments(
+      this.buildTenantFilter(tenantId, filters),
+    );
+  }
+
   async countConfirmedByExperienceAndDate(
     experienceId: string,
     selectedDate: Date | null,
@@ -114,6 +157,69 @@ export class MongoExperiencePurchaseRepository implements ExperiencePurchaseRepo
       filter.selectedDate = null;
     }
     return this.purchaseModel.countDocuments(filter);
+  }
+
+  private buildTenantFilter(
+    tenantId: TenantId,
+    filters?: TenantExperiencePurchaseFilters,
+  ): TenantPurchaseFilter {
+    const match: TenantPurchaseFilter = {
+      tenantId: new Types.ObjectId(tenantId.toString()),
+    };
+
+    if (filters?.experienceId) {
+      match.experienceId = new Types.ObjectId(filters.experienceId);
+    }
+
+    if (filters?.status) {
+      match.status = filters.status;
+    }
+
+    if (filters?.dateFrom || filters?.dateTo) {
+      const selectedDate: Record<string, Date> = {};
+      if (filters.dateFrom) {
+        selectedDate.$gte = filters.dateFrom;
+      }
+      if (filters.dateTo) {
+        selectedDate.$lte = filters.dateTo;
+      }
+      match.selectedDate = selectedDate;
+    }
+
+    return match;
+  }
+
+  private tenantPurchaseLookupStages(): PipelineStage[] {
+    return [
+      {
+        $lookup: {
+          from: 'experiences',
+          localField: 'experienceId',
+          foreignField: '_id',
+          as: 'experience',
+        },
+      },
+      {
+        $unwind: {
+          path: '$experience',
+          preserveNullAndEmptyArrays: true,
+        },
+      },
+      {
+        $lookup: {
+          from: 'guest_accounts',
+          localField: 'guestAccountId',
+          foreignField: '_id',
+          as: 'guestAccount',
+        },
+      },
+      {
+        $unwind: {
+          path: '$guestAccount',
+          preserveNullAndEmptyArrays: true,
+        },
+      },
+    ];
   }
 
   private toDomainEntity(doc: ExperiencePurchaseDocument): ExperiencePurchase {
@@ -138,3 +244,30 @@ export class MongoExperiencePurchaseRepository implements ExperiencePurchaseRepo
     });
   }
 }
+
+interface TenantPurchaseAggregationResult {
+  _id: Types.ObjectId;
+  experienceId: Types.ObjectId;
+  experience?: {
+    name?: string;
+  };
+  guestAccountId: Types.ObjectId;
+  guestAccount?: {
+    fullName?: string;
+  };
+  createdAt: Date;
+  selectedDate: Date | null;
+  quantity: number;
+  totalPriceCop: number;
+  status: string;
+}
+
+type TenantPurchaseFilter = {
+  tenantId: Types.ObjectId;
+  experienceId?: Types.ObjectId;
+  status?: ExperiencePurchaseStatusEnum;
+  selectedDate?: {
+    $gte?: Date;
+    $lte?: Date;
+  };
+};

--- a/src/infrastructure/persistence/schemas/experience-purchase.schema.ts
+++ b/src/infrastructure/persistence/schemas/experience-purchase.schema.ts
@@ -61,4 +61,6 @@ ExperiencePurchaseSchema.index({
   tenantId: 1,
   createdAt: -1,
 });
+ExperiencePurchaseSchema.index({ tenantId: 1, createdAt: -1 });
+ExperiencePurchaseSchema.index({ tenantId: 1, selectedDate: 1, status: 1 });
 ExperiencePurchaseSchema.index({ experienceId: 1, selectedDate: 1, status: 1 });

--- a/src/presentation/controllers/experience-purchases.controller.ts
+++ b/src/presentation/controllers/experience-purchases.controller.ts
@@ -1,0 +1,106 @@
+import { GetExperiencePurchasesByTenantQuery } from '@/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.query';
+import { GetExperiencePurchasesByTenantResult } from '@/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.result';
+import { type JwtPayload } from '@/application/auth/services/jwt.service';
+import { ExperiencePurchaseStatusEnum } from '@/domain/experience-purchase/value-objects/experience-purchase-status.vo';
+import { Permission } from '@/domain/role/value-objects/permission.vo';
+import { CurrentUser } from '@/infrastructure/auth/decorators/current-user.decorator';
+import { RequirePermission } from '@/infrastructure/auth/decorators/require-permission.decorator';
+import { JwtAuthGuard } from '@/infrastructure/auth/guards/jwt-auth.guard';
+import { PermissionGuard } from '@/infrastructure/auth/guards/permission.guard';
+import { GetExperiencePurchasesDto } from '@/presentation/dtos/experience-purchase/get-experience-purchases.dto';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+
+@ApiTags('experience-purchases')
+@ApiBearerAuth('JWT-auth')
+@Controller('experience-purchases')
+export class ExperiencePurchasesController {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @RequirePermission(Permission.PROPERTY_VIEW)
+  @ApiOperation({
+    summary: 'List experience purchases for the authenticated tenant',
+  })
+  @ApiQuery({
+    name: 'experienceId',
+    required: false,
+    type: String,
+    description: 'Optional experience filter',
+  })
+  @ApiQuery({
+    name: 'dateFrom',
+    required: false,
+    type: String,
+    description: 'Optional scheduled date range start',
+  })
+  @ApiQuery({
+    name: 'dateTo',
+    required: false,
+    type: String,
+    description: 'Optional scheduled date range end',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ExperiencePurchaseStatusEnum,
+    description: 'Optional purchase status filter',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number for pagination',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Items per page (default: 20)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Experience purchases retrieved successfully',
+  })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async findAll(
+    @CurrentUser() user: JwtPayload,
+    @Query() query: GetExperiencePurchasesDto,
+  ) {
+    const result = await this.queryBus.execute<
+      GetExperiencePurchasesByTenantQuery,
+      GetExperiencePurchasesByTenantResult
+    >(
+      new GetExperiencePurchasesByTenantQuery(
+        user.tenantId,
+        query.page ?? 1,
+        query.limit ?? 20,
+        query.experienceId,
+        query.dateFrom,
+        query.dateTo,
+        query.status,
+      ),
+    );
+
+    return {
+      message: 'Experience purchases retrieved successfully',
+      data: {
+        purchases: result.purchases,
+        pagination: {
+          total: result.total,
+          page: result.page,
+          limit: result.limit,
+          totalPages: result.totalPages,
+        },
+      },
+    };
+  }
+}

--- a/src/presentation/dtos/experience-purchase/get-experience-purchases.dto.ts
+++ b/src/presentation/dtos/experience-purchase/get-experience-purchases.dto.ts
@@ -1,0 +1,42 @@
+import { Type } from 'class-transformer';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { ExperiencePurchaseStatusEnum } from '@/domain/experience-purchase/value-objects/experience-purchase-status.vo';
+
+export class GetExperiencePurchasesDto {
+  @IsOptional()
+  @IsString()
+  experienceId?: string;
+
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @IsOptional()
+  @IsEnum(ExperiencePurchaseStatusEnum)
+  status?: ExperiencePurchaseStatusEnum;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/presentation/presentation.module.ts
+++ b/src/presentation/presentation.module.ts
@@ -26,6 +26,8 @@ import { StorageController } from '@/presentation/controllers/storage.controller
 import { UnitRatingController } from '@/presentation/controllers/unit-rating.controller';
 import { GuestCartController } from '@/presentation/controllers/guest-cart.controller';
 import { RefundController } from '@/presentation/controllers/refund.controller';
+import { GuestExperiencePurchasesController } from '@/presentation/controllers/guest-experience-purchases.controller';
+import { ExperiencePurchasesController } from '@/presentation/controllers/experience-purchases.controller';
 
 @Module({
   imports: [CqrsModule, ApplicationModule],
@@ -55,6 +57,8 @@ import { RefundController } from '@/presentation/controllers/refund.controller';
     UnitRatingController,
     GuestCartController,
     RefundController,
+    GuestExperiencePurchasesController,
+    ExperiencePurchasesController,
   ],
 })
 export class PresentationModule {}

--- a/test/application/experience-purchase/get-experience-purchases-by-tenant.handler.spec.ts
+++ b/test/application/experience-purchase/get-experience-purchases-by-tenant.handler.spec.ts
@@ -1,0 +1,119 @@
+import { QueryBus } from '@nestjs/cqrs';
+import { ExperiencePurchasesController } from '@/presentation/controllers/experience-purchases.controller';
+import { GetExperiencePurchasesByTenantHandler } from '@/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.handler';
+import { GetExperiencePurchasesByTenantQuery } from '@/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.query';
+import { GetExperiencePurchasesByTenantResult } from '@/application/experience-purchase/queries/get-experience-purchases-by-tenant/get-experience-purchases-by-tenant.result';
+import type { ExperiencePurchaseRepository } from '@/domain/experience-purchase/repositories/experience-purchase.repository';
+import { ExperiencePurchaseStatusEnum } from '@/domain/experience-purchase/value-objects/experience-purchase-status.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+import { createExperiencePurchaseRepositoryMock } from '@test/shared/mocks/repositories/experience-purchase-repository.mock';
+
+const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9c0';
+const EXPERIENCE_ID = '65f1a1a2b3c4d5e6f7a8b9c1';
+
+describe('GetExperiencePurchasesByTenant', () => {
+  let handler: GetExperiencePurchasesByTenantHandler;
+  let repository: jest.Mocked<ExperiencePurchaseRepository>;
+  let controller: ExperiencePurchasesController;
+  let queryBus: { execute: jest.Mock };
+
+  beforeEach(() => {
+    repository = createExperiencePurchaseRepositoryMock();
+    handler = new GetExperiencePurchasesByTenantHandler(repository);
+    queryBus = { execute: jest.fn() };
+    controller = new ExperiencePurchasesController(
+      queryBus as unknown as QueryBus,
+    );
+  });
+
+  it('handler returns paginated tenant purchases with filters', async () => {
+    const purchase = {
+      id: 'purchase-1',
+      experienceId: EXPERIENCE_ID,
+      experienceName: 'Coffee tasting',
+      guestAccountId: 'guest-1',
+      guestName: 'Ada Lovelace',
+      purchasedAt: new Date('2026-06-01T10:00:00.000Z'),
+      scheduledDate: new Date('2026-06-10T15:00:00.000Z'),
+      quantity: 2,
+      totalPriceCop: 120000,
+      status: ExperiencePurchaseStatusEnum.CONFIRMED,
+    };
+    repository.findByTenantIdPaginated.mockResolvedValue([purchase]);
+    repository.countByTenantId.mockResolvedValue(1);
+
+    const result = await handler.execute(
+      new GetExperiencePurchasesByTenantQuery(
+        TENANT_ID,
+        1,
+        20,
+        EXPERIENCE_ID,
+        '2026-06-01T00:00:00.000Z',
+        '2026-06-30T23:59:59.999Z',
+        ExperiencePurchaseStatusEnum.CONFIRMED,
+      ),
+    );
+
+    expect(result).toBeInstanceOf(GetExperiencePurchasesByTenantResult);
+    expect(result.purchases).toEqual([purchase]);
+    expect(result.totalPages).toBe(1);
+    expect(repository.findByTenantIdPaginated).toHaveBeenCalledWith(
+      expect.any(TenantId),
+      1,
+      20,
+      {
+        experienceId: EXPERIENCE_ID,
+        dateFrom: new Date('2026-06-01T00:00:00.000Z'),
+        dateTo: new Date('2026-06-30T23:59:59.999Z'),
+        status: ExperiencePurchaseStatusEnum.CONFIRMED,
+      },
+    );
+    expect(repository.countByTenantId).toHaveBeenCalledWith(
+      expect.any(TenantId),
+      expect.objectContaining({
+        experienceId: EXPERIENCE_ID,
+        status: ExperiencePurchaseStatusEnum.CONFIRMED,
+      }),
+    );
+  });
+
+  it('controller dispatches query with authenticated tenant and returns envelope', async () => {
+    const result = new GetExperiencePurchasesByTenantResult(
+      [
+        {
+          id: 'purchase-1',
+          experienceId: EXPERIENCE_ID,
+          experienceName: 'Coffee tasting',
+          guestAccountId: 'guest-1',
+          guestName: 'Ada Lovelace',
+          purchasedAt: new Date('2026-06-01T10:00:00.000Z'),
+          scheduledDate: null,
+          quantity: 1,
+          totalPriceCop: 60000,
+          status: ExperiencePurchaseStatusEnum.PENDING,
+        },
+      ],
+      1,
+      1,
+      20,
+    );
+    queryBus.execute.mockResolvedValue(result);
+
+    const response = await controller.findAll({ tenantId: TENANT_ID } as any, {
+      experienceId: EXPERIENCE_ID,
+      status: ExperiencePurchaseStatusEnum.PENDING,
+      page: 1,
+      limit: 20,
+    });
+
+    expect(queryBus.execute).toHaveBeenCalledWith(
+      expect.any(GetExperiencePurchasesByTenantQuery),
+    );
+    const dispatched = queryBus.execute.mock
+      .calls[0][0] as GetExperiencePurchasesByTenantQuery;
+    expect(dispatched.tenantId).toBe(TENANT_ID);
+    expect(dispatched.experienceId).toBe(EXPERIENCE_ID);
+    expect(response.data.purchases[0].guestName).toBe('Ada Lovelace');
+    expect(response.data.pagination.totalPages).toBe(1);
+  });
+});

--- a/test/shared/mocks/repositories/experience-purchase-repository.mock.ts
+++ b/test/shared/mocks/repositories/experience-purchase-repository.mock.ts
@@ -6,6 +6,8 @@ export function createExperiencePurchaseRepositoryMock(): jest.Mocked<Experience
     findById: jest.fn(),
     findByGuestAccountId: jest.fn(),
     countByGuestAccountId: jest.fn(),
+    findByTenantIdPaginated: jest.fn(),
+    countByTenantId: jest.fn(),
     countConfirmedByExperienceAndDate: jest.fn(),
   };
 }


### PR DESCRIPTION
**What needs to be done**

Currently, there is no way for a tenant admin to see the experience purchases made by guests for their property. Only guests can see their own purchases. We need to create a new endpoint that allows tenant staff to list all experience purchases for their tenant.

**How it should work**

New endpoint: GET /experience-purchases (authenticated with staff JWT)

The endpoint should return a paginated list of experience purchases for the authenticated tenant. Each item should include:

Purchase ID

Experience name

Guest name

Date of purchase

Scheduled date (if applicable)

Number of participants (quantity)

Total amount paid

Purchase status

Optional filters: by experience, by date range, by status.

**Why it matters**

Tenant admins need to see who has purchased experiences so they can prepare, manage capacity, and provide a good service on the day of the acti

- Implemented GET /experience-purchases for staff JWT users.