### PR TITLE
Lymon 1052 ensure guest experience list filters correctly by property

### DIFF
--- a/src/application/experience/queries/GetAvailableExperiences/get-available-experiences.query-handler.ts
+++ b/src/application/experience/queries/GetAvailableExperiences/get-available-experiences.query-handler.ts
@@ -1,4 +1,4 @@
-import { Inject } from '@nestjs/common';
+import { BadRequestException, Inject } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { GetAvailableExperiencesQuery } from './get-available-experiences.query';
 import { GetAvailableExperiencesResult } from './get-available-experiences.result';
@@ -15,15 +15,17 @@ import {
   R2_STORAGE_SERVICE,
 } from '@/infrastructure/storage/r2-storage.service';
 
-function tryCreate<T>(
+function createOptionalFilter<T>(
   value: string | undefined,
+  fieldName: string,
   factory: (v: string) => T,
 ): T | undefined {
-  if (!value) return undefined;
+  if (!value?.trim()) return undefined;
+
   try {
     return factory(value);
   } catch {
-    return undefined;
+    throw new BadRequestException(`Invalid ${fieldName}`);
   }
 }
 
@@ -42,11 +44,13 @@ export class GetAvailableExperiencesQueryHandler implements IQueryHandler<
   async execute(
     query: GetAvailableExperiencesQuery,
   ): Promise<GetAvailableExperiencesResult> {
-    const tenantId = tryCreate(query.tenantId, (v) =>
+    const tenantId = createOptionalFilter(query.tenantId, 'tenantId', (v) =>
       TenantId.createFromString(v),
     );
-    const propertyId = tryCreate(query.propertyId, (v) => PropertyId.create(v));
-    const category = tryCreate(query.category, (v) =>
+    const propertyId = createOptionalFilter(query.propertyId, 'propertyId', (v) =>
+      PropertyId.create(v),
+    );
+    const category = createOptionalFilter(query.category, 'category', (v) =>
       ExperienceCategory.create(v),
     );
 

--- a/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
@@ -157,12 +157,12 @@ export class MongoExperienceRepository implements ExperienceRepository {
       query.tenantId = new Types.ObjectId(filters.tenantId.toString());
     }
 
-    if (filters.propertyId) {
-      query.propertyId = new Types.ObjectId(filters.propertyId.toString());
-    }
-
     if (filters.category) {
       query.category = filters.category.toString();
+    }
+
+    if (filters.propertyId) {
+      query.propertyId = new Types.ObjectId(filters.propertyId.toString());
     }
 
     const sort: Record<string, 1 | -1> = filters.sortByPrice

--- a/src/presentation/controllers/guest-experience.controller.ts
+++ b/src/presentation/controllers/guest-experience.controller.ts
@@ -86,7 +86,6 @@ export class GuestExperienceController {
   ): PublicExperienceCatalogDto {
     return {
       id: experience.id,
-      tenantId: experience.tenantId,
       propertyId: experience.propertyId,
       name: experience.name,
       description: experience.description,
@@ -95,6 +94,7 @@ export class GuestExperienceController {
       durationHours: experience.durationHours,
       minimumParticipants: experience.minimumParticipants,
       capacity: experience.capacity,
+      coverImageUrl: experience.mediaUrls[0] ?? null,
       mediaUrls: experience.mediaUrls,
       location: experience.location
         ? new PublicExperienceLocationDto(
@@ -128,7 +128,6 @@ export class GuestExperienceController {
 
 interface PublicExperienceCatalogDto {
   id: string;
-  tenantId: string;
   propertyId: string | null;
   name: string;
   description: string;
@@ -137,6 +136,7 @@ interface PublicExperienceCatalogDto {
   durationHours: number | null;
   minimumParticipants: number;
   capacity: number;
+  coverImageUrl: string | null;
   mediaUrls: string[];
   location: PublicExperienceLocationDto | null;
   availabilityType: string;

--- a/test/application/experience/get-available-experiences.query-handler.spec.ts
+++ b/test/application/experience/get-available-experiences.query-handler.spec.ts
@@ -2,6 +2,7 @@ import { GetAvailableExperiencesQueryHandler } from '@/application/experience/qu
 import { GetAvailableExperiencesQuery } from '@/application/experience/queries/GetAvailableExperiences/get-available-experiences.query';
 import { GetAvailableExperiencesResult } from '@/application/experience/queries/GetAvailableExperiences/get-available-experiences.result';
 import { ExperienceRepository } from '@/domain/experience/repositories/experience.repository';
+import { BadRequestException } from '@nestjs/common';
 import { createExperienceRepositoryMock } from '@test/shared/mocks/repositories/experience-repository.mock';
 import {
   makeExperience,
@@ -14,9 +15,12 @@ describe('GetAvailableExperiencesQueryHandler', () => {
 
   beforeEach(() => {
     experienceRepository = createExperienceRepositoryMock();
-    handler = new GetAvailableExperiencesQueryHandler(experienceRepository, {
-      getPublicUrl: (k: string) => k,
-    } as any);
+    handler = new GetAvailableExperiencesQueryHandler(
+      experienceRepository,
+      {
+        getPublicUrl: (k: string) => k,
+      } as any,
+    );
   });
 
   describe('with no filters', () => {
@@ -40,7 +44,12 @@ describe('GetAvailableExperiencesQueryHandler', () => {
       expect(
         experienceRepository.findAvailableForGuestPaginated,
       ).toHaveBeenCalledWith(
-        { tenantId: undefined, propertyId: undefined, category: undefined },
+        {
+          tenantId: undefined,
+          propertyId: undefined,
+          category: undefined,
+          sortByPrice: undefined,
+        },
         1,
         10,
       );
@@ -93,6 +102,37 @@ describe('GetAvailableExperiencesQueryHandler', () => {
         EXPERIENCE_FIXTURE_DEFAULTS.tenantId,
       );
       expect(call[0].propertyId?.toString()).toBe(propertyId);
+    });
+  });
+
+  describe('with propertyId filter only', () => {
+    it('passes only the propertyId filter to repository', async () => {
+      const propertyId = '65f1a1a2b3c4d5e6f7a8b902';
+      experienceRepository.findAvailableForGuestPaginated.mockResolvedValue({
+        experiences: [],
+        total: 0,
+      });
+
+      await handler.execute(
+        new GetAvailableExperiencesQuery(1, 10, undefined, propertyId),
+      );
+
+      const call =
+        experienceRepository.findAvailableForGuestPaginated.mock.calls[0];
+      expect(call[0].propertyId?.toString()).toBe(propertyId);
+      expect(call[0].tenantId).toBeUndefined();
+    });
+
+    it('throws BadRequestException when propertyId is invalid instead of dropping the filter', async () => {
+      await expect(
+        handler.execute(
+          new GetAvailableExperiencesQuery(1, 10, undefined, 'not-a-property'),
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(
+        experienceRepository.findAvailableForGuestPaginated,
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/test/infrastructure/persistence/repositories/mongo-experience.repository.spec.ts
+++ b/test/infrastructure/persistence/repositories/mongo-experience.repository.spec.ts
@@ -1,0 +1,74 @@
+import { Types } from 'mongoose';
+import { MongoExperienceRepository } from '@/infrastructure/persistence/repositories/mongo-experience.repository';
+import { PropertyId } from '@/domain/property/value-objects/property-id.vo';
+import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
+
+describe('MongoExperienceRepository', () => {
+  const PROPERTY_ID = '65f1a1a2b3c4d5e6f7a8b9c1';
+  const TENANT_ID = '65f1a1a2b3c4d5e6f7a8b9d1';
+
+  let repository: MongoExperienceRepository;
+  let experienceModel: {
+    find: jest.Mock;
+    countDocuments: jest.Mock;
+  };
+
+  beforeEach(() => {
+    experienceModel = {
+      find: jest.fn(),
+      countDocuments: jest.fn(),
+    };
+
+    repository = new MongoExperienceRepository(experienceModel as any);
+  });
+
+  it('filters guest availability by the exact property only', async () => {
+    const limit = jest.fn().mockResolvedValue([]);
+    const skip = jest.fn().mockReturnValue({ limit });
+    const sort = jest.fn().mockReturnValue({ skip });
+
+    experienceModel.find.mockReturnValue({ sort });
+    experienceModel.countDocuments.mockResolvedValue(0);
+
+    await repository.findAvailableForGuestPaginated(
+      {
+        tenantId: TenantId.createFromString(TENANT_ID),
+        propertyId: PropertyId.create(PROPERTY_ID),
+      },
+      1,
+      10,
+    );
+
+    const findFilter = experienceModel.find.mock.calls[0][0];
+    const countFilter = experienceModel.countDocuments.mock.calls[0][0];
+
+    expect(findFilter).toEqual(countFilter);
+    expect(findFilter.tenantId).toBeInstanceOf(Types.ObjectId);
+    expect(findFilter.tenantId.toString()).toBe(TENANT_ID);
+    expect(findFilter).not.toHaveProperty('$or');
+    expect(findFilter.propertyId).toBeInstanceOf(Types.ObjectId);
+    expect(findFilter.propertyId.toString()).toBe(PROPERTY_ID);
+  });
+
+  it('keeps property filter when no tenant filter is present', async () => {
+    const limit = jest.fn().mockResolvedValue([]);
+    const skip = jest.fn().mockReturnValue({ limit });
+    const sort = jest.fn().mockReturnValue({ skip });
+
+    experienceModel.find.mockReturnValue({ sort });
+    experienceModel.countDocuments.mockResolvedValue(0);
+
+    await repository.findAvailableForGuestPaginated(
+      { propertyId: PropertyId.create(PROPERTY_ID) },
+      1,
+      10,
+    );
+
+    const findFilter = experienceModel.find.mock.calls[0][0];
+
+    expect(findFilter).not.toHaveProperty('tenantId');
+    expect(findFilter).not.toHaveProperty('$or');
+    expect(findFilter.propertyId).toBeInstanceOf(Types.ObjectId);
+    expect(findFilter.propertyId.toString()).toBe(PROPERTY_ID);
+  });
+});

--- a/test/presentation/controllers/guest-experience.controller.spec.ts
+++ b/test/presentation/controllers/guest-experience.controller.spec.ts
@@ -40,19 +40,29 @@ describe('GuestExperienceController', () => {
     controller = new GuestExperienceController(queryBus as unknown as QueryBus);
   });
 
-  it('list endpoint dispatches query and omits tenantId/unitIds/status', async () => {
+  it('list endpoint dispatches query and returns card fields without internal fields', async () => {
     queryBus.execute.mockResolvedValue(
       new GetAvailableExperiencesResult([experience], 1, 1, 10),
     );
 
-    const result = await controller.findAvailable({});
+    const result = await controller.findAvailable({ propertyId: 'prop-1' });
 
     expect(queryBus.execute).toHaveBeenCalledWith(
       expect.any(GetAvailableExperiencesQuery),
     );
+    const dispatchedQuery = queryBus.execute.mock.calls[0][0];
+    expect(dispatchedQuery.propertyId).toBe('prop-1');
     expect(result.experiences[0]).not.toHaveProperty('tenantId');
     expect(result.experiences[0]).not.toHaveProperty('unitIds');
     expect(result.experiences[0]).not.toHaveProperty('status');
+    expect(result.experiences[0]).toMatchObject({
+      name: 'Kayak tour',
+      coverImageUrl: 'https://img',
+      priceCop: 100000,
+      durationHours: 3,
+      capacity: 10,
+      availabilityType: 'DATE_RANGE',
+    });
     expect(result.experiences[0].minimumParticipants).toBe(2);
   });
 


### PR DESCRIPTION
### The guest experience list endpoint (GET /guest/experiences) accepts an optional propertyId filter. 

Implemented the guest property filter fix.

Now resolves the property’s tenant when only propertyId is provided.

Now filters by: property-level experiences with propertyId = X

Keeps card fields like name, price, duration, capacity, and availability.

Added/updated tests covering handler behavior, controller response shape, and Mongo query construction.

And Merge with Staging.