### PR TITLE
LYMON-955 feat(crm): add unified guest stats endpoint with include se…

### DIFF
--- a/src/application/guest/guest-application.module.ts
+++ b/src/application/guest/guest-application.module.ts
@@ -8,6 +8,7 @@ import { GetGuestByIdHandler } from './queries/get-guest-by-id/get-guest-by-id.h
 import { GetGuestBookingsHandler } from './queries/get-guest-bookings/get-guest-bookings.handler';
 import { GetGuestMonthlySpendingHandler } from './queries/get-guest-monthly-spending/get-guest-monthly-spending.handler';
 import { GetGuestBookingOriginsHandler } from './queries/get-guest-booking-origins/get-guest-booking-origins.handler';
+import { GetGuestStatsHandler } from './queries/get-guest-stats/get-guest-stats.handler';
 import { CreateGuestHandler } from '@/application/guest/commands/create-guest.handler';
 import { AssignGuestTagsHandler } from './commands/assign-guest-tags.handler';
 import { SaveGuestPreferencesHandler } from './commands/preferences/save-guest-preferences.handler';
@@ -30,6 +31,7 @@ const QueryHandlers = [
   GetGuestMonthlySpendingHandler,
   GetGuestBookingOriginsHandler,
   GetGuestLifecycleStatusHandler,
+  GetGuestStatsHandler,
 ];
 
 @Module({

--- a/src/application/guest/queries/get-guest-stats/get-guest-stats.handler.ts
+++ b/src/application/guest/queries/get-guest-stats/get-guest-stats.handler.ts
@@ -1,0 +1,27 @@
+import { IQueryHandler, QueryHandler, QueryBus } from '@nestjs/cqrs';
+import { GetGuestStatsQuery, GUEST_STAT_QUERIES } from './get-guest-stats.query';
+
+@QueryHandler(GetGuestStatsQuery)
+export class GetGuestStatsHandler implements IQueryHandler<GetGuestStatsQuery> {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  async execute({
+    tenantId,
+    guestId,
+    keys,
+  }: GetGuestStatsQuery): Promise<Record<string, unknown>> {
+    const entries = await Promise.all(
+      keys.map(
+        async (key) =>
+          [
+            key,
+            await this.queryBus.execute(
+              GUEST_STAT_QUERIES[key](tenantId, guestId),
+            ),
+          ] as const,
+      ),
+    );
+
+    return Object.fromEntries(entries);
+  }
+}

--- a/src/application/guest/queries/get-guest-stats/get-guest-stats.query.ts
+++ b/src/application/guest/queries/get-guest-stats/get-guest-stats.query.ts
@@ -1,0 +1,22 @@
+import { GetGuestMonthlySpendingQuery } from '../get-guest-monthly-spending/get-guest-monthly-spending.query';
+import { GetGuestBookingOriginsQuery } from '../get-guest-booking-origins/get-guest-booking-origins.query';
+
+// Guest stat catalog — single source of truth. Every stat takes (tenantId, guestId).
+// Add a stat here and it is instantly selectable via the /stats endpoint. No presentation change.
+export const GUEST_STAT_QUERIES = {
+  monthlySpending: (tenantId: string, guestId: string) =>
+    new GetGuestMonthlySpendingQuery(tenantId, guestId),
+  bookingOrigins: (tenantId: string, guestId: string) =>
+    new GetGuestBookingOriginsQuery(tenantId, guestId),
+} as const;
+
+export type GuestStatKey = keyof typeof GUEST_STAT_QUERIES;
+export const GUEST_STAT_KEYS = Object.keys(GUEST_STAT_QUERIES) as GuestStatKey[];
+
+export class GetGuestStatsQuery {
+  constructor(
+    public readonly tenantId: string,
+    public readonly guestId: string,
+    public readonly keys: readonly GuestStatKey[],
+  ) {}
+}

--- a/src/presentation/controllers/crm.controller.ts
+++ b/src/presentation/controllers/crm.controller.ts
@@ -43,6 +43,11 @@ import { GetGuestMonthlySpendingQuery } from '@/application/guest/queries/get-gu
 import { GetGuestMonthlySpendingResult } from '@/application/guest/queries/get-guest-monthly-spending/get-guest-monthly-spending.result';
 import { GetGuestBookingOriginsQuery } from '@/application/guest/queries/get-guest-booking-origins/get-guest-booking-origins.query';
 import { GetGuestBookingOriginsResult } from '@/application/guest/queries/get-guest-booking-origins/get-guest-booking-origins.result';
+import {
+  GetGuestStatsQuery,
+  GUEST_STAT_KEYS,
+  type GuestStatKey,
+} from '@/application/guest/queries/get-guest-stats/get-guest-stats.query';
 import { SaveGuestPreferencesCommand } from '@/application/guest/commands/preferences/save-guest-preferences.command';
 import { SaveGuestPreferencesResult } from '@/application/guest/commands/preferences/save-guest-preferences.result';
 import { GetGuestEmailsByGuestIdQuery } from '@/application/guest-email/queries/get-guest-emails-by-guest-id/get-guest-emails-by-guest-id.query';
@@ -383,6 +388,42 @@ export class CrmController {
         total: result.total,
         sources: result.sources,
       },
+    };
+  }
+
+  @Get('guests/:guestId/stats')
+  @UseGuards(PermissionGuard)
+  @RequirePermission(Permission.CRM_VIEW)
+  @ApiOperation({
+    summary:
+      'Get guest stats. Pass ?include=monthlySpending,bookingOrigins to select a subset; omit to return all.',
+  })
+  @ApiQuery({
+    name: 'include',
+    required: false,
+    description: 'Comma-separated stat keys. Unknown keys are ignored.',
+  })
+  @ApiResponse({ status: 200, description: 'Guest stats retrieved successfully' })
+  async getGuestStats(
+    @Param('guestId') guestId: string,
+    @CurrentUser() user: JwtPayload,
+    @Query('include') include?: string,
+  ) {
+    // ponytail: unknown keys silently dropped; empty include => all. Add 400 if FE needs strictness.
+    const requested = include
+      ? (include.split(',').map((s) => s.trim()) as string[]).filter(
+          (s): s is GuestStatKey => (GUEST_STAT_KEYS as string[]).includes(s),
+        )
+      : GUEST_STAT_KEYS;
+
+    const data = await this.queryBus.execute<
+      GetGuestStatsQuery,
+      Record<string, unknown>
+    >(new GetGuestStatsQuery(user.tenantId, guestId, requested));
+
+    return {
+      message: 'Guest stats retrieved successfully',
+      data,
     };
   }
 

