### PR TITLE
LYMON-1098 feat(auth): implement trial expiration logic and guard

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppService } from '@/app.service';
 import { AuthModule } from '@/infrastructure/auth/auth.module';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from '@/infrastructure/auth/guards/jwt-auth.guard';
+import { TrialExpiredGuard } from '@/infrastructure/auth/guards/trial-expired.guard';
 import { AuditInfrastructureModule } from '@/infrastructure/audit/audit-infrastructure.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ReservationInfrastructureModule } from '@/infrastructure/reservation/reservation-infrastructure.module';
@@ -45,6 +46,10 @@ import { PaymentModule } from '@/infrastructure/payment/payment.module';
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: TrialExpiredGuard,
     },
   ],
 })

--- a/src/application/auth/commands/login.handler.ts
+++ b/src/application/auth/commands/login.handler.ts
@@ -1,6 +1,10 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { LoginCommand } from '@/application/auth/commands/login.command';
-import { Inject, UnauthorizedException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Inject,
+  UnauthorizedException,
+} from '@nestjs/common';
 import {
   type UserRepository,
   USER_REPOSITORY,
@@ -45,6 +49,10 @@ export class LoginResult {
     public readonly accessToken: string,
     public readonly refreshToken: string,
     public readonly tutorialCompleted: boolean,
+    public readonly trialWarning: {
+      daysRemaining: number;
+      message: string;
+    } | null,
   ) {}
 }
 
@@ -86,6 +94,12 @@ export class LoginHandler implements ICommandHandler<LoginCommand> {
       throw new UnauthorizedException('Tenant not found');
     }
 
+    if (tenant.isTrialExpired()) {
+      throw new ForbiddenException(
+        'Your free trial ended. Upgrade your plan to continue.',
+      );
+    }
+
     // Resolve role permissions for staff users
     const resolvedAssignments: ResolvedRoleAssignment[] = [];
     for (const assignment of user.getRoleAssignments()) {
@@ -110,6 +124,7 @@ export class LoginHandler implements ICommandHandler<LoginCommand> {
       isOwner: user.isOwner(),
       emailVerified: user.isEmailVerified(),
       roleAssignments: resolvedAssignments,
+      trialEndsAt: tenant.getTrialEndsAt()?.toISOString() ?? null,
     };
 
     const accessToken = this.tokenService.generateAccesToken(payload);
@@ -127,6 +142,15 @@ export class LoginHandler implements ICommandHandler<LoginCommand> {
       ),
     );
 
+    const daysRemaining = tenant.getTrialDaysRemaining();
+    const trialWarning =
+      daysRemaining !== null && daysRemaining <= 2
+        ? {
+            daysRemaining,
+            message: `Your free trial ends in ${daysRemaining} day(s). Upgrade your plan.`,
+          }
+        : null;
+
     return new LoginResult(
       user.getId()!.toString(),
       user.getEmail().toString(),
@@ -136,6 +160,7 @@ export class LoginHandler implements ICommandHandler<LoginCommand> {
       accessToken,
       refreshToken,
       user.getTutorialCompleted(),
+      trialWarning,
     );
   }
 }

--- a/src/application/auth/commands/refresh-token.handler.ts
+++ b/src/application/auth/commands/refresh-token.handler.ts
@@ -40,6 +40,7 @@ export class RefreshTokenHandler implements ICommandHandler<RefreshTokenCommand>
       isOwner: payload.isOwner,
       emailVerified: payload.emailVerified,
       roleAssignments: payload.roleAssignments,
+      trialEndsAt: payload.trialEndsAt,
     };
 
     const accessToken = this.tokenService.generateAccesToken(cleanPayload);

--- a/src/application/auth/services/jwt.service.ts
+++ b/src/application/auth/services/jwt.service.ts
@@ -23,6 +23,7 @@ export interface JwtPayload {
   emailVerified: boolean;
   /** Empty array for owners — full access is implied by isOwner flag */
   roleAssignments: ResolvedRoleAssignment[];
+  trialEndsAt: string | null;
 }
 
 export interface ITokenService {

--- a/src/application/tenant/commands/register-tenant.handler.ts
+++ b/src/application/tenant/commands/register-tenant.handler.ts
@@ -97,6 +97,7 @@ export class RegisterTenantHandler implements ICommandHandler<RegisterTenantComm
       isOwner: savedUser.isOwner(),
       emailVerified: savedUser.isEmailVerified(),
       roleAssignments: [],
+      trialEndsAt: savedTenant.getTrialEndsAt()?.toISOString() ?? null,
     };
 
     const accessToken = this.tokenService.generateAccesToken(payload);
