### PR TITLE
LYMON-1028 feat(reservation): exclude CHECKED_OUT status from availab…

### DIFF
--- a/src/domain/reservation/services/availability-checker.domain-service.ts
+++ b/src/domain/reservation/services/availability-checker.domain-service.ts
@@ -5,6 +5,7 @@ import { Reservation } from '../entities/reservation.entity';
 const INACTIVE_STATUSES = new Set<ReservationStatusEnum>([
   ReservationStatusEnum.CANCELLED,
   ReservationStatusEnum.NO_SHOW,
+  ReservationStatusEnum.CHECKED_OUT,
 ]);
 
 export class AvailabilityChecker {

--- a/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-reservation.repository.ts
@@ -283,7 +283,11 @@ export class MongoReservationRepository
     const docs = await this.reservationModel.find({
       unitId: new Types.ObjectId(unitId.toString()),
       status: {
-        $nin: [ReservationStatusEnum.CANCELLED, ReservationStatusEnum.NO_SHOW],
+        $nin: [
+          ReservationStatusEnum.CANCELLED,
+          ReservationStatusEnum.NO_SHOW,
+          ReservationStatusEnum.CHECKED_OUT,
+        ],
       },
       checkOut: { $gt: fromDate },
     });


### PR DESCRIPTION
This pull request updates how reservation statuses are handled in both the domain service and the MongoDB repository, specifically by treating `CHECKED_OUT` reservations as inactive. This change ensures consistency in business logic when checking availability and querying reservations.

Reservation status handling:

* Added `ReservationStatusEnum.CHECKED_OUT` to the set of inactive statuses in `AvailabilityChecker`, so checked-out reservations are now considered inactive when checking availability.
* Updated the MongoDB reservation query to exclude reservations with the `CHECKED_OUT` status, preventing them from being returned as active reservations.