### PR TITLE
LYMON-1093 feat(guest-auth): store profile photo key and build URL on read

### DIFF
--- a/src/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler.ts
+++ b/src/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler.ts
@@ -44,14 +44,13 @@ export class UpdateGuestProfilePhotoHandler
       throw new UnauthorizedException('Account not found');
     }
 
-    const previousUrl = account.getProfilePhotoUrl();
-    const oldKey = previousUrl
-      ? this.storageService.keyFromPublicUrl(previousUrl)
-      : null;
+    const oldKey = account.getProfilePhotoKey();
 
-    const profilePhotoUrl = this.storageService.getPublicUrl(command.key);
-    account.setProfilePhotoUrl(profilePhotoUrl);
+    account.setProfilePhotoKey(command.key);
     await this.guestAccountRepository.save(account);
+
+    // URL is never persisted; it's rebuilt from R2_PUBLIC_URL on every read.
+    const profilePhotoUrl = this.storageService.getPublicUrl(command.key);
 
     // Best-effort: remove the old photo once the new one is committed.
     if (oldKey && oldKey !== command.key) {

--- a/src/application/guest-auth/guest-auth-application.module.ts
+++ b/src/application/guest-auth/guest-auth-application.module.ts
@@ -14,6 +14,7 @@ import { RefreshGuestTokenHandler } from '@/application/guest-auth/commands/refr
 import { LogoutGuestHandler } from '@/application/guest-auth/commands/logout-guest/logout-guest.handler';
 import { UpdateGuestProfilePhotoHandler } from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler';
 import { GenerateGuestProfilePhotoUrlQueryHandler } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query-handler';
+import { GetGuestAccountProfileQueryHandler } from '@/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.query-handler';
 
 const CommandHandlers = [
   RegisterGuestAccountHandler,
@@ -27,7 +28,10 @@ const CommandHandlers = [
   UpdateGuestProfilePhotoHandler,
 ];
 
-const QueryHandlers = [GenerateGuestProfilePhotoUrlQueryHandler];
+const QueryHandlers = [
+  GenerateGuestProfilePhotoUrlQueryHandler,
+  GetGuestAccountProfileQueryHandler,
+];
 
 @Module({
   imports: [

--- a/src/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.query-handler.ts
+++ b/src/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.query-handler.ts
@@ -1,0 +1,52 @@
+import { Inject, UnauthorizedException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import {
+  GUEST_ACCOUNT_REPOSITORY,
+  type GuestAccountRepository,
+} from '@/domain/guest-account/repositories/guest-account.repository';
+import { GuestAccountId } from '@/domain/guest-account/value-objects/guest-account-id.vo';
+import {
+  R2StorageService,
+  R2_STORAGE_SERVICE,
+} from '@/infrastructure/storage/r2-storage.service';
+import { GetGuestAccountProfileQuery } from './get-guest-account-profile.query';
+import { GetGuestAccountProfileResult } from './get-guest-account-profile.result';
+
+@QueryHandler(GetGuestAccountProfileQuery)
+export class GetGuestAccountProfileQueryHandler
+  implements
+    IQueryHandler<GetGuestAccountProfileQuery, GetGuestAccountProfileResult>
+{
+  constructor(
+    @Inject(GUEST_ACCOUNT_REPOSITORY)
+    private readonly guestAccountRepository: GuestAccountRepository,
+    @Inject(R2_STORAGE_SERVICE)
+    private readonly storageService: R2StorageService,
+  ) {}
+
+  async execute(
+    query: GetGuestAccountProfileQuery,
+  ): Promise<GetGuestAccountProfileResult> {
+    const account = await this.guestAccountRepository.findById(
+      GuestAccountId.createFromString(query.guestAccountId),
+    );
+
+    if (!account) {
+      throw new UnauthorizedException('Account not found');
+    }
+
+    // Only the key is persisted; the URL is rebuilt from R2_PUBLIC_URL here.
+    const key = account.getProfilePhotoKey();
+    const profilePhotoUrl = key ? this.storageService.getPublicUrl(key) : null;
+
+    return new GetGuestAccountProfileResult(
+      account.getId()!.toString(),
+      account.getEmail().toString(),
+      account.getFullName(),
+      account.getFirstName(),
+      account.getLastName(),
+      account.isEmailVerified(),
+      profilePhotoUrl,
+    );
+  }
+}

--- a/src/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.query.ts
+++ b/src/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.query.ts
@@ -1,0 +1,3 @@
+export class GetGuestAccountProfileQuery {
+  constructor(public readonly guestAccountId: string) {}
+}

--- a/src/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.result.ts
+++ b/src/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.result.ts
@@ -1,0 +1,11 @@
+export class GetGuestAccountProfileResult {
+  constructor(
+    public readonly guestAccountId: string,
+    public readonly email: string,
+    public readonly fullName: string,
+    public readonly firstName: string | null,
+    public readonly lastName: string | null,
+    public readonly emailVerified: boolean,
+    public readonly profilePhotoUrl: string | null,
+  ) {}
+}

--- a/src/domain/guest-account/entities/guest-account.entity.ts
+++ b/src/domain/guest-account/entities/guest-account.entity.ts
@@ -21,7 +21,7 @@ export class GuestAccount {
     private passwordChangedAt: Date | null,
     private readonly createdAt: Date,
     private updatedAt: Date,
-    private profilePhotoUrl: string | null,
+    private profilePhotoKey: string | null,
   ) {}
 
   static create(params: CreateGuestAccountParams): GuestAccount {
@@ -67,7 +67,7 @@ export class GuestAccount {
       data.passwordChangedAt,
       data.createdAt,
       data.updatedAt,
-      data.profilePhotoUrl,
+      data.profilePhotoKey,
     );
   }
 
@@ -137,13 +137,13 @@ export class GuestAccount {
     this.touch();
   }
 
-  setProfilePhotoUrl(url: string | null): void {
-    this.profilePhotoUrl = url;
+  setProfilePhotoKey(key: string | null): void {
+    this.profilePhotoKey = key;
     this.touch();
   }
 
-  getProfilePhotoUrl(): string | null {
-    return this.profilePhotoUrl;
+  getProfilePhotoKey(): string | null {
+    return this.profilePhotoKey;
   }
 
   getId(): GuestAccountId | null {

--- a/src/domain/guest-account/interfaces/guest-account.interface.ts
+++ b/src/domain/guest-account/interfaces/guest-account.interface.ts
@@ -18,5 +18,5 @@ export interface IGuestAccount {
   passwordChangedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
-  profilePhotoUrl: string | null;
+  profilePhotoKey: string | null;
 }

--- a/src/infrastructure/persistence/repositories/mongo-guest-account.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-guest-account.repository.ts
@@ -30,7 +30,7 @@ export class MongoGuestAccountRepository implements GuestAccountRepository {
       passwordResetToken: account.getPasswordResetToken(),
       passwordResetExpiry: account.getPasswordResetExpiry(),
       passwordChangedAt: account.getPasswordChangedAt(),
-      profilePhotoUrl: account.getProfilePhotoUrl(),
+      profilePhotoKey: account.getProfilePhotoKey(),
       updatedAt: account.getUpdatedAt(),
     };
 
@@ -89,7 +89,7 @@ export class MongoGuestAccountRepository implements GuestAccountRepository {
       passwordChangedAt: doc.passwordChangedAt,
       createdAt: doc.createdAt,
       updatedAt: doc.updatedAt,
-      profilePhotoUrl: doc.profilePhotoUrl ?? null,
+      profilePhotoKey: doc.profilePhotoKey ?? null,
     });
   }
 }

--- a/src/infrastructure/persistence/schemas/guest-account.schema.ts
+++ b/src/infrastructure/persistence/schemas/guest-account.schema.ts
@@ -45,7 +45,7 @@ export class GuestAccountDocument extends Document {
   passwordChangedAt: Date | null;
 
   @Prop({ type: String, default: null })
-  profilePhotoUrl: string | null;
+  profilePhotoKey: string | null;
 
   @Prop()
   createdAt: Date;

--- a/src/presentation/controllers/guest.controller.ts
+++ b/src/presentation/controllers/guest.controller.ts
@@ -4,6 +4,8 @@ import { ChangeGuestPasswordResult } from '@/application/guest-auth/commands/cha
 import { UpdateGuestProfilePhotoCommand } from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.command';
 import { UpdateGuestProfilePhotoResult } from '@/application/guest-auth/commands/update-guest-profile-photo/update-guest-profile-photo.handler';
 import { GenerateGuestProfilePhotoUrlQuery } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.query';
+import { GetGuestAccountProfileQuery } from '@/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.query';
+import { GetGuestAccountProfileResult } from '@/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.result';
 import { GenerateGuestProfilePhotoUrlResult } from '@/application/guest-auth/queries/generate-guest-profile-photo-url/generate-guest-profile-photo-url.result';
 import { type GuestJwtPayload } from '@/application/guest-auth/services/guest-jwt.service';
 import { CreateGuestCommand } from '@/application/guest/commands/create-guest.command';
@@ -156,6 +158,32 @@ export class GuestController {
     );
 
     return { message: result.message };
+  }
+
+  @Public()
+  @UseGuards(GuestJwtAuthGuard)
+  @Get('profile')
+  @ApiBearerAuth('GuestJWT-auth')
+  @ApiOperation({ summary: 'Get the authenticated guest account profile' })
+  @ApiResponse({ status: 200, description: 'Guest profile returned' })
+  async getProfile(@CurrentGuest() guest: GuestJwtPayload) {
+    const result = await this.queryBus.execute<
+      GetGuestAccountProfileQuery,
+      GetGuestAccountProfileResult
+    >(new GetGuestAccountProfileQuery(guest.guestAccountId));
+
+    return {
+      message: 'Guest profile returned',
+      data: {
+        guestAccountId: result.guestAccountId,
+        email: result.email,
+        fullName: result.fullName,
+        firstName: result.firstName,
+        lastName: result.lastName,
+        emailVerified: result.emailVerified,
+        profilePhotoUrl: result.profilePhotoUrl,
+      },
+    };
   }
 
   @Public()

--- a/test/application/guest-auth/get-guest-account-profile.query-handler.spec.ts
+++ b/test/application/guest-auth/get-guest-account-profile.query-handler.spec.ts
@@ -1,0 +1,64 @@
+import { GetGuestAccountProfileQueryHandler } from '@/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.query-handler';
+import { GetGuestAccountProfileQuery } from '@/application/guest-auth/queries/get-guest-account-profile/get-guest-account-profile.query';
+import { GuestAccountRepository } from '@/domain/guest-account/repositories/guest-account.repository';
+import { R2StorageService } from '@/infrastructure/storage/r2-storage.service';
+import { UnauthorizedException } from '@nestjs/common';
+import { createGuestAccountRepositoryMock } from '@test/shared/mocks/repositories/guest-account-repository.mock';
+import {
+  makeGuestAccount,
+  GUEST_ACCOUNT_FIXTURE_DEFAULTS,
+} from '@test/shared/fixtures/guest-account.fixture';
+
+const PUBLIC_BASE = 'https://cdn.example.com';
+const ACCOUNT_ID = GUEST_ACCOUNT_FIXTURE_DEFAULTS.id;
+const KEY = `guests/${ACCOUNT_ID}/profile/222.png`;
+
+describe('GetGuestAccountProfileQueryHandler', () => {
+  let handler: GetGuestAccountProfileQueryHandler;
+  let guestAccountRepository: jest.Mocked<GuestAccountRepository>;
+  let storageService: jest.Mocked<Pick<R2StorageService, 'getPublicUrl'>>;
+
+  beforeEach(() => {
+    guestAccountRepository = createGuestAccountRepositoryMock();
+    storageService = {
+      getPublicUrl: jest.fn((key: string) => `${PUBLIC_BASE}/${key}`),
+    };
+
+    handler = new GetGuestAccountProfileQueryHandler(
+      guestAccountRepository,
+      storageService as unknown as R2StorageService,
+    );
+  });
+
+  it('rejects an unknown account', async () => {
+    guestAccountRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new GetGuestAccountProfileQuery(ACCOUNT_ID)),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('builds the photo URL from the stored key', async () => {
+    guestAccountRepository.findById.mockResolvedValue(
+      makeGuestAccount({ profilePhotoKey: KEY }),
+    );
+
+    const result = await handler.execute(
+      new GetGuestAccountProfileQuery(ACCOUNT_ID),
+    );
+
+    expect(result.profilePhotoUrl).toBe(`${PUBLIC_BASE}/${KEY}`);
+    expect(result.email).toBe(GUEST_ACCOUNT_FIXTURE_DEFAULTS.email);
+  });
+
+  it('returns null photo URL when no key is stored', async () => {
+    guestAccountRepository.findById.mockResolvedValue(makeGuestAccount());
+
+    const result = await handler.execute(
+      new GetGuestAccountProfileQuery(ACCOUNT_ID),
+    );
+
+    expect(result.profilePhotoUrl).toBeNull();
+    expect(storageService.getPublicUrl).not.toHaveBeenCalled();
+  });
+});

--- a/test/application/guest-auth/update-guest-profile-photo.handler.spec.ts
+++ b/test/application/guest-auth/update-guest-profile-photo.handler.spec.ts
@@ -61,7 +61,7 @@ describe('UpdateGuestProfilePhotoHandler', () => {
     ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
-  it('saves the public URL derived from the key', async () => {
+  it('persists the key and returns the URL built from it', async () => {
     guestAccountRepository.findById.mockResolvedValue(makeGuestAccount());
 
     const result = await handler.execute(
@@ -70,14 +70,14 @@ describe('UpdateGuestProfilePhotoHandler', () => {
 
     expect(result).toBeInstanceOf(UpdateGuestProfilePhotoResult);
     const saved = guestAccountRepository.save.mock.calls[0][0];
-    expect(saved.getProfilePhotoUrl()).toBe(`${PUBLIC_BASE}/${KEY}`);
+    expect(saved.getProfilePhotoKey()).toBe(KEY);
     expect(result.profilePhotoUrl).toBe(`${PUBLIC_BASE}/${KEY}`);
   });
 
   it('deletes the previous photo after committing the new one', async () => {
     const oldKey = `guests/${ACCOUNT_ID}/profile/111.jpg`;
     guestAccountRepository.findById.mockResolvedValue(
-      makeGuestAccount({ profilePhotoUrl: `${PUBLIC_BASE}/${oldKey}` }),
+      makeGuestAccount({ profilePhotoKey: oldKey }),
     );
 
     await handler.execute(new UpdateGuestProfilePhotoCommand(ACCOUNT_ID, KEY));

--- a/test/shared/fixtures/guest-account.fixture.ts
+++ b/test/shared/fixtures/guest-account.fixture.ts
@@ -14,7 +14,7 @@ export const GUEST_ACCOUNT_FIXTURE_DEFAULTS = {
   emailVerified: false,
   emailVerificationToken: null as string | null,
   emailVerificationExpiry: null as Date | null,
-  profilePhotoUrl: null as string | null,
+  profilePhotoKey: null as string | null,
 };
 
 export function makeGuestAccount(
@@ -29,7 +29,7 @@ export function makeGuestAccount(
     emailVerified: boolean;
     emailVerificationToken: string | null;
     emailVerificationExpiry: Date | null;
-    profilePhotoUrl: string | null;
+    profilePhotoKey: string | null;
   }>,
 ): GuestAccount {
   const merged = { ...GUEST_ACCOUNT_FIXTURE_DEFAULTS, ...overrides };
@@ -49,6 +49,6 @@ export function makeGuestAccount(
     passwordChangedAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
-    profilePhotoUrl: merged.profilePhotoUrl,
+    profilePhotoKey: merged.profilePhotoKey,
   });
 }


### PR DESCRIPTION
- Guest accounts now persist only the R2 object key (`profilePhotoKey`) instead of the full photo URL; the public URL is rebuilt from `R2_PUBLIC_URL` on every read.
- `UpdateGuestProfilePhotoHandler` saves the key on commit and deletes the previous photo using the stored key.
- New `GET /guests/profile` endpoint (guest JWT) returning the account profile with `profilePhotoUrl` built from the key (`null` when the guest has no photo).