@@ -110,6 +111,7 @@ export class RegisterTenantHandler implements ICommandHandler<RegisterTenantComm
       isOwner: savedUser.isOwner(),
       emailVerified: false,
       roleAssignments: [],
+      trialEndsAt: savedTenant.getTrialEndsAt()?.toISOString() ?? null,
     };
 
     const verificationToken =

--- a/src/domain/tenant/entities/tenant.entity.ts
+++ b/src/domain/tenant/entities/tenant.entity.ts
@@ -15,6 +15,7 @@ export interface TenantReconstitutionProps {
   createdAt: Date;
   updatedAt: Date;
   deletedAt?: Date | null;
+  trialEndsAt?: Date | null;
 }
 
 export class Tenant {
@@ -31,12 +32,17 @@ export class Tenant {
     private readonly createdAt: Date,
     private updatedAt: Date,
     private deletedAt: Date | null = null,
+    private trialEndsAt: Date | null = null,
   ) {}
 
   static create(name: string, ownerEmail: Email, plan: PlanType): Tenant {
     if (!name || name.trim() === '') {
       throw new Error('Tenant name cannot be empty');
     }
+
+    const trialEndsAt = plan.isTrial()
+      ? new Date(Date.now() + 5 * 24 * 60 * 60 * 1000)
+      : null;
 
     return new Tenant(
       null,
@@ -50,6 +56,8 @@ export class Tenant {
       null,
       new Date(),
       new Date(),
+      null,
+      trialEndsAt,
     );
   }
 
@@ -67,6 +75,7 @@ export class Tenant {
       props.createdAt,
       props.updatedAt,
       props.deletedAt,
+      props.trialEndsAt,
     );
   }
 
@@ -155,5 +164,21 @@ export class Tenant {
 
   getUpdatedAt(): Date {
     return this.updatedAt;
+  }
+
+  getTrialEndsAt(): Date | null {
+    return this.trialEndsAt;
+  }
+
+  isTrialExpired(): boolean {
+    return this.trialEndsAt !== null && this.trialEndsAt.getTime() < Date.now();
+  }
+
+  getTrialDaysRemaining(): number | null {
+    if (this.trialEndsAt === null) {
+      return null;
+    }
+    const msRemaining = this.trialEndsAt.getTime() - Date.now();
+    return Math.max(0, Math.ceil(msRemaining / (24 * 60 * 60 * 1000)));
   }
 }

--- a/src/infrastructure/auth/guards/trial-expired.guard.ts
+++ b/src/infrastructure/auth/guards/trial-expired.guard.ts
@@ -1,0 +1,28 @@
+import { JwtPayload } from '@/application/auth/services/jwt.service';
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+
+@Injectable()
+export class TrialExpiredGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context
+      .switchToHttp()
+      .getRequest<Request & { user?: JwtPayload }>();
+    const user = request.user;
+
+    if (
+      user?.trialEndsAt &&
+      new Date(user.trialEndsAt).getTime() < Date.now()
+    ) {
+      throw new ForbiddenException(
+        'Your free trial ended. Upgrade your plan to continue.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/infrastructure/persistence/persistence.module.ts
+++ b/src/infrastructure/persistence/persistence.module.ts
@@ -174,7 +174,6 @@ import { CONVERSATION_REPOSITORY } from '@/domain/conversation/repositories/conv
 import { MongoConversationRepository } from '@/infrastructure/persistence/repositories/mongo-conversation.repository';
 import { ConversationBackfillMigration } from '@/infrastructure/migrations/conversation-backfill.migration';
 
-
 @Module({
   imports: [
     MongooseModule.forFeature([

--- a/src/infrastructure/persistence/repositories/mongo-tenant.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-tenant.repository.ts
@@ -32,6 +32,7 @@ export class MongoTenantRepository implements TenantRepository {
       logoUrl: tenant.getLogoUrl(),
       updatedAt: tenant.getUpdatedAt(),
       deletedAt: tenant.getDeletedAt(),
+      trialEndsAt: tenant.getTrialEndsAt(),
     };
 
     if (id) {
@@ -82,6 +83,7 @@ export class MongoTenantRepository implements TenantRepository {
       createdAt: doc.createdAt,
       updatedAt: doc.updatedAt,
       deletedAt: doc.deletedAt,
+      trialEndsAt: doc.trialEndsAt ?? null,
     };
     return Tenant.reconstitute(props);
   }

--- a/src/infrastructure/persistence/schemas/tenant.schema.ts
+++ b/src/infrastructure/persistence/schemas/tenant.schema.ts
@@ -36,6 +36,9 @@ export class TenantDocument extends Document {
 
   @Prop({ type: Date, default: null })
   deletedAt: Date | null;
+
+  @Prop({ type: Date, default: null })
+  trialEndsAt: Date | null;
 }
 
 export const TenantSchema = SchemaFactory.createForClass(TenantDocument);

--- a/test/application/auth/login.handler.spec.ts
+++ b/test/application/auth/login.handler.spec.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import {
   LoginHandler,
   LoginResult,
@@ -20,6 +20,7 @@ import {
   USER_FIXTURE_DEFAULTS,
 } from '@test/shared/fixtures/user.fixture';
 import { makeTenant } from '@test/shared/fixtures/tenant.fixture';
+import { PlanTypeEnum } from '@/domain/tenant/value-objects/plan-type.vo';
 import { Role, RoleId } from '@/domain/role/entities/role.entity';
 import { Permission } from '@/domain/role/value-objects/permission.vo';
 import type { RoleAssignment } from '@/domain/user/entities/user.entity';
@@ -70,6 +71,58 @@ describe('LoginHandler', () => {
       expect(result.accessToken).toBe('access-token');
       expect(result.refreshToken).toBe('refresh-token');
       expect(result.tutorialCompleted).toBe(false);
+      expect(result.trialWarning).toBeNull();
+    });
+  });
+
+  describe('when the trial has expired', () => {
+    it('throws ForbiddenException', async () => {
+      userRepository.findByEmail.mockResolvedValue(makeUser());
+      passwordHasher.compare.mockResolvedValue(true);
+      tenantRepository.findById.mockResolvedValue(
+        makeTenant({ trialEndsAt: new Date(Date.now() - 1000) }),
+      );
+
+      await expect(
+        handler.execute(
+          new LoginCommand(USER_FIXTURE_DEFAULTS.email, 'plain-password'),
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('when the trial ends within 2 days', () => {
+    it('returns a trialWarning in the result', async () => {
+      userRepository.findByEmail.mockResolvedValue(makeUser());
+      passwordHasher.compare.mockResolvedValue(true);
+      tenantRepository.findById.mockResolvedValue(
+        makeTenant({
+          trialEndsAt: new Date(Date.now() + 1.5 * 24 * 60 * 60 * 1000),
+        }),
+      );
+
+      const result = await handler.execute(
+        new LoginCommand(USER_FIXTURE_DEFAULTS.email, 'plain-password'),
+      );
+
+      expect(result.trialWarning).not.toBeNull();
+      expect(result.trialWarning?.daysRemaining).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('when the tenant is not on a trial plan', () => {
+    it('never blocks and never warns', async () => {
+      userRepository.findByEmail.mockResolvedValue(makeUser());
+      passwordHasher.compare.mockResolvedValue(true);
+      tenantRepository.findById.mockResolvedValue(
+        makeTenant({ plan: PlanTypeEnum.LYMON_ONE, trialEndsAt: null }),
+      );
+
+      const result = await handler.execute(
+        new LoginCommand(USER_FIXTURE_DEFAULTS.email, 'plain-password'),
+      );
+
+      expect(result.trialWarning).toBeNull();
     });
   });
 

--- a/test/application/user/verify-email.handler.spec.ts
+++ b/test/application/user/verify-email.handler.spec.ts
@@ -25,6 +25,7 @@ const VALID_PAYLOAD: JwtPayload = {
   isOwner: true,
   emailVerified: false,
   roleAssignments: [],
+  trialEndsAt: null,
 };
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/test/domain/tenant/tenant.entity.spec.ts
+++ b/test/domain/tenant/tenant.entity.spec.ts
@@ -96,6 +96,64 @@ describe('Tenant Entity - COMPREHENSIVE COVERAGE', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
+  // ●  TENANT.CREATE - TRIAL EXPIRY
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('Tenant.create - TRIAL EXPIRY', () => {
+    it('sets trialEndsAt ~5 days out for TRIAL plan', () => {
+      const email = createValidEmail();
+      const plan = PlanType.create('TRIAL');
+      const before = Date.now();
+
+      const tenant = Tenant.create(TENANT_NAME, email, plan);
+
+      const expectedMs = before + 5 * 24 * 60 * 60 * 1000;
+      expect(tenant.getTrialEndsAt()).not.toBeNull();
+      expect(tenant.getTrialEndsAt()!.getTime()).toBeGreaterThanOrEqual(
+        expectedMs - 1000,
+      );
+      expect(tenant.getTrialEndsAt()!.getTime()).toBeLessThanOrEqual(
+        expectedMs + 5000,
+      );
+      expect(tenant.isTrialExpired()).toBe(false);
+      expect(tenant.getTrialDaysRemaining()).toBe(5);
+    });
+
+    it('leaves trialEndsAt null for non-TRIAL plans', () => {
+      const email = createValidEmail();
+      const plan = createValidPlan();
+
+      const tenant = Tenant.create(TENANT_NAME, email, plan);
+
+      expect(tenant.getTrialEndsAt()).toBeNull();
+      expect(tenant.isTrialExpired()).toBe(false);
+      expect(tenant.getTrialDaysRemaining()).toBeNull();
+    });
+
+    it('isTrialExpired is true once trialEndsAt is in the past', () => {
+      const email = createValidEmail();
+      const plan = createValidPlan();
+      const tenant = Tenant.reconstitute({
+        id: TenantId.createFromString(TENANT_ID),
+        name: TENANT_NAME,
+        ownerEmail: email,
+        plan,
+        emailVerified: false,
+        contactPhone: null,
+        address: null,
+        website: null,
+        logoUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        trialEndsAt: new Date(Date.now() - 1000),
+      });
+
+      expect(tenant.isTrialExpired()).toBe(true);
+      expect(tenant.getTrialDaysRemaining()).toBe(0);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
   // ●  TENANT.CREATE - VALIDATION: NAME
   // ═══════════════════════════════════════════════════════════════════════════
 

--- a/test/infrastructure/auth/guards/trial-expired.guard.spec.ts
+++ b/test/infrastructure/auth/guards/trial-expired.guard.spec.ts
@@ -1,0 +1,39 @@
+import { type ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { TrialExpiredGuard } from '@/infrastructure/auth/guards/trial-expired.guard';
+
+describe('TrialExpiredGuard', () => {
+  const makeContext = (user?: unknown): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  it('allows the request when there is no user (public routes)', () => {
+    const guard = new TrialExpiredGuard();
+
+    expect(guard.canActivate(makeContext(undefined))).toBe(true);
+  });
+
+  it('allows the request when trialEndsAt is null', () => {
+    const guard = new TrialExpiredGuard();
+
+    expect(guard.canActivate(makeContext({ trialEndsAt: null }))).toBe(true);
+  });
+
+  it('allows the request when trialEndsAt is in the future', () => {
+    const guard = new TrialExpiredGuard();
+    const future = new Date(Date.now() + 60_000).toISOString();
+
+    expect(guard.canActivate(makeContext({ trialEndsAt: future }))).toBe(true);
+  });
+
+  it('throws ForbiddenException when trialEndsAt is in the past', () => {
+    const guard = new TrialExpiredGuard();
+    const past = new Date(Date.now() - 60_000).toISOString();
+
+    expect(() => guard.canActivate(makeContext({ trialEndsAt: past }))).toThrow(
+      ForbiddenException,
+    );
+  });
+});

--- a/test/shared/fixtures/tenant.fixture.ts
+++ b/test/shared/fixtures/tenant.fixture.ts
@@ -19,6 +19,7 @@ export const TENANT_FIXTURE_DEFAULTS = {
   address: null as string | null,
   website: null as string | null,
   logoUrl: null as string | null,
+  trialEndsAt: null as Date | null,
 };
 
 export function makeTenant(
@@ -32,6 +33,7 @@ export function makeTenant(
     address: string | null;
     website: string | null;
     logoUrl: string | null;
+    trialEndsAt: Date | null;
   }>,
 ): Tenant {
   const merged = { ...TENANT_FIXTURE_DEFAULTS, ...overrides };
@@ -47,6 +49,7 @@ export function makeTenant(
     logoUrl: merged.logoUrl,
     createdAt: new Date(),
     updatedAt: new Date(),
+    trialEndsAt: merged.trialEndsAt,
   };
   return Tenant.reconstitute(props);
 }


### PR DESCRIPTION
This pull request introduces a comprehensive trial period and expiry mechanism for tenants, including backend enforcement, user warnings, and full test coverage. The main changes add tracking for trial expiration, block access for expired trials, provide warnings as the trial nears its end, and ensure this logic is enforced and tested throughout the application.

**Trial Expiry Enforcement and User Experience:**

- Added a `trialEndsAt` property to the `Tenant` entity, set automatically for trial plans and persisted in the database. Methods for checking expiry and days remaining were introduced. [[1]](diffhunk://#diff-959e4fedf1a8005400a34defabd20af138edbc2e32fe95b5d64ef30e68eba280R18) [[2]](diffhunk://#diff-959e4fedf1a8005400a34defabd20af138edbc2e32fe95b5d64ef30e68eba280R35-R46) [[3]](diffhunk://#diff-959e4fedf1a8005400a34defabd20af138edbc2e32fe95b5d64ef30e68eba280R59-R60) [[4]](diffhunk://#diff-959e4fedf1a8005400a34defabd20af138edbc2e32fe95b5d64ef30e68eba280R78) [[5]](diffhunk://#diff-959e4fedf1a8005400a34defabd20af138edbc2e32fe95b5d64ef30e68eba280R168-R183) [[6]](diffhunk://#diff-62ffb0eae5ff361f6f3e17974ae2deb5536a4ebdc02baf1732c6aeb173fdc8d7R35) [[7]](diffhunk://#diff-62ffb0eae5ff361f6f3e17974ae2deb5536a4ebdc02baf1732c6aeb173fdc8d7R86) [[8]](diffhunk://#diff-ede0cdabb64ed4d8a99e74f0249e6d07d370827bb4ed3280343f6f0057193d21R39-R41) [[9]](diffhunk://#diff-8c4ad6dd291ce1ba379bdbe0fe70ad4557798a98bd9b0427aa2f64e3e495ae0eR22)
- Implemented a new `TrialExpiredGuard` that blocks access for users whose trial has expired, and registered it globally in `AppModule`. [[1]](diffhunk://#diff-5ee3087c09ccc9106dbdbd965efd6089c1cbf9375da7236f2e1f354c5832701bR1-R28) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R12) [[3]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R50-R53)

**Authentication and Token Handling:**

- Updated the login handler to throw a `ForbiddenException` if a tenant's trial has expired, and to return a `trialWarning` in the login result if the trial ends within 2 days. [[1]](diffhunk://#diff-b1ef8bad9bc194222faa048113212d53691722706d3216f5558b14a8970cc70cL3-R7) [[2]](diffhunk://#diff-b1ef8bad9bc194222faa048113212d53691722706d3216f5558b14a8970cc70cR97-R102) [[3]](diffhunk://#diff-b1ef8bad9bc194222faa048113212d53691722706d3216f5558b14a8970cc70cR145-R153) [[4]](diffhunk://#diff-b1ef8bad9bc194222faa048113212d53691722706d3216f5558b14a8970cc70cR163)
- Extended the JWT payload and token creation logic to include the `trialEndsAt` property, ensuring this data is available on authenticated requests and during token refresh. [[1]](diffhunk://#diff-7f7e732a917bfcd8980f35887a93a710cf2ba0a319296cf15c732d195a33a289R26) [[2]](diffhunk://#diff-b1ef8bad9bc194222faa048113212d53691722706d3216f5558b14a8970cc70cR127) [[3]](diffhunk://#diff-abb36683bdfada1c12b9b3c74e53b1bd353bbfb6143d11648da62eee393fce36R43) [[4]](diffhunk://#diff-832ec5846549337e4ac4e1ab53c9bc714435695872282f574d367224b41a20aeR100) [[5]](diffhunk://#diff-832ec5846549337e4ac4e1ab53c9bc714435695872282f574d367224b41a20aeR114) [[6]](diffhunk://#diff-01047d41b2eab04f5ec39849867ff7c01717aedcd23dc01af628bf19e24f558fR28)

**Testing and Validation:**

- Added and updated tests for the login handler to cover expired trials, warning scenarios, and non-trial tenants. [[1]](diffhunk://#diff-435f3a2ae29dc52c4e167bf6caba7f654861dfbe7b76ee9d00db09584e79c05aL1-R1) [[2]](diffhunk://#diff-435f3a2ae29dc52c4e167bf6caba7f654861dfbe7b76ee9d00db09584e79c05aR23) [[3]](diffhunk://#diff-435f3a2ae29dc52c4e167bf6caba7f654861dfbe7b76ee9d00db09584e79c05aR74-R125)
- Created tests for the `Tenant` entity's trial expiry logic and for the `TrialExpiredGuard`. [[1]](diffhunk://#diff-e30f515f7c85e4e157a1cf0ef727632baad74431966372e1382c4623dfe79f04R98-R155) [[2]](diffhunk://#diff-7eb94263ccf911a945ee0d1fdcd922db8bdb7a84c4908a4af41a97df0b727e38R1-R39)

These changes ensure that trial expirations are consistently enforced, users are notified before losing access, and the system remains robust through extensive automated tests.