### PR TITLE
LYMON-1101 fix: standardize scope values to uppercase in experience-r…

### DIFF
--- a/src/domain/experience/value-objects/experience-scope.vo.ts
+++ b/src/domain/experience/value-objects/experience-scope.vo.ts
@@ -1,6 +1,6 @@
 export enum ExperienceScopeEnum {
-  GLOBAL = 'global',
-  PROPERTY = 'property',
+  GLOBAL = 'GLOBAL',
+  PROPERTY = 'PROPERTY',
 }
 
 export class ExperienceScope {

--- a/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
@@ -3,7 +3,10 @@ import {
   AvailableExperienceFilters,
   ExperienceRepository,
 } from '@/domain/experience/repositories/experience.repository';
-import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
+import {
+  ExperienceAvailabilityType,
+  ExperienceAvailabilityTypeEnum,
+} from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
 import {
@@ -199,6 +202,29 @@ export class MongoExperienceRepository implements ExperienceRepository {
     });
   }
 
+  private normalizeScope(document: ExperienceDocument): ExperienceScopeEnum {
+    if (!document.scope) {
+      return document.propertyId
+        ? ExperienceScopeEnum.PROPERTY
+        : ExperienceScopeEnum.GLOBAL;
+    }
+
+    const upper = document.scope.toUpperCase();
+    return upper === 'TENANT'
+      ? ExperienceScopeEnum.GLOBAL
+      : (upper as ExperienceScopeEnum);
+  }
+
+  private normalizeAvailabilityType(
+    document: ExperienceDocument,
+  ): ExperienceAvailabilityTypeEnum {
+    return Object.values(ExperienceAvailabilityTypeEnum).includes(
+      document.availabilityType as ExperienceAvailabilityTypeEnum,
+    )
+      ? (document.availabilityType as ExperienceAvailabilityTypeEnum)
+      : ExperienceAvailabilityTypeEnum.RECURRING;
+  }
+
   private toDomain(document: ExperienceDocument): Experience {
     return Experience.reconstitute({
       id: ExperienceId.create(document._id.toString()),
@@ -206,9 +232,7 @@ export class MongoExperienceRepository implements ExperienceRepository {
       propertyId: document.propertyId
         ? PropertyId.create(document.propertyId.toString())
         : undefined,
-      scope: ExperienceScope.create(
-        document.scope ?? (document.propertyId ? 'property' : 'global'),
-      ),
+      scope: ExperienceScope.create(this.normalizeScope(document)),
       name: document.name,
       description: document.description,
       city: document.city,
@@ -217,7 +241,7 @@ export class MongoExperienceRepository implements ExperienceRepository {
       minimumParticipants: document.minimumParticipants ?? 1,
       capacity: document.capacity,
       availabilityType: ExperienceAvailabilityType.create(
-        document.availabilityType,
+        this.normalizeAvailabilityType(document),
       ),
       recurrence: document.recurrence
         ? {

--- a/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
+++ b/src/infrastructure/persistence/repositories/mongo-experience.repository.ts
@@ -3,10 +3,7 @@ import {
   AvailableExperienceFilters,
   ExperienceRepository,
 } from '@/domain/experience/repositories/experience.repository';
-import {
-  ExperienceAvailabilityType,
-  ExperienceAvailabilityTypeEnum,
-} from '@/domain/experience/value-objects/experience-availability-type.vo';
+import { ExperienceAvailabilityType } from '@/domain/experience/value-objects/experience-availability-type.vo';
 import { ExperienceCategory } from '@/domain/experience/value-objects/experience-category.vo';
 import { ExperienceId } from '@/domain/experience/value-objects/experience-id.vo';
 import {
@@ -202,29 +199,6 @@ export class MongoExperienceRepository implements ExperienceRepository {
     });
   }
 
-  private normalizeScope(document: ExperienceDocument): ExperienceScopeEnum {
-    if (!document.scope) {
-      return document.propertyId
-        ? ExperienceScopeEnum.PROPERTY
-        : ExperienceScopeEnum.GLOBAL;
-    }
-
-    const upper = document.scope.toUpperCase();
-    return upper === 'TENANT'
-      ? ExperienceScopeEnum.GLOBAL
-      : (upper as ExperienceScopeEnum);
-  }
-
-  private normalizeAvailabilityType(
-    document: ExperienceDocument,
-  ): ExperienceAvailabilityTypeEnum {
-    return Object.values(ExperienceAvailabilityTypeEnum).includes(
-      document.availabilityType as ExperienceAvailabilityTypeEnum,
-    )
-      ? (document.availabilityType as ExperienceAvailabilityTypeEnum)
-      : ExperienceAvailabilityTypeEnum.RECURRING;
-  }
-
   private toDomain(document: ExperienceDocument): Experience {
     return Experience.reconstitute({
       id: ExperienceId.create(document._id.toString()),
@@ -232,7 +206,12 @@ export class MongoExperienceRepository implements ExperienceRepository {
       propertyId: document.propertyId
         ? PropertyId.create(document.propertyId.toString())
         : undefined,
-      scope: ExperienceScope.create(this.normalizeScope(document)),
+      scope: ExperienceScope.create(
+        document.scope ??
+          (document.propertyId
+            ? ExperienceScopeEnum.PROPERTY
+            : ExperienceScopeEnum.GLOBAL),
+      ),
       name: document.name,
       description: document.description,
       city: document.city,
@@ -241,7 +220,7 @@ export class MongoExperienceRepository implements ExperienceRepository {
       minimumParticipants: document.minimumParticipants ?? 1,
       capacity: document.capacity,
       availabilityType: ExperienceAvailabilityType.create(
-        this.normalizeAvailabilityType(document),
+        document.availabilityType,
       ),
       recurrence: document.recurrence
         ? {

--- a/src/presentation/controllers/experience.controller.ts
+++ b/src/presentation/controllers/experience.controller.ts
@@ -153,7 +153,7 @@ export class ExperienceController {
       propertyScopedDateRange: {
         summary: 'Property-scoped recurring experience',
         value: {
-          scope: 'property',
+          scope: 'PROPERTY',
           propertyId: '6650d0ef3f3d2d2d2d2d2d2d',
           name: 'Airport transfer',
           description: 'Private transfer from airport to property',
@@ -175,7 +175,7 @@ export class ExperienceController {
       tenantRecurring: {
         summary: 'Global recurring transportation service',
         value: {
-          scope: 'global',
+          scope: 'GLOBAL',
           name: 'Daily shuttle service',
           description: 'Recurring daily transportation service',
           city: 'Medellin',


### PR DESCRIPTION
This pull request standardizes enum values for experience scope and improves data normalization in the experience repository. The main focus is on ensuring consistent handling of scope and availability type values across the codebase, reducing potential bugs from inconsistent casing or missing values.

**Enum Standardization and Data Normalization:**

* Updated the `ExperienceScopeEnum` values from lowercase (`'global'`, `'property'`) to uppercase (`'GLOBAL'`, `'PROPERTY'`) for consistency throughout the codebase.
* Adjusted API response examples in `ExperienceController` to use the new uppercase enum values for `scope`. [[1]](diffhunk://#diff-276256878cabeac42468106bda5a3f140e896ba2ea461c5a639665d0e5ec2e03L156-R156) [[2]](diffhunk://#diff-276256878cabeac42468106bda5a3f140e896ba2ea461c5a639665d0e5ec2e03L178-R178)

**Repository Logic Improvements:**

* Added `normalizeScope` and `normalizeAvailabilityType` helper methods in `MongoExperienceRepository` to ensure that scope and availability type values are consistently interpreted and defaulted when missing or invalid. These are now used in the `toDomain` mapping logic. [[1]](diffhunk://#diff-da46ad7b16f261d06bc712bbebadc382e875a165d666d6831ec74a19b8391882R205-R235) [[2]](diffhunk://#diff-da46ad7b16f261d06bc712bbebadc382e875a165d666d6831ec74a19b8391882L220-R244)
* Updated imports in the repository to include the `ExperienceAvailabilityTypeEnum` for improved type safety and normalization.