### PR TITLE
LYMON-1087 fix(reservation): align guest reservation statuses with Re…

### DIFF
--- a/src/application/reservation/queries/get-guest-reservations/get-guest-reservations.query-handler.ts
+++ b/src/application/reservation/queries/get-guest-reservations/get-guest-reservations.query-handler.ts
@@ -4,7 +4,6 @@ import { GetGuestReservationsQuery } from './get-guest-reservations.query';
 import {
   GetGuestReservationsResult,
   GuestReservationListItemDto,
-  GuestReservationStatus,
 } from './get-guest-reservations.result';
 import {
   GUEST_RESERVATIONS_READ_REPOSITORY,
@@ -25,7 +24,6 @@ import {
 import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
 import { Guest } from '@/domain/guest/entities/guest.entity';
 import { TenantId } from '@/domain/tenant/value-objects/tenant-id.vo';
-import { ReservationStatusEnum } from '@/domain/reservation/value-objects/reservation-status.vo';
 
 @QueryHandler(GetGuestReservationsQuery)
 export class GetGuestReservationsHandler implements IQueryHandler<
@@ -127,7 +125,7 @@ export class GetGuestReservationsHandler implements IQueryHandler<
           serviceName: unitName ?? propertyName ?? 'Reservation',
           checkIn: reservation.getDateRange().getCheckIn(),
           checkOut: reservation.getDateRange().getCheckOut(),
-          status: this.toGuestStatus(reservation.getStatus().getValue()),
+          status: reservation.getStatus().getValue(),
         };
       },
     );
@@ -138,21 +136,5 @@ export class GetGuestReservationsHandler implements IQueryHandler<
       query.page,
       query.limit,
     );
-  }
-
-  private toGuestStatus(status: ReservationStatusEnum): GuestReservationStatus {
-    switch (status) {
-      case ReservationStatusEnum.PENDING:
-        return 'pending';
-      case ReservationStatusEnum.CHECKED_IN:
-        return 'checked_in';
-      case ReservationStatusEnum.CANCELLED:
-      case ReservationStatusEnum.NO_SHOW:
-        return 'cancelled';
-      case ReservationStatusEnum.CHECKED_OUT:
-        return 'completed';
-      default:
-        return 'confirmed';
-    }
   }
 }

--- a/src/application/reservation/queries/get-guest-reservations/get-guest-reservations.result.ts
+++ b/src/application/reservation/queries/get-guest-reservations/get-guest-reservations.result.ts
@@ -1,9 +1,6 @@
-export type GuestReservationStatus =
-  | 'confirmed'
-  | 'pending'
-  | 'checked_in'
-  | 'cancelled'
-  | 'completed';
+import { ReservationStatusEnum } from '@/domain/reservation/value-objects/reservation-status.vo';
+
+export type GuestReservationStatus = ReservationStatusEnum;
 
 export interface GuestReservationListItemDto {
   id: string;

--- a/test/application/reservation/get-guest-reservations.query-handler.spec.ts
+++ b/test/application/reservation/get-guest-reservations.query-handler.spec.ts
@@ -153,19 +153,19 @@ describe('GetGuestReservationsHandler', () => {
       id: '65f1a1a2b3c4d5e6f7a8b9c3',
       bookingReference: '1',
       propertyId: '65f1a1a2b3c4d5e6f7a8b9c1',
-      status: 'confirmed',
+      status: ReservationStatusEnum.CONFIRMED,
     });
     expect(result.items[1]).toMatchObject({
       id: 'res-2',
       bookingReference: '1',
       propertyId: '65f1a1a2b3c4d5e6f7a8b9cd',
-      status: 'checked_in',
+      status: ReservationStatusEnum.CHECKED_IN,
     });
     expect(result.items[2]).toMatchObject({
       id: 'res-3',
       bookingReference: '1',
       propertyId: '65f1a1a2b3c4d5e6f7a8b9cd',
-      status: 'completed',
+      status: ReservationStatusEnum.CHECKED_OUT,
     });
   });
 


### PR DESCRIPTION
This pull request refactors how reservation status is represented and handled in the guest reservations query. Instead of mapping internal status enums to string literals, the code now directly uses the `ReservationStatusEnum` throughout the application and its interfaces, simplifying status handling and improving type safety.

**Refactoring and Simplification of Status Handling:**

* The `GuestReservationStatus` type in `get-guest-reservations.result.ts` is now directly set to `ReservationStatusEnum`, removing the need for manual string mapping.
* The `toGuestStatus` method and related mapping logic have been removed from `get-guest-reservations.query-handler.ts`, and the status is now passed through directly as the enum value. [[1]](diffhunk://#diff-0e8502ab97719fde3737948f3dadc3c945074e19e08106fdd86658a160a46a94L130-R128) [[2]](diffhunk://#diff-0e8502ab97719fde3737948f3dadc3c945074e19e08106fdd86658a160a46a94L142-L157)

**Code Cleanup:**

* Unused imports of `GuestReservationStatus` and `ReservationStatusEnum` have been removed from `get-guest-reservations.query-handler.ts`. [[1]](diffhunk://#diff-0e8502ab97719fde3737948f3dadc3c945074e19e08106fdd86658a160a46a94L7) [[2]](diffhunk://#diff-0e8502ab97719fde3737948f3dadc3c945074e19e08106fdd86658a160a46a94L28)

**Test Updates:**

* Unit tests in `get-guest-reservations.query-handler.spec.ts` have been updated to expect `ReservationStatusEnum` values instead of string statuses.