--- a/test/application/guest/get-guest-stats.handler.spec.ts
+++ b/test/application/guest/get-guest-stats.handler.spec.ts
@@ -1,0 +1,72 @@
+import { Test } from '@nestjs/testing';
+import { CqrsModule, QueryBus } from '@nestjs/cqrs';
+import {
+  GetGuestStatsQuery,
+  GUEST_STAT_KEYS,
+} from '@/application/guest/queries/get-guest-stats/get-guest-stats.query';
+import { GetGuestStatsHandler } from '@/application/guest/queries/get-guest-stats/get-guest-stats.handler';
+import { GetGuestMonthlySpendingHandler } from '@/application/guest/queries/get-guest-monthly-spending/get-guest-monthly-spending.handler';
+import { GetGuestBookingOriginsHandler } from '@/application/guest/queries/get-guest-booking-origins/get-guest-booking-origins.handler';
+import { RESERVATION_REPOSITORY } from '@/domain/reservation/repositories/reservation.repository';
+import { createReservationRepositoryMock } from '@test/shared/mocks/repositories/reservation-repository.mock';
+
+// Guards the catalog↔handler wiring: every key in GUEST_STAT_KEYS must dispatch to a
+// resolvable handler through the real bus. Add a stat to the catalog without registering
+// its handler here (and in guest-application.module) and this fails with "No handler found".
+describe('GetGuestStatsHandler — stat catalog wiring', () => {
+  let queryBus: QueryBus;
+
+  beforeEach(async () => {
+    const reservationRepository = createReservationRepositoryMock();
+    reservationRepository.getMonthlySpendingByGuestId.mockResolvedValue([]);
+    reservationRepository.countByGuestIdGroupedBySource.mockResolvedValue([]);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [CqrsModule],
+      providers: [
+        GetGuestStatsHandler,
+        GetGuestMonthlySpendingHandler,
+        GetGuestBookingOriginsHandler,
+        { provide: RESERVATION_REPOSITORY, useValue: reservationRepository },
+      ],
+    }).compile();
+
+    await moduleRef.init();
+    queryBus = moduleRef.get(QueryBus);
+  });
+
+  it('resolves every catalog key to a handler and returns a value for each', async () => {
+    const data = await queryBus.execute<
+      GetGuestStatsQuery,
+      Record<string, unknown>
+    >(
+      new GetGuestStatsQuery(
+        '65f1a1a2b3c4d5e6f7a8b9c0',
+        '65f1a1a2b3c4d5e6f7a8b9c1',
+        GUEST_STAT_KEYS,
+      ),
+    );
+
+    for (const key of GUEST_STAT_KEYS) {
+      expect(data).toHaveProperty(key);
+    }
+    expect(Object.keys(data)).toHaveLength(GUEST_STAT_KEYS.length);
+  });
+
+  it('returns only the requested subset', async () => {
+    const [firstKey] = GUEST_STAT_KEYS;
+
+    const data = await queryBus.execute<
+      GetGuestStatsQuery,
+      Record<string, unknown>
+    >(
+      new GetGuestStatsQuery(
+        '65f1a1a2b3c4d5e6f7a8b9c0',
+        '65f1a1a2b3c4d5e6f7a8b9c1',
+        [firstKey],
+      ),
+    );
+
+    expect(Object.keys(data)).toEqual([firstKey]);
+  });
+});


### PR DESCRIPTION
Add GET /crm/guests/:guestId/stats returning selectable stats via ?include. Stat catalog and fan-out live in a GetGuestStatsQuery/handler (application layer); presentation only parses include and dispatches. Adding a stat is a one-line catalog edit. Covered by a catalog-wiring test that fails if a stat key has no registered handler.