### PR TITLE
LYMON-1050 Guest my reservations shows checked-in reservations as confirmed instead of checked-in

### DIFF
--- a/src/application/reservation/queries/get-guest-reservations/get-guest-reservations.query-handler.ts
+++ b/src/application/reservation/queries/get-guest-reservations/get-guest-reservations.query-handler.ts
@@ -4,6 +4,7 @@ import { GetGuestReservationsQuery } from './get-guest-reservations.query';
 import {
   GetGuestReservationsResult,
   GuestReservationListItemDto,
+  GuestReservationStatus,
 } from './get-guest-reservations.result';
 import {
   GUEST_RESERVATIONS_READ_REPOSITORY,
@@ -139,12 +140,12 @@ export class GetGuestReservationsHandler implements IQueryHandler<
     );
   }
 
-  private toGuestStatus(
-    status: ReservationStatusEnum,
-  ): 'confirmed' | 'pending' | 'cancelled' | 'completed' {
+  private toGuestStatus(status: ReservationStatusEnum): GuestReservationStatus {
     switch (status) {
       case ReservationStatusEnum.PENDING:
         return 'pending';
+      case ReservationStatusEnum.CHECKED_IN:
+        return 'checked_in';
       case ReservationStatusEnum.CANCELLED:
       case ReservationStatusEnum.NO_SHOW:
         return 'cancelled';

--- a/src/application/reservation/queries/get-guest-reservations/get-guest-reservations.result.ts
+++ b/src/application/reservation/queries/get-guest-reservations/get-guest-reservations.result.ts
@@ -1,3 +1,10 @@
+export type GuestReservationStatus =
+  | 'confirmed'
+  | 'pending'
+  | 'checked_in'
+  | 'cancelled'
+  | 'completed';
+
 export interface GuestReservationListItemDto {
   id: string;
   bookingReference: string;
@@ -8,7 +15,7 @@ export interface GuestReservationListItemDto {
   serviceName: string;
   checkIn: Date;
   checkOut: Date;
-  status: 'confirmed' | 'pending' | 'cancelled' | 'completed';
+  status: GuestReservationStatus;
 }
 
 export class GetGuestReservationsResult {

--- a/src/presentation/controllers/guest-reservation.controller.ts
+++ b/src/presentation/controllers/guest-reservation.controller.ts
@@ -51,7 +51,7 @@ export class GuestReservationController {
     name: 'status',
     required: false,
     description:
-      'Filter by status: active, pending, confirmed, finished, cancelled',
+      'Filter by status: active, pending, confirmed, checked_in, finished, cancelled',
   })
   @ApiQuery({
     name: 'page',
@@ -260,6 +260,7 @@ export class GuestReservationController {
     const statusMap: Record<string, ReservationStatusEnum> = {
       pending: ReservationStatusEnum.PENDING,
       confirmed: ReservationStatusEnum.CONFIRMED,
+      checked_in: ReservationStatusEnum.CHECKED_IN,
       cancelled: ReservationStatusEnum.CANCELLED,
       finished: ReservationStatusEnum.CHECKED_OUT,
     };

--- a/test/application/reservation/get-guest-reservations.query-handler.spec.ts
+++ b/test/application/reservation/get-guest-reservations.query-handler.spec.ts
@@ -92,14 +92,23 @@ describe('GetGuestReservationsHandler', () => {
       guestId: GUEST_2_ID,
       propertyId: '65f1a1a2b3c4d5e6f7a8b9cd',
       unitId: '65f1a1a2b3c4d5e6f7a8b9cf',
+      status: ReservationStatusEnum.CHECKED_IN,
+    });
+    const booking3 = makeReservation({
+      id: 'res-3',
+      tenantId: '65f1a1a2b3c4d5e6f7a8b9c9',
+      guestId: GUEST_2_ID,
+      propertyId: '65f1a1a2b3c4d5e6f7a8b9cd',
+      unitId: '65f1a1a2b3c4d5e6f7a8b9cf',
       status: ReservationStatusEnum.CHECKED_OUT,
     });
 
     guestReservationsReadRepository.findByGuestIds.mockResolvedValue([
       booking1,
       booking2,
+      booking3,
     ] as any);
-    guestReservationsReadRepository.countByGuestIds.mockResolvedValue(2 as any);
+    guestReservationsReadRepository.countByGuestIds.mockResolvedValue(3 as any);
     propertyRepository.findByTenantId.mockImplementation((tenantId) => {
       if (tenantId.toString() === '65f1a1a2b3c4d5e6f7a8b9c0') {
         return Promise.resolve([
@@ -138,8 +147,8 @@ describe('GetGuestReservationsHandler', () => {
       [GUEST_1_ID, GUEST_2_ID],
       expect.objectContaining({ page: 1, limit: 10, sortBy: 'createdAt' }),
     );
-    expect(result.total).toBe(2);
-    expect(result.items).toHaveLength(2);
+    expect(result.total).toBe(3);
+    expect(result.items).toHaveLength(3);
     expect(result.items[0]).toMatchObject({
       id: '65f1a1a2b3c4d5e6f7a8b9c3',
       bookingReference: '1',
@@ -148,6 +157,12 @@ describe('GetGuestReservationsHandler', () => {
     });
     expect(result.items[1]).toMatchObject({
       id: 'res-2',
+      bookingReference: '1',
+      propertyId: '65f1a1a2b3c4d5e6f7a8b9cd',
+      status: 'checked_in',
+    });
+    expect(result.items[2]).toMatchObject({
+      id: 'res-3',
       bookingReference: '1',
       propertyId: '65f1a1a2b3c4d5e6f7a8b9cd',
       status: 'completed',

--- a/test/presentation/controllers/guest-reservation.controller.spec.ts
+++ b/test/presentation/controllers/guest-reservation.controller.spec.ts
@@ -3,6 +3,7 @@ import { GuestReservationController } from '@/presentation/controllers/guest-res
 import { GetGuestReservationsQuery } from '@/application/reservation/queries/get-guest-reservations/get-guest-reservations.query';
 import { GetGuestReservationQuery } from '@/application/reservation/queries/get-guest-reservation/get-guest-reservation.query';
 import { GetGuestReservationsResult } from '@/application/reservation/queries/get-guest-reservations/get-guest-reservations.result';
+import { ReservationStatusEnum } from '@/domain/reservation/value-objects/reservation-status.vo';
 
 describe('GuestReservationController', () => {
   let controller: GuestReservationController;
@@ -15,9 +16,11 @@ describe('GuestReservationController', () => {
   } as any;
 
   beforeEach(() => {
+    commandBus = { execute: jest.fn() };
     queryBus = { execute: jest.fn() };
     controller = new GuestReservationController(
       queryBus as unknown as QueryBus,
+      commandBus as unknown as CommandBus,
     );
   });
 
@@ -29,7 +32,7 @@ describe('GuestReservationController', () => {
     const queryParams = {
       page: '2',
       limit: '15',
-      status: 'completed',
+      status: 'checked_in',
       fromDate: '2026-01-01',
       toDate: '2026-02-01',
       sortBy: 'createdAt' as const,
@@ -48,6 +51,7 @@ describe('GuestReservationController', () => {
       guestAccountId: '65f1a1a2b3c4d5e6f7a8b9c5',
       page: 2,
       limit: 15,
+      statuses: [ReservationStatusEnum.CHECKED_IN],
       sortBy: 'createdAt',
       sortOrder: 'desc',
     });


### PR DESCRIPTION
- Maps ReservationStatusEnum.CHECKED_IN to guest-facing checked_in.
- Added checked_in to the response status type.
- Added checked_in to the status filter docs and parser.

Also added regression coverage in the query handler and controller specs.

