### PR TITLE
LYMON-1080 feat(units): add name query param to GET /units/public

### DIFF
--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query-handler.ts
@@ -44,6 +44,8 @@ export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
         1000, // Un límite razonable para filtrado en memoria
         query.minGuests,
         query.propertyId,
+        undefined,
+        query.name,
       );
 
       const availableUnits: Unit[] = [];
@@ -88,6 +90,7 @@ export class GetAllPublicUnitsQueryHandler implements IQueryHandler<
       query.minGuests,
       query.propertyId,
       query.sortByPrice,
+      query.name,
     );
     const dtos = units.map((u) => mapUnitToPublicDto(u, (k) => this.storage.getPublicUrl(k)));
 

--- a/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query.ts
+++ b/src/application/unit/queries/GetAllPublicUnits/get-all-public-units.query.ts
@@ -9,5 +9,6 @@ export class GetAllPublicUnitsQuery implements IQuery {
     public readonly startDate?: Date,
     public readonly endDate?: Date,
     public readonly sortByPrice?: 'asc' | 'desc',
+    public readonly name?: string,
   ) {}
 }

--- a/src/domain/unit/repositories/unit.repository.ts
+++ b/src/domain/unit/repositories/unit.repository.ts
@@ -29,6 +29,7 @@ export interface UnitRepository {
     minGuests?: number,
     propertyId?: string,
     sortByPrice?: 'asc' | 'desc',
+    name?: string,
   ): Promise<{ units: Unit[]; total: number }>;
   findByIds(ids: UnitId[]): Promise<Unit[]>;
 }

--- a/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-unit.repository.ts
@@ -130,6 +130,7 @@ export class MongoUnitRepository implements UnitRepository {
     minGuests?: number,
     propertyId?: string,
     sortByPrice?: 'asc' | 'desc',
+    name?: string,
   ): Promise<{ units: Unit[]; total: number }> {
     const filter: any = { deletedAt: null };
     if (minGuests !== undefined) {
@@ -137,6 +138,9 @@ export class MongoUnitRepository implements UnitRepository {
     }
     if (propertyId) {
       filter.propertyId = new Types.ObjectId(propertyId);
+    }
+    if (name) {
+      filter.name = { $regex: name.trim(), $options: 'i' };
     }
     const total = await this.unitModel.countDocuments(filter);
     const sortOrder: Record<string, 1 | -1> = sortByPrice

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -208,30 +208,25 @@ export class UnitController {
   async getAllPublic(
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
-    @Query('minGuests') minGuests?: string,
-    @Query('propertyId') propertyId?: string,
-    @Query('startDate') startDate?: string,
-    @Query('endDate') endDate?: string,
-    @Query('sortByPrice') sortByPrice?: string,
-    @Query('name') name?: string,
+    @Query() filters: { minGuests?: string; propertyId?: string; startDate?: string; endDate?: string; sortByPrice?: string; name?: string },
   ) {
     const { minGuestsNum, start, end } = this.parsePublicUnitFilters(
-      minGuests,
-      startDate,
-      endDate,
+      filters.minGuests,
+      filters.startDate,
+      filters.endDate,
     );
     const priceSortDir =
-      sortByPrice === 'asc' || sortByPrice === 'desc' ? sortByPrice : undefined;
+      filters.sortByPrice === 'asc' || filters.sortByPrice === 'desc' ? filters.sortByPrice : undefined;
 
     const query = new GetAllPublicUnitsQuery(
       page,
       limit,
       minGuestsNum,
-      propertyId,
+      filters.propertyId,
       start,
       end,
       priceSortDir,
-      name,
+      filters.name,
     );
 
     const result = await this.queryBus.execute<

--- a/src/presentation/controllers/unit.controller.ts
+++ b/src/presentation/controllers/unit.controller.ts
@@ -198,6 +198,12 @@ export class UnitController {
     enum: ['asc', 'desc'],
     description: 'Sort units by price per night',
   })
+  @ApiQuery({
+    name: 'name',
+    required: false,
+    type: String,
+    description: 'Filter units by name (case-insensitive substring match)',
+  })
   @ApiResponse({ status: 200, description: 'Units retrieved successfully' })
   async getAllPublic(
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
@@ -207,6 +213,7 @@ export class UnitController {
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
     @Query('sortByPrice') sortByPrice?: string,
+    @Query('name') name?: string,
   ) {
     const { minGuestsNum, start, end } = this.parsePublicUnitFilters(
       minGuests,
@@ -224,6 +231,7 @@ export class UnitController {
       start,
       end,
       priceSortDir,
+      name,
     );
 
     const result = await this.queryBus.execute<


### PR DESCRIPTION
## Summary
- Adds optional `name` query parameter to `GET /units/public`
- Filters units by case-insensitive substring match against the unit name (MongoDB `$regex`)
- Works for both paths: standard DB-paginated and date-range availability paths